### PR TITLE
Add Nigeria Professional Football League seasons 2009-2012

### DIFF
--- a/africa/nigeria/2009-10_ng1.txt
+++ b/africa/nigeria/2009-10_ng1.txt
@@ -1,0 +1,645 @@
+= Nigeria | Premier Football League 2009/2010
+
+# Date       Fri Jan/09 2009 - Wed Dec/23 2009 (348d)
+# Teams      20
+# Matches    380
+
+
+
+» Matchday 1
+  14.10.
+    16:00  Kano Pillars FC            v Shooting Stars SC          1-0
+  15.10.
+    16:00  Niger Tornadoes FC         v Heartland FC               1-0
+  20.09.
+    16:00  Dolphins FC                v Ocean Boys FC              1-1
+    16:00  Enyimba FC                 v Lobi Stars FC              0-0
+    16:00  Gateway Utd.               v Kwara United FC            1-1
+    16:00  Sunshine Stars FC          v Rangers International FC   2-1
+    16:00  Warri Wolves FC            v Zamfara United FC          5-0
+    16:00  Wikki Tourists FC          v Kaduna United FC           2-1
+  25.11.
+    00:00  Bayelsa United FC          v Sharks FC                  2-1
+  30.09.
+    16:00  Ranchers Bees FC           v Gombe United FC            0-0
+
+
+
+» Matchday 2
+  26.09.
+    16:00  Gombe United FC            v Niger Tornadoes FC         1-2
+    16:00  Ocean Boys FC              v Enyimba FC                 1-1
+    16:00  Sharks FC                  v Warri Wolves FC            0-0
+    16:00  Shooting Stars SC          v Dolphins FC                1-1
+  27.09.
+    16:00  Heartland FC               v Bayelsa United FC          2-1
+    16:00  Kwara United FC            v Kano Pillars FC            0-0
+    16:00  Lobi Stars FC              v Wikki Tourists FC          1-0
+    16:00  Rangers International FC   v Ranchers Bees FC           2-0
+    16:00  Zamfara United FC          v Gateway Utd.               1-0
+  28.09.
+    16:00  Kaduna United FC           v Sunshine Stars FC          1-1
+
+
+
+» Matchday 3
+  03.10.
+    16:00  Dolphins FC                v Kwara United FC            1-0
+    16:00  Gateway Utd.               v Sharks FC                  4-1
+    16:00  Niger Tornadoes FC         v Ranchers Bees FC           0-0
+    16:00  Wikki Tourists FC          v Ocean Boys FC              1-0
+  04.10.
+    16:00  Enyimba FC                 v Shooting Stars SC          1-0
+    16:00  Kaduna United FC           v Rangers International FC   1-1
+    16:00  Sunshine Stars FC          v Lobi Stars FC              0-0
+  07.10.
+    16:00  Bayelsa United FC          v Gombe United FC            2-0
+  25.11.
+    17:00  Kano Pillars FC            v Zamfara United FC          3-0
+    17:00  Warri Wolves FC            v Heartland FC               3-2
+
+
+
+» Matchday 4
+  10.10.
+    16:00  Kwara United FC            v Enyimba FC                 0-0
+    16:00  Lobi Stars FC              v Kaduna United FC           1-1
+    16:00  Ocean Boys FC              v Sunshine Stars FC          1-0
+    16:00  Ranchers Bees FC           v Bayelsa United FC          2-1
+    16:00  Rangers International FC   v Niger Tornadoes FC         1-0
+    16:00  Shooting Stars SC          v Wikki Tourists FC          1-0
+    16:00  Zamfara United FC          v Dolphins FC                3-2
+  12.11.
+    17:00  Gombe United FC            v Warri Wolves FC            1-0
+  23.12.
+    17:00  Heartland FC               v Gateway Utd.               2-0
+    17:00  Sharks FC                  v Kano Pillars FC            2-0
+
+
+
+» Matchday 5
+  17.10.
+    16:00  Dolphins FC                v Sharks FC                  1-1
+    16:00  Gateway Utd.               v Gombe United FC            2-1
+    16:00  Wikki Tourists FC          v Kwara United FC            3-4
+  18.10.
+    16:00  Enyimba FC                 v Zamfara United FC          1-0
+    16:00  Kaduna United FC           v Ocean Boys FC              2-0
+    16:00  Kano Pillars FC            v Heartland FC               4-0
+    16:00  Lobi Stars FC              v Rangers International FC   2-1
+    16:00  Sunshine Stars FC          v Shooting Stars SC          1-0
+    16:00  Warri Wolves FC            v Ranchers Bees FC           1-0
+  23.12.
+    17:00  Bayelsa United FC          v Niger Tornadoes FC         1-1
+
+
+
+» Matchday 6
+  18.11.
+    17:00  Gombe United FC            v Kano Pillars FC            2-0
+    17:00  Heartland FC               v Dolphins FC                1-0
+    17:00  Kwara United FC            v Sunshine Stars FC          2-0
+    17:00  Niger Tornadoes FC         v Warri Wolves FC            2-1
+    17:00  Ocean Boys FC              v Lobi Stars FC              1-0
+    17:00  Ranchers Bees FC           v Gateway Utd.               0-0
+    17:00  Rangers International FC   v Bayelsa United FC          1-0
+    17:00  Sharks FC                  v Enyimba FC                 2-3
+    17:00  Shooting Stars SC          v Kaduna United FC           3-1
+    17:00  Zamfara United FC          v Wikki Tourists FC          0-0
+
+
+
+» Matchday 7
+  21.11.
+    17:00  Dolphins FC                v Gombe United FC            1-0
+    17:00  Gateway Utd.               v Niger Tornadoes FC         1-0
+    17:00  Kano Pillars FC            v Ranchers Bees FC           2-1
+    17:00  Ocean Boys FC              v Rangers International FC   1-0
+    17:00  Wikki Tourists FC          v Sharks FC                  1-1
+  22.11.
+    17:00  Enyimba FC                 v Heartland FC               0-0
+    17:00  Kaduna United FC           v Kwara United FC            1-2
+    17:00  Lobi Stars FC              v Shooting Stars SC          2-0
+    17:00  Sunshine Stars FC          v Zamfara United FC          2-0
+    17:00  Warri Wolves FC            v Bayelsa United FC          2-0
+
+
+
+» Matchday 8
+  28.11.
+    17:00  Gombe United FC            v Enyimba FC                 1-1
+    17:00  Kwara United FC            v Lobi Stars FC              2-0
+    17:00  Niger Tornadoes FC         v Kano Pillars FC            1-1
+    17:00  Ranchers Bees FC           v Dolphins FC                2-0
+    17:00  Sharks FC                  v Sunshine Stars FC          0-1
+    17:00  Shooting Stars SC          v Ocean Boys FC              0-0
+  29.11.
+    17:00  Bayelsa United FC          v Gateway Utd.               2-1
+    17:00  Heartland FC               v Wikki Tourists FC          0-0
+    17:00  Rangers International FC   v Warri Wolves FC            1-1
+    17:00  Zamfara United FC          v Kaduna United FC           1-1
+
+
+
+» Matchday 9
+  05.12.
+    17:00  Dolphins FC                v Niger Tornadoes FC         2-1
+    17:00  Gateway Utd.               v Warri Wolves FC            2-2
+    17:00  Kano Pillars FC            v Bayelsa United FC          1-1
+    17:00  Ocean Boys FC              v Kwara United FC            1-1
+    17:00  Shooting Stars SC          v Rangers International FC   0-0
+    17:00  Wikki Tourists FC          v Gombe United FC            2-0
+  06.12.
+    17:00  Enyimba FC                 v Ranchers Bees FC           4-0
+    17:00  Kaduna United FC           v Sharks FC                  1-0
+    17:00  Lobi Stars FC              v Zamfara United FC          1-1
+    17:00  Sunshine Stars FC          v Heartland FC               0-0
+
+
+
+» Matchday 10
+  12.12.
+    17:00  Bayelsa United FC          v Dolphins FC                1-1
+    17:00  Gombe United FC            v Sunshine Stars FC          2-1
+    17:00  Kwara United FC            v Shooting Stars SC          0-0
+    17:00  Ranchers Bees FC           v Wikki Tourists FC          2-1
+    17:00  Sharks FC                  v Lobi Stars FC              3-1
+  13.12.
+    17:00  Heartland FC               v Kaduna United FC           2-0
+    17:00  Niger Tornadoes FC         v Enyimba FC                 3-2
+    17:00  Rangers International FC   v Gateway Utd.               4-0
+    17:00  Warri Wolves FC            v Kano Pillars FC            3-0
+    17:00  Zamfara United FC          v Ocean Boys FC              1-1
+
+
+
+» Matchday 11
+  09.01.
+    17:00  Dolphins FC                v Warri Wolves FC            1-1
+    17:00  Kano Pillars FC            v Gateway Utd.               1-0
+    17:00  Kwara United FC            v Rangers International FC   0-0
+    17:00  Shooting Stars SC          v Zamfara United FC          2-0
+    17:00  Wikki Tourists FC          v Niger Tornadoes FC         2-0
+  10.01.
+    17:00  Kaduna United FC           v Gombe United FC            2-1
+    17:00  Lobi Stars FC              v Heartland FC               1-1
+    17:00  Ocean Boys FC              v Sharks FC                  1-0
+    17:00  Sunshine Stars FC          v Ranchers Bees FC           1-0
+  11.01.
+    17:00  Enyimba FC                 v Bayelsa United FC          2-0
+
+
+
+» Matchday 12
+  19.12.
+    17:00  Bayelsa United FC          v Wikki Tourists FC          1-1
+    17:00  Gateway Utd.               v Dolphins FC                1-1
+    17:00  Gombe United FC            v Lobi Stars FC              2-0
+    17:00  Niger Tornadoes FC         v Sunshine Stars FC          1-0
+    17:00  Ranchers Bees FC           v Kaduna United FC           1-0
+    17:00  Sharks FC                  v Shooting Stars SC          2-0
+  20.12.
+    17:00  Heartland FC               v Ocean Boys FC              2-0
+    17:00  Rangers International FC   v Kano Pillars FC            1-0
+    17:00  Warri Wolves FC            v Enyimba FC                 0-1
+    17:00  Zamfara United FC          v Kwara United FC            1-0
+
+
+
+» Matchday 13
+  13.01.
+    17:00  Dolphins FC                v Kano Pillars FC            3-1
+    17:00  Kaduna United FC           v Niger Tornadoes FC         1-0
+    17:00  Kwara United FC            v Sharks FC                  1-0
+    17:00  Lobi Stars FC              v Ranchers Bees FC           2-0
+    17:00  Ocean Boys FC              v Gombe United FC            2-0
+    17:00  Shooting Stars SC          v Heartland FC               1-0
+    17:00  Wikki Tourists FC          v Warri Wolves FC            3-1
+    17:00  Zamfara United FC          v Rangers International FC   1-0
+  14.01.
+    17:00  Enyimba FC                 v Gateway Utd.               2-0
+    17:00  Sunshine Stars FC          v Bayelsa United FC          1-0
+
+
+
+» Matchday 14
+  17.01.
+    17:00  Bayelsa United FC          v Kaduna United FC           3-1
+    17:00  Gateway Utd.               v Wikki Tourists FC          2-1
+    17:00  Gombe United FC            v Shooting Stars SC          2-0
+    17:00  Heartland FC               v Kwara United FC            3-1
+    17:00  Kano Pillars FC            v Enyimba FC                 2-0
+    17:00  Niger Tornadoes FC         v Lobi Stars FC              2-0
+    17:00  Ranchers Bees FC           v Ocean Boys FC              1-0
+    17:00  Rangers International FC   v Dolphins FC                2-0
+    17:00  Sharks FC                  v Zamfara United FC          4-2
+    17:00  Warri Wolves FC            v Sunshine Stars FC          2-0
+
+
+
+» Matchday 15
+  23.01.
+    17:00  Kwara United FC            v Gombe United FC            2-0
+    17:00  Sharks FC                  v Rangers International FC   0-1
+    17:00  Shooting Stars SC          v Ranchers Bees FC           0-0
+  24.01.
+    17:00  Enyimba FC                 v Dolphins FC                1-0
+    17:00  Kaduna United FC           v Warri Wolves FC            1-0
+    17:00  Lobi Stars FC              v Bayelsa United FC          0-0
+    17:00  Ocean Boys FC              v Niger Tornadoes FC         1-1
+    17:00  Sunshine Stars FC          v Gateway Utd.               2-1
+    17:00  Wikki Tourists FC          v Kano Pillars FC            0-1
+    17:00  Zamfara United FC          v Heartland FC               1-0
+
+
+
+» Matchday 16
+  03.02.
+    17:00  Warri Wolves FC            v Lobi Stars FC              1-0
+  27.01.
+    17:00  Bayelsa United FC          v Ocean Boys FC              2-1
+    17:00  Dolphins FC                v Wikki Tourists FC          2-1
+    17:00  Gateway Utd.               v Kaduna United FC           1-0
+    17:00  Gombe United FC            v Zamfara United FC          3-0
+    17:00  Kano Pillars FC            v Sunshine Stars FC          1-0
+    17:00  Niger Tornadoes FC         v Shooting Stars SC          2-0
+    17:00  Ranchers Bees FC           v Kwara United FC            2-0
+    17:00  Rangers International FC   v Enyimba FC                 0-0
+  28.01.
+    17:00  Heartland FC               v Sharks FC                  0-1
+
+
+
+» Matchday 17
+  30.01.
+    17:00  Kwara United FC            v Niger Tornadoes FC         2-0
+    17:00  Sharks FC                  v Gombe United FC            1-1
+    17:00  Shooting Stars SC          v Bayelsa United FC          2-0
+    17:00  Wikki Tourists FC          v Enyimba FC                 1-0
+  31.01.
+    17:00  Heartland FC               v Rangers International FC   1-0
+    17:00  Kaduna United FC           v Kano Pillars FC            0-0
+    17:00  Lobi Stars FC              v Gateway Utd.               2-1
+    17:00  Ocean Boys FC              v Warri Wolves FC            1-1
+    17:00  Sunshine Stars FC          v Dolphins FC                1-0
+    17:00  Zamfara United FC          v Ranchers Bees FC           2-0
+
+
+
+» Matchday 18
+  06.02.
+    17:00  Dolphins FC                v Kaduna United FC           2-1
+    17:00  Gateway Utd.               v Ocean Boys FC              2-0
+    17:00  Gombe United FC            v Heartland FC               2-1
+    17:00  Kano Pillars FC            v Lobi Stars FC              2-0
+    17:00  Niger Tornadoes FC         v Zamfara United FC          3-1
+    17:00  Ranchers Bees FC           v Sharks FC                  2-1
+  07.02.
+    17:00  Bayelsa United FC          v Kwara United FC            1-2
+    17:00  Enyimba FC                 v Sunshine Stars FC          2-1
+    17:00  Rangers International FC   v Wikki Tourists FC          1-0
+    17:00  Warri Wolves FC            v Shooting Stars SC          2-0
+
+
+
+» Matchday 19
+  13.02.
+    17:00  Gombe United FC            v Rangers International FC   0-0
+    17:00  Sharks FC                  v Niger Tornadoes FC         2-0
+    17:00  Shooting Stars SC          v Gateway Utd.               1-0
+  14.02.
+    17:00  Heartland FC               v Ranchers Bees FC           2-0
+    17:00  Kaduna United FC           v Enyimba FC                 1-0
+    17:00  Lobi Stars FC              v Dolphins FC                2-1
+    17:00  Ocean Boys FC              v Kano Pillars FC            1-0
+    17:00  Sunshine Stars FC          v Wikki Tourists FC          4-0
+  17.02.
+    17:00  Kwara United FC            v Warri Wolves FC            2-0
+  18.02.
+    17:00  Zamfara United FC          v Bayelsa United FC          1-0
+
+
+
+» Matchday 20
+  20.02.
+    17:00  Dolphins FC                v Lobi Stars FC              1-0
+    17:00  Gateway Utd.               v Shooting Stars SC          1-2
+    17:00  Kano Pillars FC            v Ocean Boys FC              5-1
+    17:00  Niger Tornadoes FC         v Sharks FC                  2-1
+    17:00  Ranchers Bees FC           v Heartland FC               1-0
+    17:00  Wikki Tourists FC          v Sunshine Stars FC          1-1
+  21.02.
+    17:00  Enyimba FC                 v Kaduna United FC           1-1
+    17:00  Rangers International FC   v Gombe United FC            2-0
+    17:00  Warri Wolves FC            v Kwara United FC            3-1
+  23.02.
+    17:00  Bayelsa United FC          v Zamfara United FC          1-0
+
+
+
+» Matchday 21
+  01.03.
+    17:00  Ocean Boys FC              v Dolphins FC                2-0
+  04.03.
+    17:00  Zamfara United FC          v Warri Wolves FC            2-0
+  27.02.
+    17:00  Gombe United FC            v Ranchers Bees FC           2-0
+    17:00  Kwara United FC            v Gateway Utd.               2-0
+    17:00  Shooting Stars SC          v Kano Pillars FC            0-0
+  28.02.
+    17:00  Heartland FC               v Niger Tornadoes FC         1-1
+    17:00  Kaduna United FC           v Wikki Tourists FC          1-0
+    17:00  Lobi Stars FC              v Enyimba FC                 0-1
+    17:00  Rangers International FC   v Sunshine Stars FC          0-0
+  31.03.
+    16:00  Sharks FC                  v Bayelsa United FC          2-1
+
+
+
+» Matchday 22
+  06.03.
+    17:00  Dolphins FC                v Shooting Stars SC          2-0
+    17:00  Kano Pillars FC            v Kwara United FC            3-0
+    17:00  Niger Tornadoes FC         v Gombe United FC            1-0
+    17:00  Ranchers Bees FC           v Rangers International FC   1-1
+  07.03.
+    17:00  Bayelsa United FC          v Heartland FC               1-0
+    17:00  Enyimba FC                 v Ocean Boys FC              2-1
+    17:00  Gateway Utd.               v Zamfara United FC          1-0
+    17:00  Sunshine Stars FC          v Kaduna United FC           2-1
+    17:00  Warri Wolves FC            v Sharks FC                  1-0
+    17:00  Wikki Tourists FC          v Lobi Stars FC              1-0
+
+
+
+» Matchday 23
+  10.03.
+    17:00  Heartland FC               v Warri Wolves FC            2-0
+    17:00  Kwara United FC            v Dolphins FC                1-0
+    17:00  Lobi Stars FC              v Sunshine Stars FC          2-0
+    17:00  Ocean Boys FC              v Wikki Tourists FC          1-1
+    17:00  Ranchers Bees FC           v Niger Tornadoes FC         2-1
+    17:00  Rangers International FC   v Kaduna United FC           1-0
+    17:00  Sharks FC                  v Gateway Utd.               2-1
+    17:00  Shooting Stars SC          v Enyimba FC                 0-0
+  11.03.
+    17:00  Gombe United FC            v Bayelsa United FC          1-0
+    17:00  Zamfara United FC          v Kano Pillars FC            0-0
+
+
+
+» Matchday 24
+  13.03.
+    17:00  Gateway Utd.               v Heartland FC               0-0
+    17:00  Niger Tornadoes FC         v Rangers International FC   2-0
+  14.03.
+    17:00  Bayelsa United FC          v Ranchers Bees FC           3-1
+    17:00  Dolphins FC                v Zamfara United FC          2-1
+    17:00  Enyimba FC                 v Kwara United FC            2-0
+    17:00  Kaduna United FC           v Lobi Stars FC              2-0
+    17:00  Kano Pillars FC            v Sharks FC                  2-1
+    17:00  Sunshine Stars FC          v Ocean Boys FC              1-0
+    17:00  Warri Wolves FC            v Gombe United FC            1-0
+    17:00  Wikki Tourists FC          v Shooting Stars SC          0-0
+
+
+
+» Matchday 25
+  20.03.
+    17:00  Gombe United FC            v Gateway Utd.               1-0
+    17:00  Niger Tornadoes FC         v Bayelsa United FC          0-0
+    17:00  Sharks FC                  v Dolphins FC                0-0
+    17:00  Shooting Stars SC          v Sunshine Stars FC          2-0
+  21.03.
+    17:00  Kwara United FC            v Wikki Tourists FC          1-0
+    17:00  Ocean Boys FC              v Kaduna United FC           1-2
+    17:00  Rangers International FC   v Lobi Stars FC              0-0
+  25.03.
+    17:00  Ranchers Bees FC           v Warri Wolves FC            3-1
+    17:00  Zamfara United FC          v Enyimba FC                 1-0
+  31.03.
+    16:00  Heartland FC               v Kano Pillars FC            2-0
+
+
+
+» Matchday 26
+  15.04.
+    16:00  Dolphins FC                v Heartland FC               1-0
+  27.03.
+    17:00  Gateway Utd.               v Ranchers Bees FC           4-0
+    17:00  Kano Pillars FC            v Gombe United FC            2-1
+    17:00  Wikki Tourists FC          v Zamfara United FC          3-1
+  28.03.
+    16:00  Bayelsa United FC          v Rangers International FC   1-0
+    16:00  Enyimba FC                 v Sharks FC                  2-1
+    16:00  Kaduna United FC           v Shooting Stars SC          3-0
+    16:00  Lobi Stars FC              v Ocean Boys FC              2-0
+    16:00  Sunshine Stars FC          v Kwara United FC            1-0
+    16:00  Warri Wolves FC            v Niger Tornadoes FC         2-1
+
+
+
+» Matchday 27
+  03.04.
+    16:00  Gombe United FC            v Dolphins FC                2-0
+    16:00  Kwara United FC            v Kaduna United FC           2-1
+    16:00  Niger Tornadoes FC         v Gateway Utd.               2-0
+    16:00  Ranchers Bees FC           v Kano Pillars FC            0-1
+    16:00  Sharks FC                  v Wikki Tourists FC          2-0
+    16:00  Shooting Stars SC          v Lobi Stars FC              0-0
+  04.04.
+    16:00  Rangers International FC   v Ocean Boys FC              1-0
+    16:00  Zamfara United FC          v Sunshine Stars FC          1-0
+  08.04.
+    16:00  Bayelsa United FC          v Warri Wolves FC            2-2
+  12.05.
+    16:00  Heartland FC               v Enyimba FC                 1-0
+
+
+
+» Matchday 28
+  10.04.
+    16:00  Dolphins FC                v Ranchers Bees FC           2-0
+    16:00  Enyimba FC                 v Gombe United FC            1-0
+    16:00  Kano Pillars FC            v Niger Tornadoes FC         2-0
+  11.04.
+    16:00  Kaduna United FC           v Zamfara United FC          0-0
+    16:00  Lobi Stars FC              v Kwara United FC            2-1
+    16:00  Ocean Boys FC              v Shooting Stars SC          3-0
+    16:00  Sunshine Stars FC          v Sharks FC                  3-1
+    16:00  Warri Wolves FC            v Rangers International FC   1-1
+  12.04.
+    16:00  Gateway Utd.               v Bayelsa United FC          2-0
+    16:00  Wikki Tourists FC          v Heartland FC               3-0
+
+
+
+» Matchday 29
+  20.05.
+    16:00  Ranchers Bees FC           v Enyimba FC                 0-1
+  24.04.
+    16:00  Kwara United FC            v Ocean Boys FC              1-0
+    16:00  Niger Tornadoes FC         v Dolphins FC                1-0
+    16:00  Sharks FC                  v Kaduna United FC           5-0
+  25.04.
+    16:00  Bayelsa United FC          v Kano Pillars FC            2-1
+    16:00  Gombe United FC            v Wikki Tourists FC          1-0
+    16:00  Rangers International FC   v Shooting Stars SC          1-0
+    16:00  Zamfara United FC          v Lobi Stars FC              2-1
+  29.04.
+    16:00  Heartland FC               v Sunshine Stars FC          3-0
+    16:00  Warri Wolves FC            v Gateway Utd.               2-1
+
+
+
+» Matchday 30
+  01.05.
+    16:00  Dolphins FC                v Bayelsa United FC          3-1
+    16:00  Shooting Stars SC          v Kwara United FC            1-0
+    16:00  Wikki Tourists FC          v Ranchers Bees FC           4-0
+  02.05.
+    16:00  Enyimba FC                 v Niger Tornadoes FC         3-1
+    16:00  Gateway Utd.               v Rangers International FC   0-0
+    16:00  Kaduna United FC           v Heartland FC               3-2
+    16:00  Kano Pillars FC            v Warri Wolves FC            4-0
+    16:00  Lobi Stars FC              v Sharks FC                  1-0
+    16:00  Ocean Boys FC              v Zamfara United FC          2-0
+    16:00  Sunshine Stars FC          v Gombe United FC            2-0
+
+
+
+» Matchday 31
+  10.06.
+    16:00  Bayelsa United FC          v Enyimba FC                 1-1
+  12.05.
+    16:00  Ranchers Bees FC           v Sunshine Stars FC          0-0
+  13.05.
+    16:00  Gateway Utd.               v Kano Pillars FC            1-1
+    16:00  Gombe United FC            v Kaduna United FC           1-0
+    16:00  Niger Tornadoes FC         v Wikki Tourists FC          3-1
+    16:00  Rangers International FC   v Kwara United FC            2-0
+    16:00  Sharks FC                  v Ocean Boys FC              1-0
+    16:00  Warri Wolves FC            v Dolphins FC                2-1
+    16:00  Zamfara United FC          v Shooting Stars SC          1-1
+  19.05.
+    16:00  Heartland FC               v Lobi Stars FC              1-0
+
+
+
+» Matchday 32
+  10.06.
+    16:00  Lobi Stars FC              v Gombe United FC            2-1
+  15.05.
+    16:00  Dolphins FC                v Gateway Utd.               3-0
+  16.05.
+    16:00  Enyimba FC                 v Warri Wolves FC            1-0
+    16:00  Kaduna United FC           v Ranchers Bees FC           2-1
+    16:00  Kano Pillars FC            v Rangers International FC   1-0
+    16:00  Kwara United FC            v Zamfara United FC          3-0
+    16:00  Ocean Boys FC              v Heartland FC               1-0
+    16:00  Sunshine Stars FC          v Niger Tornadoes FC         1-0
+  19.05.
+    16:00  Shooting Stars SC          v Sharks FC                  1-0
+  21.06.
+    16:00  Wikki Tourists FC          v Bayelsa United FC          3-0
+
+
+
+» Matchday 33
+  22.05.
+    16:00  Kano Pillars FC            v Dolphins FC                1-1
+  23.05.
+    16:00  Bayelsa United FC          v Sunshine Stars FC          1-0
+    16:00  Gateway Utd.               v Enyimba FC                 1-0
+    16:00  Gombe United FC            v Ocean Boys FC              2-0
+    16:00  Heartland FC               v Shooting Stars SC          2-1
+    16:00  Niger Tornadoes FC         v Kaduna United FC           3-0
+    16:00  Ranchers Bees FC           v Lobi Stars FC              1-2
+    16:00  Rangers International FC   v Zamfara United FC          1-1
+    16:00  Sharks FC                  v Kwara United FC            1-0
+    16:00  Warri Wolves FC            v Wikki Tourists FC          1-0
+
+
+
+» Matchday 34
+  03.07.
+    16:00  Lobi Stars FC              v Kano Pillars FC            1-1
+  10.06.
+    16:00  Sharks FC                  v Ranchers Bees FC           4-0
+  25.06.
+    16:00  Sunshine Stars FC          v Enyimba FC                 3-1
+  29.05.
+    16:00  Wikki Tourists FC          v Rangers International FC   2-1
+  30.05.
+    16:00  Heartland FC               v Gombe United FC            1-0
+    16:00  Kaduna United FC           v Dolphins FC                3-0
+    16:00  Kwara United FC            v Bayelsa United FC          2-1
+    16:00  Ocean Boys FC              v Gateway Utd.               1-0
+    16:00  Shooting Stars SC          v Warri Wolves FC            2-1
+    16:00  Zamfara United FC          v Niger Tornadoes FC         1-1
+
+
+
+» Matchday 35
+  07.07.
+    16:00  Dolphins FC                v Rangers International FC   1-1
+    16:00  Enyimba FC                 v Kano Pillars FC            2-1
+    16:00  Kaduna United FC           v Bayelsa United FC          2-0
+    16:00  Kwara United FC            v Heartland FC               1-0
+    16:00  Lobi Stars FC              v Niger Tornadoes FC         2-0
+    16:00  Ocean Boys FC              v Ranchers Bees FC           3-0
+    16:00  Shooting Stars SC          v Gombe United FC            1-0
+    16:00  Sunshine Stars FC          v Warri Wolves FC            2-0
+    16:00  Wikki Tourists FC          v Gateway Utd.               2-0
+    16:00  Zamfara United FC          v Sharks FC                  0-0
+
+
+
+» Matchday 36
+  03.07.
+    16:00  Niger Tornadoes FC         v Ocean Boys FC              0-1
+  25.06.
+    16:00  Ranchers Bees FC           v Shooting Stars SC          0-2
+  28.06.
+    16:00  Bayelsa United FC          v Lobi Stars FC              4-1
+    16:00  Gateway Utd.               v Sunshine Stars FC          1-2
+    16:00  Gombe United FC            v Kwara United FC            1-0
+    16:00  Heartland FC               v Zamfara United FC          2-1
+    16:00  Kano Pillars FC            v Wikki Tourists FC          1-0
+    16:00  Rangers International FC   v Sharks FC                  3-1
+  29.06.
+    16:00  Warri Wolves FC            v Kaduna United FC           4-0
+  30.06.
+    16:00  Dolphins FC                v Enyimba FC                 1-1
+
+
+
+» Matchday 37
+  13.06.
+    16:00  Enyimba FC                 v Rangers International FC   1-0
+    16:00  Kaduna United FC           v Gateway Utd.               2-0
+    16:00  Kwara United FC            v Ranchers Bees FC           6-0
+    16:00  Lobi Stars FC              v Warri Wolves FC            3-1
+    16:00  Ocean Boys FC              v Bayelsa United FC          1-0
+    16:00  Sharks FC                  v Heartland FC               1-0
+    16:00  Shooting Stars SC          v Niger Tornadoes FC         2-1
+    16:00  Sunshine Stars FC          v Kano Pillars FC            2-1
+    16:00  Wikki Tourists FC          v Dolphins FC                0-0
+    16:00  Zamfara United FC          v Gombe United FC            1-0
+
+
+
+» Matchday 38
+  03.07.
+    16:00  Rangers International FC   v Heartland FC               2-1
+  06.06.
+    16:00  Bayelsa United FC          v Shooting Stars SC          3-1
+    16:00  Dolphins FC                v Sunshine Stars FC          1-1
+    16:00  Enyimba FC                 v Wikki Tourists FC          2-0
+    16:00  Gateway Utd.               v Lobi Stars FC              1-0
+    16:00  Gombe United FC            v Sharks FC                  2-0
+    16:00  Kano Pillars FC            v Kaduna United FC           1-0
+    16:00  Niger Tornadoes FC         v Kwara United FC            2-0
+    16:00  Ranchers Bees FC           v Zamfara United FC          0-1
+    16:00  Warri Wolves FC            v Ocean Boys FC              2-0
+

