### PR TITLE
Add Nigeria Professional Football League (NPFL) 2012/13 season

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Africa
 - [**Egypt**](africa/egypt) - Premiership
 - [**Morocco**](africa/morocco) - Botola Pro 1
 - [**Algeria**](africa/algeria) - Ligue 1
+- [**Nigeria**](africa/nigeria) - Premier Football League
 - and others
 
 Middle East

--- a/africa/nigeria/2012-13_ng1.txt
+++ b/africa/nigeria/2012-13_ng1.txt
@@ -1,0 +1,568 @@
+= Nigeria | Premier Football League 2012/2013
+
+# Date       Fri Mar/09 2012 - Sat Oct/20 2012 (225d)
+# Teams      20
+# Matches    380
+
+
+
+» Matchday 1
+  09.03.
+    16:00  Rangers International FC   v Enyimba FC                 1-0 (1-0)
+  10.03.
+    16:00  ABS FC                     v Kwara United               0-0 (0-0)
+    16:00  Akwa United FC             v Rivers United FC           1-0 (0-0)
+    16:00  Bayelsa United FC          v Lobi Stars FC              1-0 (0-0)
+    16:00  Heartland FC               v Nembe City FC              1-2 (0-1)
+    16:00  Nasarawa United            v El-Kanemi Warriors         0-0 (0-0)
+    16:00  Sharks FC                  v Warri Wolves FC            2-1 (2-1)
+    16:00  Shooting Stars SC          v Gombe United               2-0 (2-0)
+    16:00  Sunshine Stars FC          v Kaduna United              1-0 (1-0)
+    16:00  Wikki Tourists             v Kano Pillars FC            0-1 (0-0)
+
+
+» Matchday 2
+  20.03.
+    16:00  El-Kanemi Warriors         v Wikki Tourists             0-0 (0-0)
+    16:00  Kano Pillars FC            v Bayelsa United FC          1-0 (0-0)
+    16:00  Kwara United               v Sunshine Stars FC          1-1 (0-0)
+  21.03.
+    16:00  Enyimba FC                 v Nasarawa United            1-0 (0-0)
+    16:00  Gombe United               v ABS FC                     1-0
+    16:00  Kaduna United              v Sharks FC                  2-0
+    16:00  Lobi Stars FC              v Akwa United FC             2-1 (1-1)
+    16:00  Rivers United FC           v Shooting Stars SC          1-0 (0-0)
+    16:00  Warri Wolves FC            v Heartland FC               1-1 (1-1)
+  22.03.
+    16:00  Nembe City FC              v Rangers International FC   1-2 (1-0)
+
+
+» Matchday 3
+  24.03.
+    16:00  ABS FC                     v Rivers United FC           1-0 (1-0)
+    16:00  Akwa United FC             v Kano Pillars FC            1-0 (0-0)
+    16:00  Bayelsa United FC          v Wikki Tourists             2-0 (1-0)
+    16:00  Enyimba FC                 v El-Kanemi Warriors         2-0 (0-0)
+    16:00  Heartland FC               v Kaduna United              4-1 (1-0)
+    16:00  Sharks FC                  v Kwara United               0-1 (0-0)
+    16:00  Shooting Stars SC          v Lobi Stars FC              3-1 (1-1)
+    16:00  Sunshine Stars FC          v Gombe United               3-2 (0-1)
+  25.03.
+    16:00  Nasarawa United            v Nembe City FC              2-1 (1-0)
+    16:00  Rangers International FC   v Warri Wolves FC            0-0 (0-0)
+
+
+» Matchday 4
+  27.03.
+    16:00  Kwara United               v Heartland FC               1-0 (1-0)
+    16:00  Wikki Tourists             v Akwa United FC             2-0 (2-0)
+  28.03.
+    16:00  El-Kanemi Warriors         v Bayelsa United FC          2-2
+    16:00  Gombe United               v Sharks FC                  2-0 (1-0)
+    16:00  Kaduna United              v Rangers International FC   1-1 (0-0)
+    16:00  Kano Pillars FC            v Shooting Stars SC          2-0
+    16:00  Lobi Stars FC              v ABS FC                     1-0 (1-0)
+    16:00  Nembe City FC              v Enyimba FC                 1-1 (0-0)
+    16:00  Rivers United FC           v Sunshine Stars FC          1-1 (1-0)
+    16:00  Warri Wolves FC            v Nasarawa United            0-0
+
+
+» Matchday 5
+  17.04.
+    16:00  Sunshine Stars FC          v Lobi Stars FC              2-0
+  31.03.
+    16:00  ABS FC                     v Kano Pillars FC            2-3
+    16:00  Akwa United FC             v Bayelsa United FC          3-0
+    16:00  Enyimba FC                 v Warri Wolves FC            0-0 (0-0)
+    16:00  Heartland FC               v Gombe United               4-0
+    16:00  Nasarawa United            v Kaduna United              3-1
+    16:00  Nembe City FC              v El-Kanemi Warriors         2-1
+    16:00  Rangers International FC   v Kwara United               3-1
+    16:00  Sharks FC                  v Rivers United FC           0-0 (0-0)
+    16:00  Shooting Stars SC          v Wikki Tourists             3-2
+
+
+» Matchday 6
+  10.04.
+    16:00  El-Kanemi Warriors         v Akwa United FC             2-1
+    16:00  Gombe United               v Rangers International FC   2-1
+    16:00  Kano Pillars FC            v Sunshine Stars FC          1-0
+    16:00  Kwara United               v Nasarawa United            0-1
+    16:00  Wikki Tourists             v ABS FC                     1-0 (0-0)
+  11.04.
+    16:00  Bayelsa United FC          v Shooting Stars SC          3-1
+    16:00  Kaduna United              v Enyimba FC                 1-0
+    16:00  Lobi Stars FC              v Sharks FC                  2-0
+    16:00  Rivers United FC           v Heartland FC               2-1
+    16:00  Warri Wolves FC            v Nembe City FC              1-1
+
+
+» Matchday 7
+  14.04.
+    15:00  ABS FC                     v Bayelsa United FC          2-0 (1-0)
+    15:00  Enyimba FC                 v Kwara United               0-0 (0-0)
+    15:00  Heartland FC               v Lobi Stars FC              3-0 (2-0)
+    15:00  Nasarawa United            v Gombe United               2-0 (2-0)
+    15:00  Nembe City FC              v Kaduna United              1-0 (1-0)
+    15:00  Rangers International FC   v Rivers United FC           3-0 (1-0)
+    15:00  Sharks FC                  v Kano Pillars FC            0-0 (0-0)
+    15:00  Shooting Stars SC          v Akwa United FC             4-1 (0-1)
+    15:00  Sunshine Stars FC          v Wikki Tourists             3-0 (1-0)
+    15:00  Warri Wolves FC            v El-Kanemi Warriors         4-1 (4-0)
+
+
+» Matchday 8
+  01.06.
+    16:00  Kano Pillars FC            v Heartland FC               1-0 (0-0)
+  24.04.
+    16:00  El-Kanemi Warriors         v Shooting Stars SC          2-0
+    16:00  Gombe United               v Enyimba FC                 1-0
+    16:00  Kwara United               v Nembe City FC              2-0
+    16:00  Wikki Tourists             v Sharks FC                  1-1
+  25.04.
+    16:00  Akwa United FC             v ABS FC                     2-2
+    16:00  Bayelsa United FC          v Sunshine Stars FC          1-0
+    16:00  Kaduna United              v Warri Wolves FC            1-1
+    16:00  Lobi Stars FC              v Rangers International FC   2-1
+    16:00  Rivers United FC           v Nasarawa United            3-0
+
+
+» Matchday 9
+  28.04.
+    16:00  ABS FC                     v Shooting Stars SC          1-0
+    16:00  Enyimba FC                 v Rivers United FC           2-0
+    16:00  Heartland FC               v Wikki Tourists             3-0
+    16:00  Kaduna United              v El-Kanemi Warriors         1-0
+    16:00  Nasarawa United            v Lobi Stars FC              1-1
+    16:00  Nembe City FC              v Gombe United               2-0
+    16:00  Rangers International FC   v Kano Pillars FC            4-0
+    16:00  Sharks FC                  v Bayelsa United FC          2-1
+    16:00  Sunshine Stars FC          v Akwa United FC             3-0
+    16:00  Warri Wolves FC            v Kwara United               2-1
+
+
+» Matchday 10
+  08.05.
+    16:00  Kano Pillars FC            v Nasarawa United            2-0
+    16:00  Kwara United               v Kaduna United              2-0
+    16:00  Shooting Stars SC          v Sunshine Stars FC          1-0
+  09.05.
+    16:00  Akwa United FC             v Sharks FC                  3-0
+    16:00  Bayelsa United FC          v Heartland FC               1-0
+    16:00  El-Kanemi Warriors         v ABS FC                     4-1
+    16:00  Gombe United               v Warri Wolves FC            3-0
+    16:00  Lobi Stars FC              v Enyimba FC                 0-0
+    16:00  Rivers United FC           v Nembe City FC              2-0
+  10.05.
+    16:00  Wikki Tourists             v Rangers International FC   3-0
+
+
+» Matchday 11
+  12.05.
+    16:00  Enyimba FC                 v Kano Pillars FC            3-0
+    16:00  Heartland FC               v Akwa United FC             2-1
+    16:00  Kaduna United              v Gombe United               1-0
+    16:00  Kwara United               v El-Kanemi Warriors         2-0
+    16:00  Nembe City FC              v Lobi Stars FC              1-0
+    16:00  Sharks FC                  v Shooting Stars SC          0-0
+    16:00  Sunshine Stars FC          v ABS FC                     0-0
+    16:00  Warri Wolves FC            v Rivers United FC           2-1
+  13.05.
+    16:00  Nasarawa United            v Wikki Tourists             2-1
+    16:00  Rangers International FC   v Bayelsa United FC          1-1
+
+
+» Matchday 12
+  15.05.
+    16:00  ABS FC                     v Sharks FC                  0-0 (0-0)
+    16:00  Akwa United FC             v Rangers International FC   1-0
+    16:00  El-Kanemi Warriors         v Sunshine Stars FC          1-0
+    16:00  Gombe United               v Kwara United               1-0
+    16:00  Kano Pillars FC            v Nembe City FC              3-1
+    16:00  Lobi Stars FC              v Warri Wolves FC            1-0
+    16:00  Rivers United FC           v Kaduna United              2-0
+    16:00  Shooting Stars SC          v Heartland FC               0-2 (0-1)
+  16.05.
+    16:00  Bayelsa United FC          v Nasarawa United            2-1
+    16:00  Wikki Tourists             v Enyimba FC                 1-0
+
+
+» Matchday 13
+  19.05.
+    16:00  Enyimba FC                 v Bayelsa United FC          2-0
+    16:00  Gombe United               v El-Kanemi Warriors         1-0
+    16:00  Heartland FC               v ABS FC                     1-0
+    16:00  Kaduna United              v Lobi Stars FC              1-0
+    16:00  Kwara United               v Rivers United FC           1-1
+    16:00  Nasarawa United            v Akwa United FC             0-0
+    16:00  Nembe City FC              v Wikki Tourists             2-1
+    16:00  Sharks FC                  v Sunshine Stars FC          1-0
+    16:00  Warri Wolves FC            v Kano Pillars FC            2-1
+  19.06.
+    16:00  Rangers International FC   v Shooting Stars SC          2-0
+
+
+» Matchday 14
+  22.05.
+    16:00  ABS FC                     v Rangers International FC   2-1
+    16:00  Akwa United FC             v Enyimba FC                 1-0
+    16:00  Bayelsa United FC          v Nembe City FC              2-0
+    16:00  El-Kanemi Warriors         v Sharks FC                  2-1
+    16:00  Kano Pillars FC            v Kaduna United              3-2
+    16:00  Lobi Stars FC              v Kwara United               0-1
+    16:00  Rivers United FC           v Gombe United               1-0
+    16:00  Shooting Stars SC          v Nasarawa United            2-0
+    16:00  Sunshine Stars FC          v Heartland FC               2-1
+    16:00  Wikki Tourists             v Warri Wolves FC            2-1
+
+
+» Matchday 15
+  26.05.
+    16:00  Enyimba FC                 v Shooting Stars SC          1-0 (0-0)
+    16:00  Gombe United               v Lobi Stars FC              2-2 (1-1)
+    16:00  Heartland FC               v Sharks FC                  1-0 (1-0)
+    16:00  Kaduna United              v Wikki Tourists             1-0 (0-0)
+    16:00  Kwara United               v Kano Pillars FC            3-0 (2-0)
+    16:00  Nasarawa United            v ABS FC                     2-1 (2-0)
+    16:00  Nembe City FC              v Akwa United FC             2-0 (2-0)
+    16:00  Rangers International FC   v Sunshine Stars FC          2-0 (1-0)
+    16:00  Rivers United FC           v El-Kanemi Warriors         1-0 (1-0)
+    16:00  Warri Wolves FC            v Bayelsa United FC          4-0 (2-0)
+
+
+» Matchday 16
+  05.06.
+    16:00  ABS FC                     v Enyimba FC                 3-0
+    16:00  Bayelsa United FC          v Kaduna United              2-0
+    16:00  El-Kanemi Warriors         v Heartland FC               1-0
+    16:00  Kano Pillars FC            v Gombe United               4-0 (2-0)
+    16:00  Lobi Stars FC              v Rivers United FC           1-0
+    16:00  Shooting Stars SC          v Nembe City FC              3-1 (1-0)
+    16:00  Wikki Tourists             v Kwara United               2-1 (1-0)
+  06.06.
+    16:00  Sunshine Stars FC          v Nasarawa United            3-0
+  07.08.
+    17:00  Akwa United FC             v Warri Wolves FC            1-0
+  23.06.
+    16:00  Sharks FC                  v Rangers International FC   1-0 (1-0)
+
+
+» Matchday 17
+  08.06.
+    16:00  Gombe United               v Wikki Tourists             1-0 (1-0)
+    16:00  Kwara United               v Bayelsa United FC          2-0 (1-0)
+    16:00  Rivers United FC           v Kano Pillars FC            1-1 (0-1)
+  09.06.
+    16:00  Enyimba FC                 v Sunshine Stars FC          1-0 (0-0)
+    16:00  Kaduna United              v Akwa United FC             2-1 (1-1)
+    16:00  Lobi Stars FC              v El-Kanemi Warriors         1-1
+    16:00  Nasarawa United            v Sharks FC                  1-0 (0-0)
+    16:00  Nembe City FC              v ABS FC                     0-1
+    16:00  Rangers International FC   v Heartland FC               3-1 (2-0)
+    16:00  Warri Wolves FC            v Shooting Stars SC          2-1 (0-0)
+
+
+» Matchday 18
+  12.06.
+    16:00  ABS FC                     v Warri Wolves FC            0-2
+    16:00  Bayelsa United FC          v Gombe United               1-0
+    16:00  Heartland FC               v Nasarawa United            2-0
+    16:00  Kano Pillars FC            v Lobi Stars FC              1-1
+    16:00  Sharks FC                  v Enyimba FC                 1-0
+    16:00  Shooting Stars SC          v Kaduna United              2-0
+    16:00  Sunshine Stars FC          v Nembe City FC              2-0
+    16:00  Wikki Tourists             v Rivers United FC           1-0
+  13.06.
+    16:00  Akwa United FC             v Kwara United               0-0
+    16:00  El-Kanemi Warriors         v Rangers International FC   3-0
+
+
+» Matchday 19
+  16.06.
+    16:00  Enyimba FC                 v Heartland FC               1-0
+    16:00  Gombe United               v Akwa United FC             4-1
+    16:00  Kaduna United              v ABS FC                     3-0
+    16:00  Kano Pillars FC            v El-Kanemi Warriors         2-0
+    16:00  Kwara United               v Shooting Stars SC          2-0
+    16:00  Lobi Stars FC              v Wikki Tourists             1-0
+    16:00  Nasarawa United            v Rangers International FC   2-0
+    16:00  Nembe City FC              v Sharks FC                  1-0
+    16:00  Rivers United FC           v Bayelsa United FC          2-0
+    16:00  Warri Wolves FC            v Sunshine Stars FC          2-0
+
+
+» Matchday 20
+  03.07.
+    16:00  El-Kanemi Warriors         v Kano Pillars FC            2-0
+    16:00  Sharks FC                  v Nembe City FC              1-0 (1-0)
+    16:00  Shooting Stars SC          v Kwara United               1-1 (0-1)
+    16:00  Wikki Tourists             v Lobi Stars FC              4-0 (1-0)
+  04.07.
+    16:00  ABS FC                     v Kaduna United              1-0
+    16:00  Akwa United FC             v Gombe United               3-2
+    16:00  Bayelsa United FC          v Rivers United FC           2-2
+    16:00  Heartland FC               v Enyimba FC                 0-1
+    16:00  Rangers International FC   v Nasarawa United            2-0
+    16:00  Sunshine Stars FC          v Warri Wolves FC            1-1
+
+
+» Matchday 21
+  07.07.
+    16:00  El-Kanemi Warriors         v Nasarawa United            3-0
+    16:00  Enyimba FC                 v Rangers International FC   1-0
+    16:00  Gombe United               v Shooting Stars SC          3-2
+    16:00  Kaduna United              v Sunshine Stars FC          2-0
+    16:00  Kano Pillars FC            v Wikki Tourists             3-1
+    16:00  Kwara United               v ABS FC                     0-0
+    16:00  Lobi Stars FC              v Bayelsa United FC          3-4
+    16:00  Nembe City FC              v Heartland FC               2-0
+    16:00  Warri Wolves FC            v Sharks FC                  1-0
+  08.07.
+    12:00  Rivers United FC           v Akwa United FC             2-1 (2-0)
+
+
+» Matchday 22
+  21.07.
+    16:00  ABS FC                     v Gombe United               1-0
+    16:00  Akwa United FC             v Lobi Stars FC              2-1
+    16:00  Bayelsa United FC          v Kano Pillars FC            1-0
+    16:00  Heartland FC               v Warri Wolves FC            1-0
+    16:00  Nasarawa United            v Enyimba FC                 1-1
+    16:00  Rangers International FC   v Nembe City FC              2-0
+    16:00  Sharks FC                  v Kaduna United              2-1
+    16:00  Shooting Stars SC          v Rivers United FC           0-0
+    16:00  Sunshine Stars FC          v Kwara United               3-1
+    16:00  Wikki Tourists             v El-Kanemi Warriors         0-3
+
+
+» Matchday 23
+  03.08.
+    16:00  Kwara United               v Sharks FC                  0-0 (0-0)
+    16:00  Rivers United FC           v ABS FC                     2-0 (1-0)
+  04.08.
+    16:00  El-Kanemi Warriors         v Enyimba FC                 2-0
+    16:00  Gombe United               v Sunshine Stars FC          2-0 (0-0)
+    16:00  Kaduna United              v Heartland FC               1-0 (1-0)
+    16:00  Lobi Stars FC              v Shooting Stars SC          1-0 (1-0)
+    16:00  Nembe City FC              v Nasarawa United            1-0 (1-0)
+    16:00  Warri Wolves FC            v Rangers International FC   1-0 (1-0)
+    16:00  Wikki Tourists             v Bayelsa United FC          1-0 (0-0)
+  04.09.
+    16:00  Kano Pillars FC            v Akwa United FC             1-0 (0-0)
+
+
+» Matchday 24
+  11.08.
+    16:00  ABS FC                     v Lobi Stars FC              2-1 (1-0)
+    16:00  Akwa United FC             v Wikki Tourists             1-0 (0-0)
+    16:00  Bayelsa United FC          v El-Kanemi Warriors         3-0 (3-0)
+    16:00  Enyimba FC                 v Nembe City FC              2-0 (2-0)
+    16:00  Heartland FC               v Kwara United               0-1 (0-0)
+    16:00  Nasarawa United            v Warri Wolves FC            1-1
+    16:00  Rangers International FC   v Kaduna United              2-1 (0-1)
+    16:00  Sharks FC                  v Gombe United               3-0
+    16:00  Shooting Stars SC          v Kano Pillars FC            3-1
+    16:00  Sunshine Stars FC          v Rivers United FC           3-0 (2-0)
+
+
+» Matchday 25
+  14.08.
+    16:00  Bayelsa United FC          v Akwa United FC             4-1
+    16:00  El-Kanemi Warriors         v Nembe City FC              3-0
+    16:00  Gombe United               v Heartland FC               1-0
+    16:00  Kaduna United              v Nasarawa United            2-1
+    16:00  Kano Pillars FC            v ABS FC                     3-0
+    16:00  Kwara United               v Rangers International FC   1-0 (0-0)
+    16:00  Lobi Stars FC              v Sunshine Stars FC          1-0
+    16:00  Rivers United FC           v Sharks FC                  1-2
+    16:00  Warri Wolves FC            v Enyimba FC                 0-0 (0-0)
+    16:00  Wikki Tourists             v Shooting Stars SC          2-1 (2-1)
+
+
+» Matchday 26
+  18.08.
+    16:00  ABS FC                     v Wikki Tourists             2-2
+    16:00  Akwa United FC             v El-Kanemi Warriors         1-1
+    16:00  Enyimba FC                 v Kaduna United              1-0
+    16:00  Heartland FC               v Rivers United FC           1-0
+    16:00  Nasarawa United            v Kwara United               2-1
+    16:00  Nembe City FC              v Warri Wolves FC            1-0
+    16:00  Rangers International FC   v Gombe United               1-0
+    16:00  Sharks FC                  v Lobi Stars FC              1-0
+    16:00  Shooting Stars SC          v Bayelsa United FC          2-0
+    16:00  Sunshine Stars FC          v Kano Pillars FC            2-1
+
+
+» Matchday 27
+  24.08.
+    16:00  Bayelsa United FC          v ABS FC                     2-0
+    16:00  Gombe United               v Nasarawa United            2-0 (1-0)
+    16:00  Kano Pillars FC            v Sharks FC                  1-0
+    16:00  Kwara United               v Enyimba FC                 1-0 (1-0)
+  25.08.
+    16:00  Akwa United FC             v Shooting Stars SC          1-0
+    16:00  El-Kanemi Warriors         v Warri Wolves FC            3-0
+    16:00  Kaduna United              v Nembe City FC              2-0
+    16:00  Lobi Stars FC              v Heartland FC               1-0
+    16:00  Rivers United FC           v Rangers International FC   2-0
+    16:00  Wikki Tourists             v Sunshine Stars FC          2-0
+
+
+» Matchday 28
+  28.08.
+    16:00  ABS FC                     v Akwa United FC             1-0 (0-0)
+    16:00  Enyimba FC                 v Gombe United               3-0 (2-0)
+    16:00  Heartland FC               v Kano Pillars FC            2-0 (1-0)
+    16:00  Nasarawa United            v Rivers United FC           4-0 (3-0)
+    16:00  Nembe City FC              v Kwara United               2-0 (1-0)
+    16:00  Rangers International FC   v Lobi Stars FC              2-1 (1-1)
+    16:00  Sharks FC                  v Wikki Tourists             2-1 (1-0)
+    16:00  Shooting Stars SC          v El-Kanemi Warriors         2-0 (0-0)
+    16:00  Warri Wolves FC            v Kaduna United              4-0 (3-0)
+  29.08.
+    16:00  Sunshine Stars FC          v Bayelsa United FC          0-0 (0-0)
+
+
+» Matchday 29
+  01.09.
+    16:00  Akwa United FC             v Sunshine Stars FC          4-0
+    16:00  Bayelsa United FC          v Sharks FC                  1-0
+    16:00  Gombe United               v Nembe City FC              1-0
+    16:00  Lobi Stars FC              v Nasarawa United            1-0
+    16:00  Shooting Stars SC          v ABS FC                     1-1
+    16:00  Wikki Tourists             v Heartland FC               0-1
+  05.09.
+    15:00  Kwara United               v Warri Wolves FC            0-3
+  31.08.
+    16:00  El-Kanemi Warriors         v Kaduna United              1-0
+    16:00  Kano Pillars FC            v Rangers International FC   2-1
+    16:00  Rivers United FC           v Enyimba FC                 0-0 (0-0)
+
+
+» Matchday 30
+  08.09.
+    16:00  ABS FC                     v El-Kanemi Warriors         0-0
+    16:00  Enyimba FC                 v Lobi Stars FC              3-0
+    16:00  Heartland FC               v Bayelsa United FC          1-0
+    16:00  Kaduna United              v Kwara United               2-0
+    16:00  Kano Pillars FC            v Nasarawa United            1-2
+    16:00  Nembe City FC              v Rivers United FC           0-0
+    16:00  Rangers International FC   v Wikki Tourists             1-0
+    16:00  Sharks FC                  v Akwa United FC             1-1
+    16:00  Warri Wolves FC            v Gombe United               1-0
+    16:00  Sunshine Stars FC          v Shooting Stars SC          3-0
+
+
+» Matchday 31
+  11.09.
+    16:00  ABS FC                     v Sunshine Stars FC          2-1
+    16:00  Akwa United FC             v Heartland FC               0-0 (0-0)
+    16:00  Bayelsa United FC          v Rangers International FC   1-0
+    16:00  El-Kanemi Warriors         v Kwara United               1-0
+    16:00  Gombe United               v Kaduna United              3-0
+    16:00  Kano Pillars FC            v Enyimba FC                 1-0
+    16:00  Lobi Stars FC              v Nembe City FC              3-0
+    16:00  Rivers United FC           v Warri Wolves FC            2-1
+    16:00  Shooting Stars SC          v Sharks FC                  1-1
+    16:00  Wikki Tourists             v Nasarawa United            1-0
+
+
+» Matchday 32
+  18.09.
+    16:00  Enyimba FC                 v Wikki Tourists             2-0
+    16:00  Heartland FC               v Shooting Stars SC          1-1
+    16:00  Kaduna United              v Rivers United FC           1-0
+    16:00  Kwara United               v Gombe United               2-0
+    16:00  Nasarawa United            v Bayelsa United FC          2-1 (1-1)
+    16:00  Nembe City FC              v Kano Pillars FC            1-0
+    16:00  Rangers International FC   v Akwa United FC             3-1
+    16:00  Sharks FC                  v ABS FC                     4-0
+    16:00  Sunshine Stars FC          v El-Kanemi Warriors         1-0
+    16:00  Warri Wolves FC            v Lobi Stars FC              0-0
+
+
+» Matchday 33
+  11.09.
+    15:00  Wikki Tourists             v Nembe City FC              3-0
+  22.09.
+    16:00  ABS FC                     v Heartland FC               2-1
+    16:00  Akwa United FC             v Nasarawa United            1-1
+    16:00  Bayelsa United FC          v Enyimba FC                 1-0
+    16:00  El-Kanemi Warriors         v Gombe United               1-0
+    16:00  Kano Pillars FC            v Warri Wolves FC            2-0
+    16:00  Lobi Stars FC              v Kaduna United              2-1
+    16:00  Rivers United FC           v Kwara United               1-0
+    16:00  Shooting Stars SC          v Rangers International FC   2-1
+    16:00  Sunshine Stars FC          v Sharks FC                  1-0
+
+
+» Matchday 34
+  25.09.
+    16:00  Enyimba FC                 v Akwa United FC             1-0
+    16:00  Gombe United               v Rivers United FC           1-0
+    16:00  Heartland FC               v Sunshine Stars FC          0-0 (0-0)
+    16:00  Kaduna United              v Kano Pillars FC            1-0
+    16:00  Kwara United               v Lobi Stars FC              0-0 (0-0)
+    16:00  Nasarawa United            v Shooting Stars SC          3-0
+    16:00  Nembe City FC              v Bayelsa United FC          1-0
+    16:00  Rangers International FC   v ABS FC                     2-0
+    16:00  Sharks FC                  v El-Kanemi Warriors         3-0
+    16:00  Warri Wolves FC            v Wikki Tourists             3-1
+
+
+» Matchday 35
+  02.10.
+    16:00  ABS FC                     v Nasarawa United            1-0 (0-0)
+    16:00  Akwa United FC             v Nembe City FC              0-0 (0-0)
+    16:00  Bayelsa United FC          v Warri Wolves FC            1-0 (0-0)
+    16:00  Lobi Stars FC              v Gombe United               2-0 (1-0)
+    16:00  Sharks FC                  v Heartland FC               3-1 (1-0)
+    16:00  Shooting Stars SC          v Enyimba FC                 1-1 (0-0)
+    16:00  Sunshine Stars FC          v Rangers International FC   1-1 (0-1)
+    16:00  Wikki Tourists             v Kaduna United              2-0 (1-0)
+  03.10.
+    09:00  Kano Pillars FC            v Kwara United               2-0 (1-0)
+    16:00  El-Kanemi Warriors         v Rivers United FC           2-0
+
+
+» Matchday 36
+  12.10.
+    16:00  Enyimba FC                 v ABS FC                     1-0
+    16:00  Gombe United               v Kano Pillars FC            2-1
+    16:00  Heartland FC               v El-Kanemi Warriors         1-0
+    16:00  Kaduna United              v Bayelsa United FC          1-0
+    16:00  Kwara United               v Wikki Tourists             1-1
+    16:00  Nasarawa United            v Sunshine Stars FC          1-0
+    16:00  Nembe City FC              v Shooting Stars SC          1-0
+    16:00  Rangers International FC   v Sharks FC                  2-0
+    16:00  Rivers United FC           v Lobi Stars FC              1-0
+    16:00  Warri Wolves FC            v Akwa United FC             0-1
+
+
+» Matchday 37
+  16.10.
+    16:00  ABS FC                     v Nembe City FC              6-1 (1-0)
+    16:00  Akwa United FC             v Kaduna United              3-2 (1-1)
+    16:00  Bayelsa United FC          v Kwara United               2-1 (1-1)
+    16:00  El-Kanemi Warriors         v Lobi Stars FC              1-0 (0-0)
+    16:00  Heartland FC               v Rangers International FC   2-1 (1-1)
+    16:00  Kano Pillars FC            v Rivers United FC           1-0 (1-0)
+    16:00  Sharks FC                  v Nasarawa United            3-1 (2-0)
+    16:00  Shooting Stars SC          v Warri Wolves FC            2-0 (2-0)
+    16:00  Sunshine Stars FC          v Enyimba FC                 2-0 (1-0)
+    16:00  Wikki Tourists             v Gombe United               2-0 (0-0)
+
+
+» Matchday 38
+  20.10.
+    16:00  Enyimba FC                 v Sharks FC                  1-0
+    16:00  Gombe United               v Bayelsa United FC          1-0 (0-0)
+    16:00  Kaduna United              v Shooting Stars SC          2-0 (0-0)
+    16:00  Kwara United               v Akwa United FC             1-1 (0-0)
+    16:00  Lobi Stars FC              v Kano Pillars FC            2-0 (1-0)
+    16:00  Nasarawa United            v Heartland FC               1-0
+    16:00  Nembe City FC              v Sunshine Stars FC          2-0
+    16:00  Rangers International FC   v El-Kanemi Warriors         1-0 (0-0)
+    16:00  Rivers United FC           v Wikki Tourists             1-0 (0-0)
+    16:00  Warri Wolves FC            v ABS FC                     1-0
+


### PR DESCRIPTION
**Summary**

Adds the Nigeria Professional Football League (NPFL) 2012/13 season to the Open Football dataset.

**Details**

- Country: Nigeria

- Competition: Nigeria Professional Football League

- Season: 2012/13

- Tier: 1 (ng1)

- Teams: 20

- Matches: Full league season

- Source: Soccerway

**Notes**

- Team names use expanded, consistent canonical forms.

- This is the first historical NPFL season; additional seasons can be added in follow-up PRs.