--- a/africa/nigeria/2010-11_ng1.txt
+++ b/africa/nigeria/2010-11_ng1.txt
@@ -1,0 +1,636 @@
+= Nigeria | Premier Football League 2010/2011
+
+# Date       Fri Jan/01 2010 - Thu Dec/23 2010 (356d)
+# Teams      20
+# Matches    380
+
+
+
+» Matchday 1
+  06.11.
+    16:00  Kaduna United FC           v Kano Pillars FC            1-1
+  07.11.
+    16:00  ABS FC                     v Zamfara United FC          0-0
+    16:00  Enyimba FC                 v Ocean Boys FC              1-0
+    16:00  Gombe United FC            v Heartland FC               2-0
+    16:00  Niger Tornadoes FC         v Crown FC                   1-0
+    16:00  Plateau United FC          v Rivers United FC           0-1
+    16:00  Rangers International FC   v Lobi Stars FC              3-2
+    16:00  Sharks FC                  v JUTH FC                    1-1
+    16:00  Shooting Stars SC          v Sunshine Stars FC          2-1
+    16:00  Warri Wolves FC            v Kwara United FC            1-0
+
+
+
+» Matchday 2
+  13.11.
+    16:00  Crown FC                   v Warri Wolves FC            1-1
+    16:00  JUTH FC                    v Gombe United FC            1-1
+    16:00  Kano Pillars FC            v ABS FC                     1-0
+    16:00  Kwara United FC            v Kaduna United FC           1-1
+    16:00  Rivers United FC           v Rangers International FC   1-0
+  14.11.
+    16:00  Heartland FC               v Niger Tornadoes FC         2-1
+    16:00  Lobi Stars FC              v Sharks FC                  1-1
+    16:00  Ocean Boys FC              v Plateau United FC          1-1
+    16:00  Sunshine Stars FC          v Enyimba FC                 2-1
+    16:00  Zamfara United FC          v Shooting Stars SC          2-2
+
+
+
+» Matchday 3
+  20.11.
+    16:00  Gombe United FC            v Lobi Stars FC              1-0
+    16:00  Kwara United FC            v Kano Pillars FC            1-0
+    16:00  Niger Tornadoes FC         v JUTH FC                    0-0
+    16:00  Plateau United FC          v Sunshine Stars FC          0-1
+    16:00  Sharks FC                  v Rivers United FC           1-0
+    16:00  Shooting Stars SC          v ABS FC                     2-0
+  21.11.
+    16:00  Enyimba FC                 v Zamfara United FC          1-0
+    16:00  Kaduna United FC           v Crown FC                   2-1
+    16:00  Rangers International FC   v Ocean Boys FC              5-2
+    16:00  Warri Wolves FC            v Heartland FC               2-2
+
+
+
+» Matchday 4
+  27.11.
+    16:00  ABS FC                     v Enyimba FC                 1-0
+    16:00  Crown FC                   v Kwara United FC            1-0
+    16:00  JUTH FC                    v Warri Wolves FC            0-1
+    16:00  Kano Pillars FC            v Shooting Stars SC          1-0
+    16:00  Rivers United FC           v Gombe United FC            3-0
+  28.11.
+    16:00  Heartland FC               v Kaduna United FC           2-1
+    16:00  Lobi Stars FC              v Niger Tornadoes FC         2-1
+    16:00  Ocean Boys FC              v Sharks FC                  1-1
+    16:00  Sunshine Stars FC          v Rangers International FC   2-0
+    16:00  Zamfara United FC          v Plateau United FC          3-2
+
+
+
+» Matchday 5
+  04.12.
+    16:00  Gombe United FC            v Ocean Boys FC              1-0
+    16:00  Kwara United FC            v Heartland FC               1-0
+    16:00  Niger Tornadoes FC         v Rivers United FC           1-0
+    16:00  Plateau United FC          v ABS FC                     1-0
+    16:00  Sharks FC                  v Sunshine Stars FC          2-1
+  05.12.
+    16:00  Crown FC                   v Kano Pillars FC            2-0
+    16:00  Enyimba FC                 v Shooting Stars SC          1-0
+    16:00  Kaduna United FC           v JUTH FC                    1-1
+    16:00  Rangers International FC   v Zamfara United FC          5-1
+    16:00  Warri Wolves FC            v Lobi Stars FC              2-1
+
+
+
+» Matchday 6
+  11.12.
+    16:00  ABS FC                     v Rangers International FC   1-0
+    16:00  JUTH FC                    v Kwara United FC            0-2
+    16:00  Kano Pillars FC            v Enyimba FC                 3-0
+    16:00  Rivers United FC           v Warri Wolves FC            1-0
+  12.12.
+    16:00  Heartland FC               v Crown FC                   1-0
+    16:00  Lobi Stars FC              v Kaduna United FC           2-1
+    16:00  Ocean Boys FC              v Niger Tornadoes FC         2-0
+    16:00  Shooting Stars SC          v Plateau United FC          2-1
+    16:00  Sunshine Stars FC          v Gombe United FC            3-1
+    16:00  Zamfara United FC          v Sharks FC                  2-1
+
+
+
+» Matchday 7
+  05.01.
+    16:00  Warri Wolves FC            v Ocean Boys FC              1-0
+  18.12.
+    16:00  Gombe United FC            v Zamfara United FC          2-0
+    16:00  Kwara United FC            v Lobi Stars FC              1-0
+    16:00  Niger Tornadoes FC         v Sunshine Stars FC          0-0
+    16:00  Plateau United FC          v Enyimba FC                 1-0
+    16:00  Sharks FC                  v ABS FC                     1-0
+  19.12.
+    16:00  Crown FC                   v JUTH FC                    1-0
+    16:00  Heartland FC               v Kano Pillars FC            2-0
+    16:00  Kaduna United FC           v Rivers United FC           2-1
+    16:00  Rangers International FC   v Shooting Stars SC          2-0
+
+
+
+» Matchday 8
+  06.01.
+    16:00  Shooting Stars SC          v Sharks FC                  2-0
+  22.12.
+    16:00  ABS FC                     v Gombe United FC            3-2
+    16:00  Lobi Stars FC              v Crown FC                   1-0
+    16:00  Rivers United FC           v Kwara United FC            1-0
+    16:00  Sunshine Stars FC          v Warri Wolves FC            3-1
+    16:00  Zamfara United FC          v Niger Tornadoes FC         2-2
+  23.12.
+    16:00  Enyimba FC                 v Rangers International FC   1-0
+    16:00  JUTH FC                    v Heartland FC               1-0
+    16:00  Kano Pillars FC            v Plateau United FC          5-1
+    16:00  Ocean Boys FC              v Kaduna United FC           2-1 (2-1)
+
+
+
+» Matchday 9
+  01.01.
+    16:00  Gombe United FC            v Shooting Stars SC          1-0
+    16:00  Kwara United FC            v Ocean Boys FC              2-0
+    16:00  Niger Tornadoes FC         v ABS FC                     0-0
+    16:00  Sharks FC                  v Enyimba FC                 2-1
+  02.01.
+    16:00  Crown FC                   v Rivers United FC           0-1
+    16:00  Heartland FC               v Lobi Stars FC              0-0
+    16:00  Kaduna United FC           v Sunshine Stars FC          1-0
+    16:00  Rangers International FC   v Plateau United FC          1-0
+    16:00  Warri Wolves FC            v Zamfara United FC          3-0
+  03.02.
+    16:00  JUTH FC                    v Kano Pillars FC            1-2
+
+
+
+» Matchday 10
+  08.01.
+    16:00  ABS FC                     v Warri Wolves FC            1-0
+    16:00  Kano Pillars FC            v Rangers International FC   1-0
+    16:00  Ocean Boys FC              v Crown FC                   2-0
+    16:00  Rivers United FC           v Heartland FC               1-0
+  09.01.
+    16:00  Enyimba FC                 v Gombe United FC            2-0
+    16:00  Shooting Stars SC          v Niger Tornadoes FC         2-1
+    16:00  Sunshine Stars FC          v Kwara United FC            1-0
+    16:00  Zamfara United FC          v Kaduna United FC           0-1
+  09.02.
+    16:00  Plateau United FC          v Sharks FC                  0-1
+  10.02.
+    16:00  Lobi Stars FC              v JUTH FC                    2-1
+
+
+
+» Matchday 11
+  06.03.
+    16:00  Crown FC                   v Sunshine Stars FC          1-1
+    16:00  Heartland FC               v Ocean Boys FC              4-0 (0-0)
+    16:00  Kaduna United FC           v ABS FC                     1-0
+    16:00  Lobi Stars FC              v Kano Pillars FC            1-0
+    16:00  Niger Tornadoes FC         v Enyimba FC                 1-0
+    16:00  Warri Wolves FC            v Shooting Stars SC          1-0
+  12.01.
+    16:00  Gombe United FC            v Plateau United FC          1-0
+    16:00  JUTH FC                    v Rivers United FC           1-3
+    16:00  Kwara United FC            v Zamfara United FC          3-0
+    16:00  Sharks FC                  v Rangers International FC   1-1
+
+
+
+» Matchday 12
+  15.01.
+    16:00  ABS FC                     v Kwara United FC            3-0
+    16:00  Kano Pillars FC            v Sharks FC                  1-1
+    16:00  Plateau United FC          v Niger Tornadoes FC         2-2
+    16:00  Rivers United FC           v Lobi Stars FC              1-0
+  16.01.
+    16:00  Enyimba FC                 v Warri Wolves FC            0-0
+    16:00  Rangers International FC   v Gombe United FC            1-0
+    16:00  Shooting Stars SC          v Kaduna United FC           1-1
+    16:00  Sunshine Stars FC          v Heartland FC               2-1
+    16:00  Zamfara United FC          v Crown FC                   1-0
+  16.02.
+    16:00  Ocean Boys FC              v JUTH FC                    4-1
+
+
+
+» Matchday 13
+  21.01.
+    16:00  JUTH FC                    v Sunshine Stars FC          0-0
+  22.01.
+    16:00  Gombe United FC            v Sharks FC                  0-0
+    16:00  Heartland FC               v Zamfara United FC          3-0
+    16:00  Kwara United FC            v Shooting Stars SC          1-0
+    16:00  Niger Tornadoes FC         v Rangers International FC   0-0
+    16:00  Rivers United FC           v Kano Pillars FC            1-0
+  23.01.
+    16:00  Crown FC                   v ABS FC                     0-2
+    16:00  Kaduna United FC           v Enyimba FC                 1-0
+    16:00  Lobi Stars FC              v Ocean Boys FC              1-0
+    16:00  Warri Wolves FC            v Plateau United FC          3-1
+
+
+
+» Matchday 14
+  09.02.
+    16:00  Enyimba FC                 v Kwara United FC            3-0
+  16.02.
+    16:00  Kano Pillars FC            v Gombe United FC            2-1
+  29.01.
+    16:00  ABS FC                     v Heartland FC               1-0
+    16:00  Plateau United FC          v Kaduna United FC           0-0
+    16:00  Sharks FC                  v Niger Tornadoes FC         3-0
+  30.01.
+    16:00  Ocean Boys FC              v Rivers United FC           2-0
+    16:00  Rangers International FC   v Warri Wolves FC            0-0
+    16:00  Shooting Stars SC          v Crown FC                   1-1
+    16:00  Sunshine Stars FC          v Lobi Stars FC              2-0
+    16:00  Zamfara United FC          v JUTH FC                    1-0
+
+
+
+» Matchday 15
+  05.02.
+    16:00  Kwara United FC            v Plateau United FC          1-1
+    16:00  Niger Tornadoes FC         v Gombe United FC            1-0
+    16:00  Rivers United FC           v Sunshine Stars FC          1-0
+  06.02.
+    16:00  Crown FC                   v Enyimba FC                 1-2
+    16:00  Heartland FC               v Shooting Stars SC          1-0
+    16:00  JUTH FC                    v ABS FC                     2-2
+    16:00  Kaduna United FC           v Rangers International FC   1-0
+    16:00  Lobi Stars FC              v Zamfara United FC          1-0
+    16:00  Ocean Boys FC              v Kano Pillars FC            1-0
+    16:00  Warri Wolves FC            v Sharks FC                  3-0
+
+
+
+» Matchday 16
+  08.02.
+    16:00  ABS FC                     v Lobi Stars FC              3-1
+    16:00  Gombe United FC            v Warri Wolves FC            1-1
+    16:00  Kano Pillars FC            v Niger Tornadoes FC         0-0
+    16:00  Plateau United FC          v Crown FC                   1-2
+    16:00  Rangers International FC   v Kwara United FC            1-0
+    16:00  Sharks FC                  v Kaduna United FC           2-1
+    16:00  Shooting Stars SC          v JUTH FC                    3-0
+    16:00  Sunshine Stars FC          v Ocean Boys FC              2-0
+    16:00  Zamfara United FC          v Rivers United FC           0-1
+  16.02.
+    16:00  Enyimba FC                 v Heartland FC               1-0 (0-0)
+
+
+
+» Matchday 17
+  19.02.
+    16:00  Kwara United FC            v Sharks FC                  3-0
+    16:00  Rivers United FC           v ABS FC                     2-0
+  20.02.
+    16:00  Crown FC                   v Rangers International FC   0-1
+    16:00  Heartland FC               v Plateau United FC          2-1
+    16:00  Kaduna United FC           v Gombe United FC            3-0
+    16:00  Lobi Stars FC              v Shooting Stars SC          1-0
+    16:00  Ocean Boys FC              v Zamfara United FC          3-1
+    16:00  Sunshine Stars FC          v Kano Pillars FC            3-0
+    16:00  Warri Wolves FC            v Niger Tornadoes FC         1-0
+  21.02.
+    16:00  JUTH FC                    v Enyimba FC                 2-1 (2-0)
+
+
+
+» Matchday 18
+  02.03.
+    17:00  Enyimba FC                 v Lobi Stars FC              3-0 (1-0)
+  09.03.
+    16:00  Rangers International FC   v Heartland FC               1-0
+    16:00  Zamfara United FC          v Sunshine Stars FC          0-1
+  26.02.
+    17:00  Plateau United FC          v JUTH FC                    1-0
+    17:00  Sharks FC                  v Crown FC                   4-3
+  27.02.
+    16:00  Gombe United FC            v Kwara United FC            0-2
+    16:00  Kano Pillars FC            v Warri Wolves FC            1-0
+    17:00  Niger Tornadoes FC         v Kaduna United FC           0-0 (0-0)
+    17:00  Shooting Stars SC          v Rivers United FC           1-1
+  28.02.
+    17:00  ABS FC                     v Ocean Boys FC              2-1
+
+
+
+» Matchday 19
+  12.03.
+    16:00  Kwara United FC            v Niger Tornadoes FC         2-0
+    16:00  Rivers United FC           v Enyimba FC                 2-1
+    16:00  Zamfara United FC          v Kano Pillars FC            1-1
+  13.03.
+    16:00  Crown FC                   v Gombe United FC            2-0
+    16:00  Heartland FC               v Sharks FC                  0-0 (0-0)
+    16:00  JUTH FC                    v Rangers International FC   2-0
+    16:00  Kaduna United FC           v Warri Wolves FC            1-0
+    16:00  Lobi Stars FC              v Plateau United FC          1-0
+    16:00  Ocean Boys FC              v Shooting Stars SC          1-0
+    16:00  Sunshine Stars FC          v ABS FC                     1-0
+
+
+
+» Matchday 20
+  11.05.
+    16:00  Enyimba FC                 v Rivers United FC           3-0
+    16:00  Gombe United FC            v Crown FC                   3-1
+    16:00  Kano Pillars FC            v Zamfara United FC          3-0
+    16:00  Niger Tornadoes FC         v Kwara United FC            2-1
+    16:00  Plateau United FC          v Lobi Stars FC              2-0
+    16:00  Rangers International FC   v JUTH FC                    4-0
+    16:00  Sharks FC                  v Heartland FC               1-0
+    16:00  Warri Wolves FC            v Kaduna United FC           1-0
+    17:00  Shooting Stars SC          v Ocean Boys FC              1-0 (0-0)
+  25.05.
+    16:00  ABS FC                     v Sunshine Stars FC          0-1
+
+
+
+» Matchday 21
+  14.05.
+    16:00  Kwara United FC            v Warri Wolves FC            2-0
+    16:00  Rivers United FC           v Plateau United FC          3-0 (1-0)
+  15.05.
+    16:00  Crown FC                   v Niger Tornadoes FC         2-3
+    16:00  Heartland FC               v Gombe United FC            1-0
+    16:00  JUTH FC                    v Sharks FC                  0-0 (0-0)
+    16:00  Kano Pillars FC            v Kaduna United FC           2-0
+    16:00  Lobi Stars FC              v Rangers International FC   1-0
+    16:00  Ocean Boys FC              v Enyimba FC                 0-0 (0-0)
+    16:00  Sunshine Stars FC          v Shooting Stars SC          1-0
+    16:00  Zamfara United FC          v ABS FC                     1-1
+
+
+
+» Matchday 22
+  18.05.
+    16:00  Enyimba FC                 v Sunshine Stars FC          4-0
+    16:00  Gombe United FC            v JUTH FC                    1-0
+    16:00  Kaduna United FC           v Kwara United FC            3-0
+    16:00  Niger Tornadoes FC         v Heartland FC               3-1
+    16:00  Plateau United FC          v Ocean Boys FC              3-1
+    16:00  Rangers International FC   v Rivers United FC           2-2
+    16:00  Sharks FC                  v Lobi Stars FC              1-0
+    16:00  Shooting Stars SC          v Zamfara United FC          1-0
+    16:00  Warri Wolves FC            v Crown FC                   2-1
+  19.05.
+    16:00  ABS FC                     v Kano Pillars FC            0-1
+
+
+
+» Matchday 23
+  22.05.
+    16:00  ABS FC                     v Shooting Stars SC          4-1
+    16:00  Crown FC                   v Kaduna United FC           1-0
+    16:00  Heartland FC               v Warri Wolves FC            0-0 (0-0)
+    16:00  JUTH FC                    v Niger Tornadoes FC         2-1
+    16:00  Kano Pillars FC            v Kwara United FC            2-1
+    16:00  Lobi Stars FC              v Gombe United FC            0-0 (0-0)
+    16:00  Ocean Boys FC              v Rangers International FC   1-0
+    16:00  Rivers United FC           v Sharks FC                  1-0
+    16:00  Sunshine Stars FC          v Plateau United FC          4-1 (0-0)
+    16:00  Zamfara United FC          v Enyimba FC                 1-0
+
+
+
+» Matchday 24
+  01.06.
+    16:00  Enyimba FC                 v ABS FC                     1-0
+    16:00  Gombe United FC            v Rivers United FC           1-0
+    16:00  Kwara United FC            v Crown FC                   2-0
+    16:00  Niger Tornadoes FC         v Lobi Stars FC              1-1
+    16:00  Plateau United FC          v Zamfara United FC          2-0
+    16:00  Rangers International FC   v Sunshine Stars FC          1-0
+    16:00  Sharks FC                  v Ocean Boys FC              1-0
+    16:00  Shooting Stars SC          v Kano Pillars FC            2-1 (1-0)
+    16:00  Warri Wolves FC            v JUTH FC                    2-1 (1-1)
+  15.06.
+    16:00  Kaduna United FC           v Heartland FC               1-0
+
+
+
+» Matchday 25
+  04.06.
+    16:00  Rivers United FC           v Niger Tornadoes FC         3-0
+  05.06.
+    16:00  ABS FC                     v Plateau United FC          2-2
+    16:00  Heartland FC               v Kwara United FC            2-1
+    16:00  JUTH FC                    v Kaduna United FC           1-0
+    16:00  Kano Pillars FC            v Crown FC                   1-0
+    16:00  Lobi Stars FC              v Warri Wolves FC            1-0
+    16:00  Ocean Boys FC              v Gombe United FC            2-0
+    16:00  Shooting Stars SC          v Enyimba FC                 1-0 (0-0)
+    16:00  Sunshine Stars FC          v Sharks FC                  2-0
+    16:00  Zamfara United FC          v Rangers International FC   0-0 (0-0)
+
+
+
+» Matchday 26
+  08.06.
+    16:00  Enyimba FC                 v Kano Pillars FC            1-0
+    16:00  Kwara United FC            v JUTH FC                    1-0
+    16:00  Niger Tornadoes FC         v Ocean Boys FC              3-0
+    16:00  Plateau United FC          v Shooting Stars SC          1-0
+    16:00  Rangers International FC   v ABS FC                     2-0
+    16:00  Sharks FC                  v Zamfara United FC          2-2
+  09.06.
+    16:00  Crown FC                   v Heartland FC               1-0 (1-0)
+    16:00  Warri Wolves FC            v Rivers United FC           4-1
+  20.08.
+    16:00  Kaduna United FC           v Lobi Stars FC              4-2
+  29.06.
+    16:00  Gombe United FC            v Sunshine Stars FC          3-0
+
+
+
+» Matchday 27
+  12.06.
+    16:00  ABS FC                     v Sharks FC                  1-1 (0-0)
+    16:00  Enyimba FC                 v Plateau United FC          3-0
+    16:00  JUTH FC                    v Crown FC                   0-1
+    16:00  Kano Pillars FC            v Heartland FC               3-0 (0-0)
+    16:00  Lobi Stars FC              v Kwara United FC            2-1
+    16:00  Ocean Boys FC              v Warri Wolves FC            1-1
+    16:00  Shooting Stars SC          v Rangers International FC   0-1
+    16:00  Zamfara United FC          v Gombe United FC            1-0
+  15.06.
+    16:00  Sunshine Stars FC          v Niger Tornadoes FC         2-0
+  29.06.
+    16:00  Rivers United FC           v Kaduna United FC           1-0
+
+
+
+» Matchday 28
+  09.10.
+    16:00  Rangers International FC   v Enyimba FC                 1-0 (0-0)
+  18.06.
+    16:00  Gombe United FC            v ABS FC                     3-0
+    16:00  Kwara United FC            v Rivers United FC           1-1
+    16:00  Plateau United FC          v Kano Pillars FC            2-2
+    16:00  Sharks FC                  v Shooting Stars SC          1-1
+  19.06.
+    16:00  Crown FC                   v Lobi Stars FC              0-1
+    16:00  Kaduna United FC           v Ocean Boys FC              2-0
+    16:00  Niger Tornadoes FC         v Zamfara United FC          1-0
+    16:00  Warri Wolves FC            v Sunshine Stars FC          2-0
+  29.06.
+    16:00  Heartland FC               v JUTH FC                    4-2
+
+
+
+» Matchday 29
+  25.06.
+    16:00  Kano Pillars FC            v JUTH FC                    1-0
+    16:00  Lobi Stars FC              v Heartland FC               3-0
+    16:00  Plateau United FC          v Rangers International FC   0-1
+  26.06.
+    16:00  ABS FC                     v Niger Tornadoes FC         0-1
+    16:00  Enyimba FC                 v Sharks FC                  1-0
+    16:00  Ocean Boys FC              v Kwara United FC            1-1
+    16:00  Shooting Stars SC          v Gombe United FC            1-1
+    16:00  Sunshine Stars FC          v Kaduna United FC           4-1 (3-0)
+    16:00  Zamfara United FC          v Warri Wolves FC            1-0
+  31.07.
+    16:00  Rivers United FC           v Crown FC                   2-0
+
+
+
+» Matchday 30
+  02.07.
+    16:00  Kwara United FC            v Sunshine Stars FC          3-2
+    16:00  Sharks FC                  v Plateau United FC          2-1
+  03.07.
+    16:00  Crown FC                   v Ocean Boys FC              1-0
+    16:00  Gombe United FC            v Enyimba FC                 0-0 (0-0)
+    16:00  Heartland FC               v Rivers United FC           2-0
+    16:00  JUTH FC                    v Lobi Stars FC              0-0 (0-0)
+    16:00  Kaduna United FC           v Zamfara United FC          2-0
+    16:00  Niger Tornadoes FC         v Shooting Stars SC          2-0
+    16:00  Rangers International FC   v Kano Pillars FC            0-1
+    16:00  Warri Wolves FC            v ABS FC                     1-0
+
+
+
+» Matchday 31
+  06.07.
+    16:00  ABS FC                     v Kaduna United FC           2-1
+    16:00  Enyimba FC                 v Niger Tornadoes FC         2-0
+    16:00  Kano Pillars FC            v Lobi Stars FC              2-0
+    16:00  Plateau United FC          v Gombe United FC            2-1
+    16:00  Rivers United FC           v JUTH FC                    2-0
+    16:00  Shooting Stars SC          v Warri Wolves FC            1-1
+    16:00  Sunshine Stars FC          v Crown FC                   2-1
+    16:00  Zamfara United FC          v Kwara United FC            1-0
+  12.08.
+    16:00  Ocean Boys FC              v Heartland FC               1-0 (0-0)
+  13.07.
+    16:00  Rangers International FC   v Sharks FC                  2-1
+
+
+
+» Matchday 32
+  09.07.
+    16:00  Gombe United FC            v Rangers International FC   0-0 (0-0)
+    16:00  Kwara United FC            v ABS FC                     0-3
+    16:00  Sharks FC                  v Kano Pillars FC            1-0
+  10.07.
+    16:00  Crown FC                   v Zamfara United FC          3-0
+    16:00  Heartland FC               v Sunshine Stars FC          2-0
+    16:00  JUTH FC                    v Ocean Boys FC              2-0
+    16:00  Kaduna United FC           v Shooting Stars SC          2-0
+    16:00  Lobi Stars FC              v Rivers United FC           2-1
+    16:00  Niger Tornadoes FC         v Plateau United FC          1-1 (1-0)
+    16:00  Warri Wolves FC            v Enyimba FC                 2-0
+
+
+
+» Matchday 33
+  16.07.
+    16:00  Kano Pillars FC            v Rivers United FC           3-2
+    16:00  Plateau United FC          v Warri Wolves FC            2-0
+    16:00  Sharks FC                  v Gombe United FC            1-0
+    16:00  Shooting Stars SC          v Kwara United FC            1-0
+  17.07.
+    16:00  ABS FC                     v Crown FC                   1-0
+    16:00  Rangers International FC   v Niger Tornadoes FC         4-0
+    16:00  Zamfara United FC          v Heartland FC               1-0
+  20.10.
+    16:00  Enyimba FC                 v Kaduna United FC           4-1 (2-0)
+  21.08.
+    16:00  Sunshine Stars FC          v JUTH FC                    2-0
+  24.08.
+    16:00  Ocean Boys FC              v Lobi Stars FC              1-1 (0-0)
+
+
+
+» Matchday 34
+  01.09.
+    16:00  Lobi Stars FC              v Sunshine Stars FC          1-1
+  06.10.
+    15:00  Kwara United FC            v Enyimba FC                 2-1
+  23.07.
+    16:00  Gombe United FC            v Kano Pillars FC            2-1
+    16:00  Rivers United FC           v Ocean Boys FC              0-0
+  24.07.
+    16:00  Crown FC                   v Shooting Stars SC          2-2
+    16:00  Heartland FC               v ABS FC                     2-0
+    16:00  JUTH FC                    v Zamfara United FC          2-0
+    16:00  Kaduna United FC           v Plateau United FC          1-1
+  27.07.
+    16:00  Niger Tornadoes FC         v Sharks FC                  3-2
+    16:00  Warri Wolves FC            v Rangers International FC   1-0
+
+
+
+» Matchday 35
+  23.10.
+    15:00  Sharks FC                  v Warri Wolves FC            2-0
+    16:00  ABS FC                     v JUTH FC                    1-0
+    16:00  Enyimba FC                 v Crown FC                   2-1
+    16:00  Gombe United FC            v Niger Tornadoes FC         1-0
+    16:00  Kano Pillars FC            v Ocean Boys FC              2-0
+    16:00  Plateau United FC          v Kwara United FC            7-0
+    16:00  Rangers International FC   v Kaduna United FC           3-0
+    16:00  Shooting Stars SC          v Heartland FC               1-0
+    16:00  Sunshine Stars FC          v Rivers United FC           3-2
+    16:00  Zamfara United FC          v Lobi Stars FC              2-1
+
+
+
+» Matchday 36
+  09.11.
+    16:00  Crown FC                   v Plateau United FC          1-0
+    16:00  Heartland FC               v Enyimba FC                 2-0
+    16:00  JUTH FC                    v Shooting Stars SC          2-1
+    16:00  Kaduna United FC           v Sharks FC                  1-1
+    16:00  Kwara United FC            v Rangers International FC   3-2
+    16:00  Lobi Stars FC              v ABS FC                     0-1
+    16:00  Niger Tornadoes FC         v Kano Pillars FC            1-0
+    16:00  Ocean Boys FC              v Sunshine Stars FC          2-2
+    16:00  Rivers United FC           v Zamfara United FC          4-0
+    16:00  Warri Wolves FC            v Gombe United FC            2-1
+
+
+
+» Matchday 37
+  13.11.
+    16:00  ABS FC                     v Rivers United FC           0-1
+    16:00  Enyimba FC                 v JUTH FC                    2-0
+    16:00  Gombe United FC            v Kaduna United FC           2-0
+    16:00  Kano Pillars FC            v Sunshine Stars FC          1-0
+    16:00  Niger Tornadoes FC         v Warri Wolves FC            1-1
+    16:00  Plateau United FC          v Heartland FC               1-0
+    16:00  Rangers International FC   v Crown FC                   2-1
+    16:00  Sharks FC                  v Kwara United FC            1-0
+    16:00  Shooting Stars SC          v Lobi Stars FC              1-0
+    16:00  Zamfara United FC          v Ocean Boys FC              0-1
+
+
+
+» Matchday 38
+  02.11.
+    16:00  Heartland FC               v Rangers International FC   3-1
+    16:00  Kaduna United FC           v Niger Tornadoes FC         3-1
+    16:00  Kwara United FC            v Gombe United FC            1-1
+    16:00  Lobi Stars FC              v Enyimba FC                 1-1
+    16:00  Ocean Boys FC              v ABS FC                     3-0
+    16:00  Rivers United FC           v Shooting Stars SC          1-0
+    16:00  Warri Wolves FC            v Kano Pillars FC            2-1
+    17:00  Crown FC                   v Sharks FC                  1-3 (0-0)
+    17:00  JUTH FC                    v Plateau United FC          0-1 (0-0)
+  04.11.
+    16:00  Sunshine Stars FC          v Zamfara United FC          3-1 (1-1)
+

--- a/africa/nigeria/2011-12_ng1.txt
+++ b/africa/nigeria/2011-12_ng1.txt
@@ -1,0 +1,629 @@
+= Nigeria | Premier Football League 2011/2012
+
+# Date       Fri Jan/07 2011 - Wed Sep/07 2011 (243d)
+# Teams      20
+# Matches    374
+
+
+
+» Matchday 1
+  07.01.
+    16:00  Enyimba FC                 v ABS FC                     2-0 (0-0)
+    16:00  Gombe United FC            v Lobi Stars FC              2-0 (0-0)
+    16:00  Kano Pillars FC            v Niger Tornadoes FC         1-0 (0-0)
+    16:00  Rangers International FC   v Warri Wolves FC            0-0 (0-0)
+    16:00  Rising Stars FC            v Akwa United FC             0-0 (0-0)
+    16:00  Rivers United FC           v Sunshine Stars FC          1-0 (0-0)
+    16:00  Shooting Stars SC          v Sharks FC                  2-1 (0-0)
+    16:00  Wikki Tourists FC          v Heartland FC               1-0 (0-0)
+  19.01.
+    17:00  Kaduna United FC           v Jigawa Golden Stars FC     2-1 (0-1)
+
+
+
+» Matchday 2
+  25.01.
+    15:00  Kwara United FC            v Enyimba FC                 1-0
+    15:00  Niger Tornadoes FC         v Ocean Boys FC              3-0
+    15:00  Rangers International FC   v Wikki Tourists FC          1-0
+    15:00  Rising Stars FC            v Kano Pillars FC            1-1
+    15:00  Sharks FC                  v Jigawa Golden Stars FC     4-0
+    15:00  Shooting Stars SC          v Gombe United FC            0-0 (0-0)
+    15:00  Warri Wolves FC            v ABS FC                     1-0
+  26.01.
+    15:00  Lobi Stars FC              v Akwa United FC             1-0
+    15:00  Rivers United FC           v Kaduna United FC           3-0
+    16:00  Sunshine Stars FC          v Heartland FC               1-0 (0-0)
+
+
+
+» Matchday 3
+  11.04.
+    16:00  Akwa United FC             v Warri Wolves FC            2-1
+  21.03.
+    15:00  Enyimba FC                 v Rivers United FC           1-0
+    15:00  Gombe United FC            v Rangers International FC   2-1 (1-0)
+    15:00  Heartland FC               v Niger Tornadoes FC         2-1
+    15:00  Kaduna United FC           v Rising Stars FC            1-0 (1-0)
+    15:00  Wikki Tourists FC          v Kwara United FC            1-0
+  22.03.
+    16:00  Jigawa Golden Stars FC     v Lobi Stars FC              1-0
+    16:00  Kano Pillars FC            v Shooting Stars SC          3-0
+    16:00  Ocean Boys FC              v Sharks FC                  2-0 (2-0)
+  23.08.
+    16:00  ABS FC                     v Sunshine Stars FC          4-1 (1-1)
+
+
+
+» Matchday 4
+  21.01.
+    15:00  Kwara United FC            v Rivers United FC           1-0
+    15:00  Shooting Stars SC          v Rising Stars FC            0-0 (0-0)
+    15:00  Wikki Tourists FC          v Kano Pillars FC            1-0
+  22.01.
+    15:00  Akwa United FC             v Jigawa Golden Stars FC     1-0
+    15:00  Enyimba FC                 v Sharks FC                  2-0
+    15:00  Gombe United FC            v Niger Tornadoes FC         3-1
+    15:00  Heartland FC               v ABS FC                     2-1
+    15:00  Rangers International FC   v Kaduna United FC           3-0
+    15:00  Sunshine Stars FC          v Ocean Boys FC              1-1
+    15:00  Warri Wolves FC            v Lobi Stars FC              2-1
+
+
+
+» Matchday 5
+  28.01.
+    14:00  Niger Tornadoes FC         v Shooting Stars SC          1-0 (1-0)
+    14:00  Rising Stars FC            v Wikki Tourists FC          1-0 (1-0)
+    14:00  Sharks FC                  v Warri Wolves FC            1-1 (0-1)
+  29.01.
+    14:00  ABS FC                     v Kwara United FC            0-0 (0-0)
+    16:00  Jigawa Golden Stars FC     v Heartland FC               2-0
+    16:00  Kaduna United FC           v Gombe United FC            0-1
+    16:00  Lobi Stars FC              v Sunshine Stars FC          1-0 (0-0)
+    16:00  Ocean Boys FC              v Akwa United FC             1-1
+    16:00  Rivers United FC           v Rangers International FC   1-0
+  29.02.
+    15:00  Kano Pillars FC            v Enyimba FC                 2-0 (0-0)
+
+
+
+» Matchday 6
+  01.02.
+    15:00  Enyimba FC                 v Ocean Boys FC              2-0 (1-0)
+    15:00  Gombe United FC            v Sharks FC                  5-0 (2-0)
+    15:00  Heartland FC               v Rising Stars FC            2-0 (1-0)
+    15:00  Kwara United FC            v Kaduna United FC           3-1 (1-1)
+    15:00  Rangers International FC   v Kano Pillars FC            3-1 (2-0)
+    15:00  Shooting Stars SC          v Rivers United FC           1-0 (1-0)
+    15:00  Warri Wolves FC            v Jigawa Golden Stars FC     2-0 (0-0)
+    15:00  Wikki Tourists FC          v Lobi Stars FC              2-1 (1-1)
+    16:00  Sunshine Stars FC          v Niger Tornadoes FC         3-0 (2-0)
+  02.02.
+    16:00  Akwa United FC             v ABS FC                     2-1 (1-1)
+
+
+
+» Matchday 7
+  04.02.
+    16:00  Niger Tornadoes FC         v Wikki Tourists FC          0-0
+    16:00  Rising Stars FC            v Rangers International FC   0-0 (0-0)
+    16:00  Sharks FC                  v Akwa United FC             0-0 (0-0)
+  05.02.
+    16:00  ABS FC                     v Shooting Stars SC          2-0 (2-0)
+    16:00  Jigawa Golden Stars FC     v Sunshine Stars FC          1-0
+    16:00  Kaduna United FC           v Enyimba FC                 1-0
+    16:00  Kano Pillars FC            v Kwara United FC            2-0
+    16:00  Lobi Stars FC              v Heartland FC               1-0
+    16:00  Ocean Boys FC              v Warri Wolves FC            0-0 (0-0)
+    16:00  Rivers United FC           v Gombe United FC            2-1
+
+
+
+» Matchday 8
+  07.03.
+    15:00  Kano Pillars FC            v Heartland FC               1-1 (0-0)
+  11.02.
+    14:00  Kwara United FC            v Rangers International FC   0-0 (0-0)
+    14:00  Niger Tornadoes FC         v ABS FC                     1-1 (0-1)
+    14:00  Sharks FC                  v Lobi Stars FC              2-0 (2-0)
+    14:00  Shooting Stars SC          v Sunshine Stars FC          1-1 (1-1)
+  12.02.
+    14:00  Enyimba FC                 v Gombe United FC            3-1 (3-0)
+    14:00  Kaduna United FC           v Wikki Tourists FC          1-0 (1-0)
+    14:00  Ocean Boys FC              v Jigawa Golden Stars FC     2-0 (2-0)
+    14:00  Rising Stars FC            v Warri Wolves FC            1-0
+    14:00  Rivers United FC           v Akwa United FC             2-1 (2-0)
+
+
+
+» Matchday 9
+  07.03.
+    15:00  ABS FC                     v Rivers United FC           2-0 (1-0)
+  15.02.
+    16:00  Akwa United FC             v Niger Tornadoes FC         2-0 (1-0)
+    16:00  Jigawa Golden Stars FC     v Rising Stars FC            0-0
+    16:00  Lobi Stars FC              v Ocean Boys FC              3-0 (1-0)
+    16:00  Rangers International FC   v Enyimba FC                 1-0
+    16:00  Sunshine Stars FC          v Sharks FC                  3-2 (1-0)
+    16:00  Warri Wolves FC            v Kano Pillars FC            0-0
+    16:00  Wikki Tourists FC          v Shooting Stars SC          2-1 (1-0)
+  16.02.
+    16:00  Gombe United FC            v Kwara United FC            0-2
+    16:00  Heartland FC               v Kaduna United FC           1-0
+
+
+
+» Matchday 10
+  18.02.
+    16:00  Rising Stars FC            v Sharks FC                  0-0 (0-0)
+    16:00  Shooting Stars SC          v Ocean Boys FC              1-0 (0-0)
+    16:00  Wikki Tourists FC          v ABS FC                     1-0 (1-0)
+  19.02.
+    16:00  Enyimba FC                 v Warri Wolves FC            2-0 (1-0)
+    16:00  Gombe United FC            v Sunshine Stars FC          1-0 (0-0)
+    16:00  Kaduna United FC           v Niger Tornadoes FC         1-0
+    16:00  Kano Pillars FC            v Lobi Stars FC              1-0 (0-0)
+    16:00  Kwara United FC            v Akwa United FC             2-1 (2-1)
+    16:00  Rangers International FC   v Heartland FC               1-1 (1-0)
+  29.02.
+    16:00  Rivers United FC           v Jigawa Golden Stars FC     2-1 (0-0)
+
+
+
+» Matchday 11
+  08.03.
+    15:00  Warri Wolves FC            v Wikki Tourists FC          2-1
+  25.02.
+    14:00  Niger Tornadoes FC         v Rising Stars FC            1-0
+    14:00  Sharks FC                  v Rivers United FC           3-1
+  26.02.
+    14:00  Heartland FC               v Kwara United FC            1-0 (1-0)
+    14:00  Jigawa Golden Stars FC     v Gombe United FC            0-0 (0-0)
+    14:00  Lobi Stars FC              v Shooting Stars SC          1-1
+    14:00  Ocean Boys FC              v Kano Pillars FC            1-0
+    14:00  Sunshine Stars FC          v Enyimba FC                 0-0 (0-0)
+    16:00  ABS FC                     v Rangers International FC   0-1
+    17:00  Akwa United FC             v Kaduna United FC           1-0
+
+
+
+» Matchday 12
+  03.03.
+    16:00  Kano Pillars FC            v Akwa United FC             1-0
+    16:00  Rising Stars FC            v Ocean Boys FC              0-0
+    16:00  Shooting Stars SC          v Warri Wolves FC            1-1 (0-1)
+    16:00  Wikki Tourists FC          v Sharks FC                  1-0
+  04.03.
+    16:00  Enyimba FC                 v Jigawa Golden Stars FC     1-0
+    16:00  Gombe United FC            v Heartland FC               2-2
+    16:00  Kaduna United FC           v ABS FC                     1-2 (1-2)
+    16:00  Rangers International FC   v Lobi Stars FC              1-0 (1-0)
+  11.04.
+    15:00  Rivers United FC           v Niger Tornadoes FC         2-1 (0-0)
+  23.05.
+    15:00  Kwara United FC            v Sunshine Stars FC          1-0 (0-0)
+
+
+
+» Matchday 13
+  10.03.
+    16:00  Niger Tornadoes FC         v Rangers International FC   1-1 (1-1)
+    16:00  Sharks FC                  v Kwara United FC            1-0
+  11.03.
+    16:00  ABS FC                     v Kano Pillars FC            2-2 (1-2)
+    16:00  Akwa United FC             v Shooting Stars SC          1-0 (1-0)
+    16:00  Heartland FC               v Enyimba FC                 2-3
+    16:00  Jigawa Golden Stars FC     v Wikki Tourists FC          2-1 (1-1)
+    16:00  Lobi Stars FC              v Rising Stars FC            2-1 (2-1)
+    16:00  Ocean Boys FC              v Gombe United FC            2-1
+    16:00  Sunshine Stars FC          v Kaduna United FC           2-0 (1-0)
+    16:00  Warri Wolves FC            v Rivers United FC           1-1
+
+
+
+» Matchday 14
+  14.03.
+    16:00  Enyimba FC                 v Lobi Stars FC              0-0 (0-0)
+    16:00  Kaduna United FC           v Warri Wolves FC            2-1 (1-0)
+    16:00  Kano Pillars FC            v Sharks FC                  3-0
+    16:00  Kwara United FC            v Niger Tornadoes FC         2-2
+    16:00  Rangers International FC   v Ocean Boys FC              4-0
+    16:00  Rising Stars FC            v Sunshine Stars FC          0-3 (0-1)
+    16:00  Rivers United FC           v Heartland FC               1-1
+    16:00  Wikki Tourists FC          v Akwa United FC             1-0 (1-0)
+  15.03.
+    16:00  Gombe United FC            v ABS FC                     1-1 (1-0)
+    16:00  Shooting Stars SC          v Jigawa Golden Stars FC     1-0 (1-0)
+
+
+
+» Matchday 15
+  17.03.
+    16:00  Niger Tornadoes FC         v Enyimba FC                 1-0
+    16:00  Sharks FC                  v Kaduna United FC           1-0
+  18.03.
+    16:00  ABS FC                     v Rising Stars FC            1-0
+    16:00  Akwa United FC             v Gombe United FC            3-1 (2-0)
+    16:00  Heartland FC               v Shooting Stars SC          1-0
+    16:00  Lobi Stars FC              v Rivers United FC           2-0 (1-0)
+    16:00  Ocean Boys FC              v Wikki Tourists FC          1-1 (1-0)
+    16:00  Sunshine Stars FC          v Rangers International FC   2-0
+    16:00  Warri Wolves FC            v Kwara United FC            2-0
+  19.03.
+    16:00  Jigawa Golden Stars FC     v Kano Pillars FC            0-0 (0-0)
+
+
+
+» Matchday 16
+  04.04.
+    15:00  Sunshine Stars FC          v Wikki Tourists FC          4-1 (2-1)
+  15.04.
+    15:00  Heartland FC               v Warri Wolves FC            3-1 (2-1)
+    15:00  Rivers United FC           v Ocean Boys FC              3-0
+  25.03.
+    15:00  Kwara United FC            v Jigawa Golden Stars FC     4-2
+    15:00  Niger Tornadoes FC         v Sharks FC                  1-0
+    16:00  ABS FC                     v Lobi Stars FC              2-1
+    16:00  Enyimba FC                 v Rising Stars FC            1-0
+    16:00  Gombe United FC            v Kano Pillars FC            1-0
+    16:00  Kaduna United FC           v Shooting Stars SC          2-0
+    16:00  Rangers International FC   v Akwa United FC             2-1
+
+
+
+» Matchday 17
+  28.03.
+    15:00  Ocean Boys FC              v ABS FC                     1-1
+    15:00  Rising Stars FC            v Rivers United FC           0-1
+    15:00  Shooting Stars SC          v Kwara United FC            1-0 (1-0)
+    15:00  Wikki Tourists FC          v Enyimba FC                 1-1
+  29.03.
+    15:00  Akwa United FC             v Heartland FC               0-0 (0-0)
+    15:00  Jigawa Golden Stars FC     v Niger Tornadoes FC         1-0 (1-0)
+    15:00  Kano Pillars FC            v Sunshine Stars FC          1-0 (1-0)
+    15:00  Lobi Stars FC              v Kaduna United FC           1-0 (0-0)
+    15:00  Sharks FC                  v Rangers International FC   1-0 (0-0)
+    15:00  Warri Wolves FC            v Gombe United FC            2-0 (0-0)
+
+
+
+» Matchday 18
+  01.04.
+    16:00  ABS FC                     v Jigawa Golden Stars FC     3-0
+    16:00  Enyimba FC                 v Akwa United FC             1-1
+    16:00  Gombe United FC            v Wikki Tourists FC          1-0
+    16:00  Heartland FC               v Sharks FC                  0-1
+    16:00  Kaduna United FC           v Ocean Boys FC              1-0
+    16:00  Kwara United FC            v Rising Stars FC            2-0 (1-0)
+    16:00  Niger Tornadoes FC         v Lobi Stars FC              1-1
+    16:00  Rangers International FC   v Shooting Stars SC          3-2
+    16:00  Rivers United FC           v Kano Pillars FC            1-0
+    16:00  Sunshine Stars FC          v Warri Wolves FC            1-1
+
+
+
+» Matchday 19
+  07.04.
+    15:00  Kano Pillars FC            v Kaduna United FC           2-1
+    15:00  Rising Stars FC            v Gombe United FC            2-1
+    15:00  Sharks FC                  v ABS FC                     2-1
+    15:00  Shooting Stars SC          v Enyimba FC                 1-0
+  08.04.
+    15:00  Jigawa Golden Stars FC     v Rangers International FC   1-0
+    15:00  Lobi Stars FC              v Kwara United FC            2-1
+    15:00  Warri Wolves FC            v Niger Tornadoes FC         2-0 (0-0)
+  15.04.
+    15:00  Akwa United FC             v Sunshine Stars FC          1-0 (1-0)
+  18.04.
+    15:00  Wikki Tourists FC          v Rivers United FC           2-1 (2-0)
+
+
+
+» Matchday 20
+  02.05.
+    15:00  ABS FC                     v Sharks FC                  1-3 (0-0)
+    15:00  Enyimba FC                 v Shooting Stars SC          1-0 (0-0)
+    15:00  Gombe United FC            v Rising Stars FC            2-1 (0-0)
+    15:00  Kaduna United FC           v Kano Pillars FC            2-0 (0-0)
+    15:00  Niger Tornadoes FC         v Warri Wolves FC            1-0 (0-0)
+    15:00  Rangers International FC   v Jigawa Golden Stars FC     5-0 (0-0)
+    15:00  Rivers United FC           v Wikki Tourists FC          3-0 (0-0)
+  03.05.
+    15:00  Kwara United FC            v Lobi Stars FC              1-0 (1-0)
+    15:00  Sunshine Stars FC          v Akwa United FC             1-0 (1-0)
+
+
+
+» Matchday 21
+  21.04.
+    16:00  Kano Pillars FC            v Gombe United FC            0-0 (0-0)
+    16:00  Rising Stars FC            v Enyimba FC                 1-0 (0-0)
+    16:00  Sharks FC                  v Niger Tornadoes FC         2-0 (0-0)
+    16:00  Shooting Stars SC          v Kaduna United FC           2-1 (0-0)
+  22.04.
+    15:00  Akwa United FC             v Rangers International FC   1-1
+    15:00  Jigawa Golden Stars FC     v Kwara United FC            1-0
+    15:00  Lobi Stars FC              v ABS FC                     2-0
+    15:00  Ocean Boys FC              v Rivers United FC           0-0 (0-0)
+    15:00  Warri Wolves FC            v Heartland FC               0-0 (0-0)
+    15:00  Wikki Tourists FC          v Sunshine Stars FC          1-0
+
+
+
+» Matchday 22
+  23.06.
+    15:00  Heartland FC               v Sunshine Stars FC          1-1 (0-0)
+  25.04.
+    15:00  ABS FC                     v Warri Wolves FC            0-0 (0-0)
+    15:00  Akwa United FC             v Lobi Stars FC              2-1
+    15:00  Enyimba FC                 v Kwara United FC            2-0
+    15:00  Gombe United FC            v Shooting Stars SC          2-1
+    15:00  Jigawa Golden Stars FC     v Sharks FC                  2-1
+    15:00  Kaduna United FC           v Rivers United FC           1-1 (0-0)
+    15:00  Kano Pillars FC            v Rising Stars FC            2-1
+    15:00  Ocean Boys FC              v Niger Tornadoes FC         1-0
+    15:00  Wikki Tourists FC          v Rangers International FC   1-1 (0-0)
+
+
+
+» Matchday 23
+  16.05.
+    14:00  Sunshine Stars FC          v ABS FC                     2-1 (1-0)
+  17.05.
+    14:00  Warri Wolves FC            v Akwa United FC             1-0 (1-0)
+  17.06.
+    16:00  Niger Tornadoes FC         v Heartland FC               1-0 (0-0)
+  25.08.
+    16:00  Sharks FC                  v Ocean Boys FC              2-0
+  28.04.
+    16:00  Rising Stars FC            v Kaduna United FC           2-2
+  29.04.
+    16:00  Kwara United FC            v Wikki Tourists FC          2-1
+    16:00  Lobi Stars FC              v Jigawa Golden Stars FC     1-0
+    16:00  Rangers International FC   v Gombe United FC            3-0
+    16:00  Rivers United FC           v Enyimba FC                 1-1
+    16:00  Shooting Stars SC          v Kano Pillars FC            2-1
+
+
+
+» Matchday 24
+  07.06.
+    13:00  Sharks FC                  v Enyimba FC                 1-0 (0-0)
+    15:00  ABS FC                     v Heartland FC               1-1 (1-1)
+    15:00  Jigawa Golden Stars FC     v Akwa United FC             1-0 (0-0)
+    15:00  Kaduna United FC           v Rangers International FC   1-0 (0-0)
+    15:00  Kano Pillars FC            v Wikki Tourists FC          4-0 (0-0)
+    15:00  Lobi Stars FC              v Warri Wolves FC            2-1 (0-0)
+    15:00  Niger Tornadoes FC         v Gombe United FC            2-0 (0-0)
+    15:00  Rising Stars FC            v Shooting Stars SC          1-0 (0-0)
+    15:00  Rivers United FC           v Kwara United FC            4-1 (2-0)
+  17.06.
+    16:00  Ocean Boys FC              v Sunshine Stars FC          0-3 (0-0)
+
+
+
+» Matchday 25
+  09.05.
+    15:00  Akwa United FC             v Ocean Boys FC              3-0 (1-0)
+    15:00  Enyimba FC                 v Kano Pillars FC            2-2 (1-1)
+    15:00  Gombe United FC            v Kaduna United FC           1-1
+    15:00  Kwara United FC            v ABS FC                     0-1
+    15:00  Rangers International FC   v Rivers United FC           2-0
+    15:00  Sunshine Stars FC          v Lobi Stars FC              2-0
+    15:00  Wikki Tourists FC          v Rising Stars FC            2-1
+  10.05.
+    15:00  Shooting Stars SC          v Niger Tornadoes FC         3-1
+  17.05.
+    15:00  Heartland FC               v Jigawa Golden Stars FC     1-0 (0-0)
+  23.05.
+    15:00  Warri Wolves FC            v Sharks FC                  4-1 (3-1)
+
+
+
+» Matchday 26
+  12.05.
+    15:00  Sharks FC                  v Gombe United FC            5-2 (4-2)
+  13.05.
+    15:00  Kano Pillars FC            v Rangers International FC   2-0
+    16:00  ABS FC                     v Akwa United FC             2-0
+    16:00  Kaduna United FC           v Kwara United FC            2-1
+    16:00  Lobi Stars FC              v Wikki Tourists FC          2-0
+    16:00  Ocean Boys FC              v Enyimba FC                 0-0 (0-0)
+    16:00  Rivers United FC           v Shooting Stars SC          0-0 (0-0)
+  30.05.
+    15:00  Jigawa Golden Stars FC     v Warri Wolves FC            2-1
+    15:00  Niger Tornadoes FC         v Sunshine Stars FC          2-0
+    15:00  Rising Stars FC            v Heartland FC               1-0
+
+
+
+» Matchday 27
+  19.05.
+    15:00  Kwara United FC            v Kano Pillars FC            1-0
+    15:00  Shooting Stars SC          v ABS FC                     2-1
+    15:00  Wikki Tourists FC          v Niger Tornadoes FC         0-0 (0-0)
+  20.05.
+    16:00  Akwa United FC             v Sharks FC                  0-0
+    16:00  Enyimba FC                 v Kaduna United FC           2-0
+    16:00  Gombe United FC            v Rivers United FC           1-0 (1-0)
+    16:00  Heartland FC               v Lobi Stars FC              2-0
+    16:00  Rangers International FC   v Rising Stars FC            3-1 (2-0)
+    16:00  Sunshine Stars FC          v Jigawa Golden Stars FC     3-3
+    16:00  Warri Wolves FC            v Ocean Boys FC              2-1 (0-0)
+
+
+
+» Matchday 28
+  03.07.
+    15:00  Wikki Tourists FC          v Kaduna United FC           2-1 (0-0)
+  20.06.
+    16:00  ABS FC                     v Niger Tornadoes FC         3-2 (2-1)
+    16:00  Akwa United FC             v Rivers United FC           3-2 (2-2)
+    16:00  Heartland FC               v Kano Pillars FC            1-1 (1-0)
+    16:00  Lobi Stars FC              v Sharks FC                  2-0 (2-0)
+    16:00  Rangers International FC   v Kwara United FC            2-0 (0-0)
+    16:00  Sunshine Stars FC          v Shooting Stars SC          0-0 (0-0)
+  23.08.
+    16:00  Warri Wolves FC            v Rising Stars FC            0-0 (0-0)
+  26.06.
+    16:00  Gombe United FC            v Enyimba FC                 3-1 (0-0)
+
+
+
+» Matchday 29
+  10.08.
+    16:00  Kaduna United FC           v Heartland FC               2-0 (2-0)
+  26.05.
+    16:00  Kano Pillars FC            v Warri Wolves FC            1-0
+    16:00  Kwara United FC            v Gombe United FC            2-1 (2-0)
+    16:00  Niger Tornadoes FC         v Akwa United FC             2-0
+    16:00  Rising Stars FC            v Jigawa Golden Stars FC     1-1
+    16:00  Sharks FC                  v Sunshine Stars FC          1-0
+    16:00  Shooting Stars SC          v Wikki Tourists FC          2-0
+  27.05.
+    16:00  Enyimba FC                 v Rangers International FC   2-0
+    16:00  Ocean Boys FC              v Lobi Stars FC              2-1
+    16:00  Rivers United FC           v ABS FC                     2-0
+
+
+
+» Matchday 30
+  02.06.
+    15:00  ABS FC                     v Wikki Tourists FC          2-1
+    15:00  Akwa United FC             v Kwara United FC            1-0
+    15:00  Heartland FC               v Rangers International FC   0-0
+    15:00  Jigawa Golden Stars FC     v Rivers United FC           3-1
+    15:00  Lobi Stars FC              v Kano Pillars FC            1-0
+    15:00  Niger Tornadoes FC         v Kaduna United FC           4-1
+    15:00  Ocean Boys FC              v Shooting Stars SC          1-2
+    15:00  Sharks FC                  v Rising Stars FC            3-1
+    15:00  Sunshine Stars FC          v Gombe United FC            2-0
+    15:00  Warri Wolves FC            v Enyimba FC                 1-0
+
+
+
+» Matchday 31
+  10.06.
+    16:00  Enyimba FC                 v Sunshine Stars FC          2-1 (0-1)
+    16:00  Gombe United FC            v Jigawa Golden Stars FC     1-0 (0-0)
+    16:00  Kaduna United FC           v Akwa United FC             2-0 (0-0)
+    16:00  Kano Pillars FC            v Ocean Boys FC              3-0 (0-0)
+    16:00  Kwara United FC            v Heartland FC               1-0 (0-0)
+    16:00  Rangers International FC   v ABS FC                     1-0 (0-0)
+    16:00  Rising Stars FC            v Niger Tornadoes FC         1-0 (0-0)
+    16:00  Rivers United FC           v Sharks FC                  1-0 (0-0)
+    16:00  Shooting Stars SC          v Lobi Stars FC              1-0 (0-0)
+    16:00  Wikki Tourists FC          v Warri Wolves FC            2-0 (0-0)
+
+
+
+» Matchday 32
+  13.06.
+    16:00  ABS FC                     v Enyimba FC                 3-1 (1-0)
+    16:00  Akwa United FC             v Rising Stars FC            1-0 (0-0)
+    16:00  Heartland FC               v Wikki Tourists FC          2-0 (0-0)
+    16:00  Jigawa Golden Stars FC     v Kaduna United FC           0-0 (0-0)
+    16:00  Niger Tornadoes FC         v Kano Pillars FC            1-1 (0-0)
+    16:00  Ocean Boys FC              v Kwara United FC            2-1 (1-1)
+    16:00  Sharks FC                  v Shooting Stars SC          2-1 (2-1)
+    16:00  Sunshine Stars FC          v Rivers United FC           1-0 (0-0)
+    16:00  Warri Wolves FC            v Rangers International FC   1-0 (0-0)
+  14.06.
+    16:00  Lobi Stars FC              v Gombe United FC            3-0 (0-0)
+
+
+
+» Matchday 33
+  04.07.
+    15:00  Gombe United FC            v Ocean Boys FC              3-1 (0-0)
+    15:00  Kano Pillars FC            v ABS FC                     2-1 (2-0)
+    15:00  Kwara United FC            v Sharks FC                  2-0 (0-0)
+    15:00  Rangers International FC   v Niger Tornadoes FC         3-0 (2-0)
+    15:00  Rising Stars FC            v Lobi Stars FC              1-0
+    15:00  Rivers United FC           v Warri Wolves FC            1-0 (0-0)
+    15:00  Shooting Stars SC          v Akwa United FC             2-0 (2-0)
+  05.07.
+    15:00  Wikki Tourists FC          v Jigawa Golden Stars FC     2-0
+    16:00  Enyimba FC                 v Heartland FC               1-0 (0-0)
+  15.07.
+    16:00  Kaduna United FC           v Sunshine Stars FC          1-0
+
+
+
+» Matchday 34
+  10.07.
+    23:00  Akwa United FC             v Wikki Tourists FC          1-0
+    23:00  Heartland FC               v Rivers United FC           1-0
+    23:00  Jigawa Golden Stars FC     v Shooting Stars SC          2-0
+    23:00  Lobi Stars FC              v Enyimba FC                 2-0
+    23:00  Niger Tornadoes FC         v Kwara United FC            3-1
+    23:00  Ocean Boys FC              v Rangers International FC   0-1
+    23:00  Sharks FC                  v Kano Pillars FC            0-0
+    23:00  Sunshine Stars FC          v Rising Stars FC            2-1
+  11.07.
+    23:00  ABS FC                     v Gombe United FC            1-0
+    23:00  Warri Wolves FC            v Kaduna United FC           1-0
+
+
+
+» Matchday 35
+  29.07.
+    15:00  Akwa United FC             v Enyimba FC                 2-1 (2-1)
+    15:00  Jigawa Golden Stars FC     v ABS FC                     2-0 (2-0)
+    15:00  Kano Pillars FC            v Rivers United FC           2-1 (0-0)
+    15:00  Lobi Stars FC              v Niger Tornadoes FC         2-0 (0-0)
+    15:00  Rising Stars FC            v Kwara United FC            1-0 (1-0)
+    15:00  Sharks FC                  v Heartland FC               2-0 (1-0)
+    15:00  Shooting Stars SC          v Rangers International FC   1-0 (1-0)
+    15:00  Warri Wolves FC            v Sunshine Stars FC          1-2 (0-0)
+    15:00  Wikki Tourists FC          v Gombe United FC            3-1 (1-0)
+
+
+
+» Matchday 36
+  01.08.
+    15:00  Enyimba FC                 v Niger Tornadoes FC         3-0 (2-0)
+    15:00  Gombe United FC            v Akwa United FC             1-0 (1-0)
+    15:00  Kano Pillars FC            v Jigawa Golden Stars FC     3-0 (2-0)
+    15:00  Kwara United FC            v Warri Wolves FC            1-0 (1-0)
+    15:00  Rivers United FC           v Lobi Stars FC              0-2 (0-1)
+    15:00  Shooting Stars SC          v Heartland FC               2-0 (1-0)
+    16:00  Wikki Tourists FC          v Ocean Boys FC              3-0
+  02.08.
+    15:00  Kaduna United FC           v Sharks FC                  2-1 (0-1)
+    15:00  Rising Stars FC            v ABS FC                     2-1 (1-1)
+  08.08.
+    16:00  Rangers International FC   v Sunshine Stars FC          3-0 (1-0)
+
+
+
+» Matchday 37
+  12.08.
+    16:00  Sunshine Stars FC          v Kwara United FC            1-1 (0-0)
+  15.08.
+    16:00  Akwa United FC             v Kano Pillars FC            0-1 (0-0)
+    16:00  Heartland FC               v Gombe United FC            2-1 (0-0)
+    16:00  Jigawa Golden Stars FC     v Enyimba FC                 1-0 (0-0)
+    16:00  Lobi Stars FC              v Rangers International FC   3-0 (2-0)
+    16:00  Niger Tornadoes FC         v Rivers United FC           4-0 (3-0)
+    16:00  Sharks FC                  v Wikki Tourists FC          2-3 (1-0)
+    16:00  Warri Wolves FC            v Shooting Stars SC          1-0 (1-0)
+  16.08.
+    16:00  ABS FC                     v Kaduna United FC           3-1 (3-0)
+    16:00  Ocean Boys FC              v Rising Stars FC            0-3
+
+
+
+» Matchday 38
+  07.09.
+    16:00  Enyimba FC                 v Wikki Tourists FC          3-0 (0-0)
+    16:00  Gombe United FC            v Warri Wolves FC            1-0 (0-0)
+    16:00  Heartland FC               v Akwa United FC             1-0 (0-0)
+    16:00  Kaduna United FC           v Lobi Stars FC              3-1 (0-0)
+    16:00  Kwara United FC            v Shooting Stars SC          2-0 (0-0)
+    16:00  Niger Tornadoes FC         v Jigawa Golden Stars FC     2-0 (0-0)
+    16:00  Rangers International FC   v Sharks FC                  3-0 (0-0)
+    16:00  Rivers United FC           v Rising Stars FC            2-0 (0-0)
+    16:00  Sunshine Stars FC          v Kano Pillars FC            2-1 (0-0)
+


### PR DESCRIPTION
## Summary

Adds Nigeria Professional Football League (NPFL) seasons from 2009/10 to 2011/12 to the Open Football dataset.

## Details

- **Country:** Nigeria  
- **Competition:** Nigeria Professional Football League  
- **Seasons:** 2009/10 – 2011/12  
- **Tier:** 1 (ng1)  
- **Matches:** Full league seasons  
- **Source:** Soccerway  

## Notes

- Team names use consistent, expanded canonical forms.
- The 2019/20 season is intentionally excluded due to COVID-19 disruption.
- Additional seasons will be submitted in follow-up PRs.
