### PR TITLE
Add Nigeria Professional Football League seasons 2017-2021

### DIFF
--- a/africa/nigeria/2016-17_ng1.txt
+++ b/africa/nigeria/2016-17_ng1.txt
@@ -1,0 +1,614 @@
+= Nigeria | Premier Football League 2016/2017
+
+# Date       Thu Jan/14 2016 - Fri Sep/16 2016 (246d)
+# Teams      20
+# Matches    380
+
+
+
+» Matchday 1
+  14.01.
+    16:00  Kano Pillars FC            v Ifeanyi Ubah FC            3-0
+  15.01.
+    16:00  ABS FC                     v Akwa United FC             3-1 (2-1)
+    16:00  Enyimba FC                 v Sunshine Stars FC          1-0 (1-0)
+    16:00  Katsina United FC          v Gombe United FC            2-1 (2-1)
+    16:00  MFM FC                     v Niger Tornadoes FC         3-0 (3-0)
+    16:00  Rangers International FC   v Abia Warriors FC           1-2 (1-1)
+    16:00  Remo Stars FC              v Plateau United FC          1-2 (1-1)
+    16:00  Rivers United FC           v El-Kanemi Warriors FC      2-1 (1-0)
+    16:00  Shooting Stars SC          v Lobi Stars FC              2-0 (1-0)
+    16:00  Wikki Tourists FC          v Nasarawa United FC         0-0 (0-0)
+
+
+
+» Matchday 2
+  18.01.
+    16:00  Abia Warriors FC           v Katsina United FC          2-0 (1-0)
+    16:00  Akwa United FC             v Rivers United FC           1-1 (1-1)
+    16:00  Gombe United FC            v Remo Stars FC              2-1 (1-1)
+    16:00  Ifeanyi Ubah FC            v MFM FC                     4-0 (3-0)
+    16:00  Lobi Stars FC              v Kano Pillars FC            1-0 (1-0)
+    16:00  Nasarawa United FC         v Rangers International FC   1-1 (0-0)
+    16:00  Niger Tornadoes FC         v ABS FC                     1-1 (1-1)
+    16:00  Plateau United FC          v Enyimba FC                 3-1 (1-0)
+    16:00  Sunshine Stars FC          v Shooting Stars SC          1-0 (0-0)
+  19.01.
+    16:00  El-Kanemi Warriors FC      v Wikki Tourists FC          2-1 (2-1)
+
+
+
+» Matchday 3
+  22.01.
+    16:00  ABS FC                     v Ifeanyi Ubah FC            1-0 (1-0)
+    16:00  Enyimba FC                 v Gombe United FC            2-0 (0-0)
+    16:00  Kano Pillars FC            v Shooting Stars SC          2-1 (0-1)
+    16:00  Katsina United FC          v Nasarawa United FC         1-0 (0-0)
+    16:00  MFM FC                     v Lobi Stars FC              4-0 (1-0)
+    16:00  Plateau United FC          v Sunshine Stars FC          3-1 (1-0)
+    16:00  Rangers International FC   v El-Kanemi Warriors FC      1-0 (0-0)
+    16:00  Remo Stars FC              v Abia Warriors FC           1-0 (0-0)
+    16:00  Rivers United FC           v Niger Tornadoes FC         1-0 (1-0)
+    16:00  Wikki Tourists FC          v Akwa United FC             1-0 (0-0)
+
+
+
+» Matchday 4
+  25.01.
+    16:00  Abia Warriors FC           v Enyimba FC                 0-0 (0-0)
+    16:00  Akwa United FC             v Rangers International FC   0-0 (0-0)
+    16:00  El-Kanemi Warriors FC      v Katsina United FC          1-0 (0-0)
+    16:00  Gombe United FC            v Plateau United FC          0-0 (0-0)
+    16:00  Ifeanyi Ubah FC            v Rivers United FC           0-0 (0-0)
+    16:00  Lobi Stars FC              v ABS FC                     3-0 (1-0)
+    16:00  Nasarawa United FC         v Remo Stars FC              3-1 (1-0)
+    16:00  Niger Tornadoes FC         v Wikki Tourists FC          2-0 (1-0)
+    16:00  Shooting Stars SC          v MFM FC                     1-1 (0-1)
+    16:00  Sunshine Stars FC          v Kano Pillars FC            1-0 (0-0)
+
+
+
+» Matchday 5
+  29.01.
+    16:00  ABS FC                     v Shooting Stars SC          2-0 (1-0)
+    16:00  Enyimba FC                 v Nasarawa United FC         2-1 (1-1)
+    16:00  Gombe United FC            v Sunshine Stars FC          2-0 (0-0)
+    16:00  Katsina United FC          v Akwa United FC             1-1 (0-1)
+    16:00  MFM FC                     v Kano Pillars FC            1-0 (0-0)
+    16:00  Plateau United FC          v Abia Warriors FC           2-1 (2-1)
+    16:00  Rangers International FC   v Niger Tornadoes FC         1-1 (1-1)
+    16:00  Remo Stars FC              v El-Kanemi Warriors FC      2-0 (1-0)
+    16:00  Rivers United FC           v Lobi Stars FC              0-0 (0-0)
+    16:00  Wikki Tourists FC          v Ifeanyi Ubah FC            3-1 (2-1)
+
+
+
+» Matchday 6
+  05.02.
+    16:00  Abia Warriors FC           v Gombe United FC            1-0 (0-0)
+    16:00  Akwa United FC             v Remo Stars FC              1-0 (0-0)
+    16:00  El-Kanemi Warriors FC      v Enyimba FC                 1-0 (0-0)
+    16:00  Ifeanyi Ubah FC            v Rangers International FC   1-0 (0-0)
+    16:00  Kano Pillars FC            v ABS FC                     1-0 (0-0)
+    16:00  Lobi Stars FC              v Wikki Tourists FC          2-0 (0-0)
+    16:00  Nasarawa United FC         v Plateau United FC          0-0 (0-0)
+    16:00  Niger Tornadoes FC         v Katsina United FC          1-1 (0-1)
+    16:00  Shooting Stars SC          v Rivers United FC           2-1 (1-1)
+    16:00  Sunshine Stars FC          v MFM FC                     0-1 (0-0)
+
+
+
+» Matchday 7
+  08.02.
+    16:00  Abia Warriors FC           v Sunshine Stars FC          1-1 (0-1)
+    16:00  Gombe United FC            v Nasarawa United FC         1-0 (0-0)
+    16:00  Plateau United FC          v El-Kanemi Warriors FC      2-0 (2-0)
+    16:00  Remo Stars FC              v Niger Tornadoes FC         0-1 (0-1)
+  09.02.
+    16:00  ABS FC                     v MFM FC                     1-0 (0-0)
+    16:00  Enyimba FC                 v Akwa United FC             1-0 (0-0)
+  22.02.
+    16:00  Katsina United FC          v Ifeanyi Ubah FC            1-0 (1-0)
+    16:00  Rangers International FC   v Lobi Stars FC              2-1 (1-1)
+    16:00  Rivers United FC           v Kano Pillars FC            1-1 (1-0)
+    16:00  Wikki Tourists FC          v Shooting Stars SC          1-0 (0-0)
+
+
+
+» Matchday 8
+  08.03.
+    16:00  Ifeanyi Ubah FC            v Remo Stars FC              3-0 (0-0)
+    16:00  Kano Pillars FC            v Wikki Tourists FC          1-0 (1-0)
+  12.02.
+    16:00  Akwa United FC             v Plateau United FC          2-1 (1-0)
+    16:00  El-Kanemi Warriors FC      v Gombe United FC            3-0 (3-0)
+    16:00  Lobi Stars FC              v Katsina United FC          0-0 (0-0)
+    16:00  Nasarawa United FC         v Abia Warriors FC           3-1 (2-1)
+    16:00  Niger Tornadoes FC         v Enyimba FC                 1-0 (1-0)
+    16:00  Sunshine Stars FC          v ABS FC                     2-2 (2-1)
+  22.03.
+    16:00  MFM FC                     v Rivers United FC           2-1 (2-1)
+    16:00  Shooting Stars SC          v Rangers International FC   1-0 (0-0)
+
+
+
+» Matchday 9
+  06.04.
+    16:00  Rivers United FC           v ABS FC                     2-0 (1-0)
+  15.03.
+    16:00  Enyimba FC                 v Ifeanyi Ubah FC            2-0 (1-0)
+    16:00  Wikki Tourists FC          v MFM FC                     1-1 (1-0)
+  19.02.
+    16:00  Abia Warriors FC           v El-Kanemi Warriors FC      0-1 (0-1)
+    16:00  Gombe United FC            v Akwa United FC             0-0 (0-0)
+    16:00  Katsina United FC          v Shooting Stars SC          1-1 (1-0)
+    16:00  Nasarawa United FC         v Sunshine Stars FC          1-1 (0-0)
+    16:00  Plateau United FC          v Niger Tornadoes FC         2-0 (1-0)
+    16:00  Remo Stars FC              v Lobi Stars FC              1-1 (1-0)
+  23.04.
+    16:00  Rangers International FC   v Kano Pillars FC            3-1 (3-1)
+
+
+
+» Matchday 10
+  24.02.
+    19:00  MFM FC                     v Rangers International FC   2-1 (1-0)
+  25.02.
+    16:00  Akwa United FC             v Abia Warriors FC           3-1 (2-1)
+    16:15  Shooting Stars SC          v Remo Stars FC              1-1 (1-0)
+  26.02.
+    16:00  ABS FC                     v Wikki Tourists FC          1-0 (1-0)
+    16:00  El-Kanemi Warriors FC      v Nasarawa United FC         2-0 (0-0)
+    16:00  Ifeanyi Ubah FC            v Plateau United FC          1-0 (1-0)
+    16:00  Kano Pillars FC            v Katsina United FC          1-0 (1-0)
+    16:00  Lobi Stars FC              v Enyimba FC                 2-1 (0-1)
+    16:00  Niger Tornadoes FC         v Gombe United FC            1-0 (1-0)
+    16:15  Sunshine Stars FC          v Rivers United FC           1-0 (1-0)
+
+
+
+» Matchday 11
+  01.03.
+    16:00  Abia Warriors FC           v Niger Tornadoes FC         1-0 (1-0)
+    16:00  El-Kanemi Warriors FC      v Sunshine Stars FC          3-1 (1-1)
+    16:00  Enyimba FC                 v Shooting Stars SC          0-0 (0-0)
+    16:00  Gombe United FC            v Ifeanyi Ubah FC            2-0 (1-0)
+    16:00  Katsina United FC          v MFM FC                     2-1 (1-0)
+    16:00  Plateau United FC          v Lobi Stars FC              0-0 (0-0)
+    16:00  Rangers International FC   v ABS FC                     1-0 (1-0)
+    16:00  Remo Stars FC              v Kano Pillars FC            1-1 (1-0)
+    16:00  Wikki Tourists FC          v Rivers United FC           0-0 (0-0)
+  02.03.
+    16:00  Nasarawa United FC         v Akwa United FC             1-0 (1-0)
+
+
+
+» Matchday 12
+  05.03.
+    16:00  ABS FC                     v Katsina United FC          1-0 (1-0)
+    16:00  Akwa United FC             v El-Kanemi Warriors FC      1-0 (0-0)
+    16:00  Ifeanyi Ubah FC            v Abia Warriors FC           2-2 (1-1)
+    16:00  Lobi Stars FC              v Gombe United FC            1-0 (1-0)
+    16:00  MFM FC                     v Remo Stars FC              1-0 (1-0)
+    16:00  Niger Tornadoes FC         v Nasarawa United FC         2-0 (1-0)
+    16:00  Rivers United FC           v Rangers International FC   1-0 (1-0)
+    16:00  Shooting Stars SC          v Plateau United FC          1-1
+    16:00  Sunshine Stars FC          v Wikki Tourists FC          1-0 (1-0)
+    16:15  Kano Pillars FC            v Enyimba FC                 3-1 (1-0)
+
+
+
+» Matchday 13
+  11.03.
+    16:15  Enyimba FC                 v MFM FC                     1-1 (0-1)
+  12.03.
+    16:00  Abia Warriors FC           v Lobi Stars FC              2-1 (1-1)
+    16:00  El-Kanemi Warriors FC      v Niger Tornadoes FC         2-0 (1-0)
+    16:00  Gombe United FC            v Shooting Stars SC          1-1 (1-0)
+    16:00  Nasarawa United FC         v Ifeanyi Ubah FC            2-0 (1-0)
+    16:00  Plateau United FC          v Kano Pillars FC            2-0 (1-0)
+    16:00  Remo Stars FC              v ABS FC                     3-0 (1-0)
+    16:15  Akwa United FC             v Sunshine Stars FC          3-1 (3-1)
+  26.04.
+    16:00  Rangers International FC   v Wikki Tourists FC          3-2 (2-0)
+  27.04.
+    16:00  Katsina United FC          v Rivers United FC           2-0 (1-0)
+
+
+
+» Matchday 14
+  03.05.
+    16:00  Rivers United FC           v Remo Stars FC              1-0 (1-0)
+  19.03.
+    16:00  ABS FC                     v Enyimba FC                 1-1 (0-0)
+    16:00  Ifeanyi Ubah FC            v El-Kanemi Warriors FC      3-2 (2-0)
+    16:00  Kano Pillars FC            v Gombe United FC            2-0 (0-0)
+    16:00  Lobi Stars FC              v Nasarawa United FC         0-0 (0-0)
+    16:00  Niger Tornadoes FC         v Akwa United FC             1-0 (1-0)
+    16:00  Shooting Stars SC          v Abia Warriors FC           0-0 (0-0)
+    16:00  Wikki Tourists FC          v Katsina United FC          2-1 (1-0)
+    16:15  MFM FC                     v Plateau United FC          2-1 (1-0)
+  30.04.
+    16:00  Sunshine Stars FC          v Rangers International FC   2-0 (0-0)
+
+
+
+» Matchday 15
+  26.03.
+    16:00  Abia Warriors FC           v Kano Pillars FC            3-0 (1-0)
+    16:00  El-Kanemi Warriors FC      v Lobi Stars FC              1-0 (0-0)
+    16:00  Enyimba FC                 v Rivers United FC           1-0 (0-0)
+    16:00  Gombe United FC            v MFM FC                     1-0 (0-0)
+    16:00  Katsina United FC          v Rangers International FC   1-0 (1-0)
+    16:00  Nasarawa United FC         v Shooting Stars SC          1-0 (0-0)
+    16:00  Niger Tornadoes FC         v Sunshine Stars FC          2-1 (1-0)
+    16:00  Plateau United FC          v ABS FC                     4-1 (2-1)
+    16:00  Remo Stars FC              v Wikki Tourists FC          2-1 (1-1)
+    19:15  Akwa United FC             v Ifeanyi Ubah FC            1-1 (0-1)
+
+
+
+» Matchday 16
+  29.03.
+    16:00  ABS FC                     v Gombe United FC            1-1 (1-0)
+    16:00  Ifeanyi Ubah FC            v Niger Tornadoes FC         1-0 (1-0)
+    16:00  Kano Pillars FC            v Nasarawa United FC         1-1 (1-0)
+    16:00  MFM FC                     v Abia Warriors FC           2-1 (2-0)
+    16:00  Rangers International FC   v Remo Stars FC              1-1 (1-0)
+    16:00  Rivers United FC           v Plateau United FC          0-0 (0-0)
+    16:00  Shooting Stars SC          v El-Kanemi Warriors FC      1-0 (0-0)
+    16:00  Sunshine Stars FC          v Katsina United FC          2-0 (0-0)
+    16:00  Wikki Tourists FC          v Enyimba FC                 1-0 (0-0)
+  30.03.
+    16:00  Lobi Stars FC              v Akwa United FC             2-1 (1-1)
+
+
+
+» Matchday 17
+  02.04.
+    16:00  Abia Warriors FC           v ABS FC                     2-0 (0-0)
+    16:00  Akwa United FC             v Shooting Stars SC          4-2 (4-0)
+    16:00  El-Kanemi Warriors FC      v Kano Pillars FC            1-0 (0-0)
+    16:00  Enyimba FC                 v Rangers International FC   2-1 (0-1)
+    16:00  Gombe United FC            v Rivers United FC           1-0 (1-0)
+    16:00  Ifeanyi Ubah FC            v Sunshine Stars FC          2-1 (0-0)
+    16:00  Nasarawa United FC         v MFM FC                     4-0 (1-0)
+    16:00  Niger Tornadoes FC         v Lobi Stars FC              2-1 (1-0)
+    16:00  Plateau United FC          v Wikki Tourists FC          1-0
+    16:00  Remo Stars FC              v Katsina United FC          1-0 (0-0)
+
+
+
+» Matchday 18
+  03.05.
+    16:00  Rangers International FC   v Plateau United FC          1-0 (1-0)
+  09.04.
+    16:00  ABS FC                     v Nasarawa United FC         1-0 (0-0)
+    16:00  Kano Pillars FC            v Akwa United FC             0-1 (0-1)
+    16:00  Katsina United FC          v Enyimba FC                 2-1 (1-1)
+    16:00  Lobi Stars FC              v Ifeanyi Ubah FC            0-0 (0-0)
+    16:00  MFM FC                     v El-Kanemi Warriors FC      3-0 (3-0)
+    16:00  Rivers United FC           v Abia Warriors FC           1-0 (1-0)
+    16:00  Shooting Stars SC          v Niger Tornadoes FC         2-1 (1-0)
+    16:00  Sunshine Stars FC          v Remo Stars FC              1-0 (1-0)
+    16:00  Wikki Tourists FC          v Gombe United FC            3-1 (2-0)
+
+
+
+» Matchday 19
+  10.05.
+    16:00  Gombe United FC            v Rangers International FC   3-3 (0-1)
+  19.04.
+    16:00  Abia Warriors FC           v Wikki Tourists FC          2-0 (1-0)
+    16:00  Akwa United FC             v MFM FC                     2-0 (2-0)
+    16:00  El-Kanemi Warriors FC      v ABS FC                     1-0 (1-0)
+    16:00  Enyimba FC                 v Remo Stars FC              1-0 (1-0)
+    16:00  Ifeanyi Ubah FC            v Shooting Stars SC          2-1 (0-1)
+    16:00  Lobi Stars FC              v Sunshine Stars FC          3-1 (1-0)
+    16:00  Niger Tornadoes FC         v Kano Pillars FC            1-0 (0-0)
+    16:00  Plateau United FC          v Katsina United FC          3-0 (1-0)
+  30.04.
+    16:00  Nasarawa United FC         v Rivers United FC           1-0 (1-0)
+
+
+
+» Matchday 20
+  20.05.
+    16:00  Rivers United FC           v Nasarawa United FC         1-0 (1-0)
+  21.05.
+    16:00  ABS FC                     v El-Kanemi Warriors FC      2-1 (1-1)
+    16:00  Kano Pillars FC            v Niger Tornadoes FC         1-0 (1-0)
+    16:00  Katsina United FC          v Plateau United FC          1-1 (1-0)
+    16:00  MFM FC                     v Akwa United FC             0-0 (0-0)
+    16:00  Rangers International FC   v Gombe United FC            2-1 (1-1)
+    16:00  Remo Stars FC              v Enyimba FC                 0-1 (0-1)
+    16:00  Shooting Stars SC          v Ifeanyi Ubah FC            0-3 (0-2)
+    16:00  Sunshine Stars FC          v Lobi Stars FC              0-1 (0-1)
+    16:00  Wikki Tourists FC          v Abia Warriors FC           3-0 (2-0)
+
+
+
+» Matchday 21
+  28.05.
+    16:00  Abia Warriors FC           v Rangers International FC   4-0 (2-0)
+    16:00  Akwa United FC             v ABS FC                     3-0 (1-0)
+    16:00  El-Kanemi Warriors FC      v Rivers United FC           2-1 (1-0)
+    16:00  Gombe United FC            v Katsina United FC          1-0 (1-0)
+    16:00  Ifeanyi Ubah FC            v Kano Pillars FC            2-0 (1-0)
+    16:00  Lobi Stars FC              v Shooting Stars SC          3-0 (2-0)
+    16:00  Nasarawa United FC         v Wikki Tourists FC          2-0 (2-0)
+    16:00  Niger Tornadoes FC         v MFM FC                     3-0 (2-0)
+    16:00  Plateau United FC          v Remo Stars FC              1-0 (1-0)
+    16:00  Sunshine Stars FC          v Enyimba FC                 1-0 (0-0)
+
+
+
+» Matchday 22
+  04.06.
+    16:00  ABS FC                     v Niger Tornadoes FC         2-1 (1-1)
+    16:00  Enyimba FC                 v Plateau United FC          1-0 (0-0)
+    16:00  Kano Pillars FC            v Lobi Stars FC              2-1 (1-0)
+    16:00  Katsina United FC          v Abia Warriors FC           1-0 (1-0)
+    16:00  MFM FC                     v Ifeanyi Ubah FC            1-0 (1-0)
+    16:00  Rangers International FC   v Nasarawa United FC         1-1 (0-0)
+    16:00  Remo Stars FC              v Gombe United FC            2-0 (2-0)
+    16:00  Shooting Stars SC          v Sunshine Stars FC          1-0 (1-0)
+    16:00  Wikki Tourists FC          v El-Kanemi Warriors FC      2-1 (1-0)
+  26.07.
+    16:00  Rivers United FC           v Akwa United FC             1-1 (1-1)
+
+
+
+» Matchday 23
+  07.06.
+    16:00  El-Kanemi Warriors FC      v Rangers International FC   1-1 (0-0)
+    16:00  Gombe United FC            v Enyimba FC                 1-1 (0-0)
+    16:00  Ifeanyi Ubah FC            v ABS FC                     2-0 (1-0)
+    16:00  Lobi Stars FC              v MFM FC                     3-1 (3-1)
+    16:00  Nasarawa United FC         v Katsina United FC          2-0 (1-0)
+    16:00  Niger Tornadoes FC         v Rivers United FC           1-0 (1-0)
+    16:00  Shooting Stars SC          v Kano Pillars FC            0-0 (0-0)
+    16:00  Sunshine Stars FC          v Plateau United FC          1-2 (1-0)
+  08.06.
+    16:00  Abia Warriors FC           v Remo Stars FC              0-0 (0-0)
+  14.06.
+    16:00  Akwa United FC             v Wikki Tourists FC          2-0 (1-0)
+
+
+
+» Matchday 24
+  11.06.
+    16:00  ABS FC                     v Lobi Stars FC              1-0 (1-0)
+    16:00  Enyimba FC                 v Abia Warriors FC           2-1 (1-0)
+    16:00  Kano Pillars FC            v Sunshine Stars FC          3-1 (3-0)
+    16:00  Katsina United FC          v El-Kanemi Warriors FC      3-0 (1-0)
+    16:00  MFM FC                     v Shooting Stars SC          1-0 (1-0)
+    16:00  Plateau United FC          v Gombe United FC            5-1 (3-1)
+    16:00  Rangers International FC   v Akwa United FC             1-0 (1-0)
+    16:00  Remo Stars FC              v Nasarawa United FC         1-0 (0-0)
+    16:00  Rivers United FC           v Ifeanyi Ubah FC            2-1 (0-0)
+    16:00  Wikki Tourists FC          v Niger Tornadoes FC         3-1 (2-0)
+
+
+
+» Matchday 25
+  16.06.
+    16:00  Lobi Stars FC              v Rivers United FC           1-0 (0-0)
+  18.06.
+    16:00  Abia Warriors FC           v Plateau United FC          2-1 (1-0)
+    16:00  Akwa United FC             v Katsina United FC          2-0 (2-0)
+    16:00  El-Kanemi Warriors FC      v Remo Stars FC              2-0 (1-0)
+    16:00  Ifeanyi Ubah FC            v Wikki Tourists FC          0-0 (0-0)
+    16:00  Kano Pillars FC            v MFM FC                     3-1 (1-0)
+    16:00  Nasarawa United FC         v Enyimba FC                 1-0 (0-0)
+    16:00  Niger Tornadoes FC         v Rangers International FC   0-0 (0-0)
+    16:00  Shooting Stars SC          v ABS FC                     2-0 (0-0)
+    16:00  Sunshine Stars FC          v Gombe United FC            2-1 (1-0)
+
+
+
+» Matchday 26
+  24.06.
+    16:00  Rivers United FC           v Shooting Stars SC          1-0 (1-0)
+  28.06.
+    16:00  ABS FC                     v Kano Pillars FC            1-1 (0-0)
+    16:00  Enyimba FC                 v El-Kanemi Warriors FC      4-0 (1-0)
+    16:00  Gombe United FC            v Abia Warriors FC           2-1 (0-0)
+    16:00  Katsina United FC          v Niger Tornadoes FC         1-0 (0-0)
+    16:00  MFM FC                     v Sunshine Stars FC          2-1 (1-0)
+    16:00  Plateau United FC          v Nasarawa United FC         1-0 (0-0)
+    16:00  Rangers International FC   v Ifeanyi Ubah FC            1-0 (1-0)
+    16:00  Remo Stars FC              v Akwa United FC             2-2 (1-1)
+    16:00  Wikki Tourists FC          v Lobi Stars FC              1-0 (0-0)
+
+
+
+» Matchday 27
+  02.07.
+    16:00  Akwa United FC             v Enyimba FC                 1-0 (1-0)
+    16:00  El-Kanemi Warriors FC      v Plateau United FC          1-0 (0-0)
+    16:00  Ifeanyi Ubah FC            v Katsina United FC          2-0 (1-0)
+    16:00  Lobi Stars FC              v Rangers International FC   3-1 (2-0)
+    16:00  MFM FC                     v ABS FC                     2-1 (1-0)
+    16:00  Nasarawa United FC         v Gombe United FC            1-1 (1-0)
+    16:00  Niger Tornadoes FC         v Remo Stars FC              1-0 (0-0)
+    16:00  Shooting Stars SC          v Wikki Tourists FC          2-0 (2-0)
+    16:00  Sunshine Stars FC          v Abia Warriors FC           1-0 (0-0)
+  03.08.
+    16:00  Kano Pillars FC            v Rivers United FC           2-0 (0-0)
+
+
+
+» Matchday 28
+  09.07.
+    16:00  Abia Warriors FC           v Nasarawa United FC         2-0 (1-0)
+    16:00  ABS FC                     v Sunshine Stars FC          2-4 (0-0)
+    16:00  Enyimba FC                 v Niger Tornadoes FC         3-0 (1-0)
+    16:00  Gombe United FC            v El-Kanemi Warriors FC      2-0 (0-0)
+    16:00  Katsina United FC          v Lobi Stars FC              2-1 (2-1)
+    16:00  Plateau United FC          v Akwa United FC             3-0 (1-0)
+    16:00  Rangers International FC   v Shooting Stars SC          1-1 (1-0)
+    16:00  Wikki Tourists FC          v Kano Pillars FC            2-0 (1-0)
+  11.07.
+    16:00  Remo Stars FC              v Ifeanyi Ubah FC            1-1 (0-0)
+  12.07.
+    16:00  Rivers United FC           v MFM FC                     1-0 (1-0)
+
+
+
+» Matchday 29
+  16.07.
+    16:00  ABS FC                     v Rivers United FC           0-0 (0-0)
+    16:00  Akwa United FC             v Gombe United FC            3-0 (0-0)
+    16:00  El-Kanemi Warriors FC      v Abia Warriors FC           1-0 (1-0)
+    16:00  Ifeanyi Ubah FC            v Enyimba FC                 1-0 (0-0)
+    16:00  Kano Pillars FC            v Rangers International FC   2-0 (2-0)
+    16:00  Lobi Stars FC              v Remo Stars FC              3-2 (2-1)
+    16:00  MFM FC                     v Wikki Tourists FC          1-0 (1-0)
+    16:00  Niger Tornadoes FC         v Plateau United FC          1-0 (1-0)
+    16:00  Shooting Stars SC          v Katsina United FC          1-0 (1-0)
+    16:00  Sunshine Stars FC          v Nasarawa United FC         0-1 (0-1)
+
+
+
+» Matchday 30
+  19.07.
+    16:00  Abia Warriors FC           v Akwa United FC             0-0 (0-0)
+    16:00  Enyimba FC                 v Lobi Stars FC              2-1 (0-1)
+    16:00  Gombe United FC            v Niger Tornadoes FC         0-0 (0-0)
+    16:00  Katsina United FC          v Kano Pillars FC            1-0 (1-0)
+    16:00  Nasarawa United FC         v El-Kanemi Warriors FC      2-1 (1-0)
+    16:00  Plateau United FC          v Ifeanyi Ubah FC            1-0 (1-0)
+    16:00  Remo Stars FC              v Shooting Stars SC          1-1 (0-0)
+    16:00  Rivers United FC           v Sunshine Stars FC          0-1 (0-0)
+    16:00  Wikki Tourists FC          v ABS FC                     1-0 (1-0)
+  20.07.
+    08:00  Rangers International FC   v MFM FC                     2-0 (1-0)
+
+
+
+» Matchday 31
+  23.07.
+    16:00  ABS FC                     v Rangers International FC   2-0 (1-0)
+    16:00  Akwa United FC             v Nasarawa United FC         2-1 (1-1)
+    16:00  Ifeanyi Ubah FC            v Gombe United FC            2-2 (2-0)
+    16:00  Kano Pillars FC            v Remo Stars FC              2-0 (2-0)
+    16:00  Lobi Stars FC              v Plateau United FC          0-0 (0-0)
+    16:00  Niger Tornadoes FC         v Abia Warriors FC           0-0 (0-0)
+    16:00  Rivers United FC           v Wikki Tourists FC          3-1 (2-0)
+    16:00  Shooting Stars SC          v Enyimba FC                 1-0 (1-0)
+    16:00  Sunshine Stars FC          v El-Kanemi Warriors FC      1-0 (1-0)
+  24.07.
+    08:00  MFM FC                     v Katsina United FC          3-2 (2-0)
+
+
+
+» Matchday 32
+  30.07.
+    16:00  Abia Warriors FC           v Ifeanyi Ubah FC            0-0 (0-0)
+    16:00  El-Kanemi Warriors FC      v Akwa United FC             1-0 (1-0)
+    16:00  Enyimba FC                 v Kano Pillars FC            1-0 (0-0)
+    16:00  Gombe United FC            v Lobi Stars FC              0-0 (0-0)
+    16:00  Katsina United FC          v ABS FC                     2-2 (1-1)
+    16:00  Nasarawa United FC         v Niger Tornadoes FC         1-0 (1-0)
+    16:00  Plateau United FC          v Shooting Stars SC          2-0 (1-0)
+    16:00  Remo Stars FC              v MFM FC                     0-1 (0-0)
+    16:00  Wikki Tourists FC          v Sunshine Stars FC          2-1 (1-1)
+  31.07.
+    08:00  Rangers International FC   v Rivers United FC           2-1 (2-0)
+
+
+
+» Matchday 33
+  06.08.
+    16:00  ABS FC                     v Remo Stars FC              2-0 (1-0)
+    16:00  Ifeanyi Ubah FC            v Nasarawa United FC         1-0 (1-0)
+    16:00  Kano Pillars FC            v Plateau United FC          1-1 (0-1)
+    16:00  Lobi Stars FC              v Abia Warriors FC           2-4 (1-1)
+    16:00  MFM FC                     v Enyimba FC                 0-0 (0-0)
+    16:00  Niger Tornadoes FC         v El-Kanemi Warriors FC      1-0 (0-0)
+    16:00  Shooting Stars SC          v Gombe United FC            2-1 (0-0)
+    16:00  Sunshine Stars FC          v Akwa United FC             1-0 (1-0)
+    16:00  Wikki Tourists FC          v Rangers International FC   1-1 (1-1)
+  07.08.
+    16:00  Rivers United FC           v Katsina United FC          1-1 (1-0)
+
+
+
+» Matchday 34
+  13.08.
+    16:00  Abia Warriors FC           v Shooting Stars SC          2-0 (2-0)
+    16:00  Akwa United FC             v Niger Tornadoes FC         3-0 (2-0)
+    16:00  Enyimba FC                 v ABS FC                     3-0 (2-0)
+    16:00  Gombe United FC            v Kano Pillars FC            1-0 (0-0)
+    16:00  Katsina United FC          v Wikki Tourists FC          2-0 (2-0)
+    16:00  Nasarawa United FC         v Lobi Stars FC              1-0 (0-0)
+    16:00  Plateau United FC          v MFM FC                     1-0 (1-0)
+    16:00  Rangers International FC   v Sunshine Stars FC          1-0 (1-0)
+    16:00  Remo Stars FC              v Rivers United FC           1-3 (0-2)
+  14.08.
+    08:00  El-Kanemi Warriors FC      v Ifeanyi Ubah FC            2-0 (1-0)
+
+
+
+» Matchday 35
+  20.08.
+    16:00  ABS FC                     v Plateau United FC          2-0 (1-0)
+    16:00  Ifeanyi Ubah FC            v Akwa United FC             1-0 (0-0)
+    16:00  Kano Pillars FC            v Abia Warriors FC           2-0 (2-0)
+    16:00  Lobi Stars FC              v El-Kanemi Warriors FC      3-2 (2-1)
+    16:00  MFM FC                     v Gombe United FC            1-0 (1-0)
+    16:00  Rangers International FC   v Katsina United FC          2-1 (1-1)
+    16:00  Rivers United FC           v Enyimba FC                 2-1 (2-1)
+    16:00  Shooting Stars SC          v Nasarawa United FC         2-0 (0-0)
+    16:00  Sunshine Stars FC          v Niger Tornadoes FC         2-1 (1-0)
+    16:00  Wikki Tourists FC          v Remo Stars FC              2-0 (1-0)
+
+
+
+» Matchday 36
+  25.08.
+    16:00  Akwa United FC             v Lobi Stars FC              2-1 (2-1)
+  27.08.
+    16:00  Abia Warriors FC           v MFM FC                     1-0 (0-0)
+    16:00  El-Kanemi Warriors FC      v Shooting Stars SC          1-1 (0-0)
+    16:00  Enyimba FC                 v Wikki Tourists FC          4-0 (3-0)
+    16:00  Gombe United FC            v ABS FC                     2-1 (1-1)
+    16:00  Katsina United FC          v Sunshine Stars FC          2-0 (1-0)
+    16:00  Nasarawa United FC         v Kano Pillars FC            1-0 (1-0)
+    16:00  Plateau United FC          v Rivers United FC           1-1 (0-1)
+    16:00  Remo Stars FC              v Rangers International FC   1-2 (0-1)
+  28.08.
+    08:00  Niger Tornadoes FC         v Ifeanyi Ubah FC            2-1 (0-1)
+
+
+
+» Matchday 37
+  03.09.
+    16:00  ABS FC                     v Abia Warriors FC           2-1 (0-1)
+    16:00  Kano Pillars FC            v El-Kanemi Warriors FC      2-0 (2-0)
+    16:00  Katsina United FC          v Remo Stars FC              3-0 (2-0)
+    16:00  Lobi Stars FC              v Niger Tornadoes FC         1-0 (0-0)
+    16:00  MFM FC                     v Nasarawa United FC         2-0 (2-0)
+    16:00  Rangers International FC   v Enyimba FC                 1-1 (0-1)
+    16:00  Rivers United FC           v Gombe United FC            3-0 (0-0)
+    16:00  Shooting Stars SC          v Akwa United FC             1-0 (0-0)
+    16:00  Sunshine Stars FC          v Ifeanyi Ubah FC            4-0 (1-0)
+    16:00  Wikki Tourists FC          v Plateau United FC          1-0 (0-0)
+
+
+
+» Matchday 38
+  09.09.
+    16:00  Abia Warriors FC           v Rivers United FC           4-1 (1-1)
+    16:00  Akwa United FC             v Kano Pillars FC            3-0 (1-0)
+    16:00  El-Kanemi Warriors FC      v MFM FC                     2-1 (2-1)
+    16:00  Enyimba FC                 v Katsina United FC          1-0 (1-0)
+    16:00  Ifeanyi Ubah FC            v Lobi Stars FC              1-1 (0-1)
+    16:00  Nasarawa United FC         v ABS FC                     2-1 (0-0)
+    16:00  Niger Tornadoes FC         v Shooting Stars SC          2-0 (1-0)
+    16:00  Plateau United FC          v Rangers International FC   2-0 (1-0)
+    16:00  Remo Stars FC              v Sunshine Stars FC          0-1 (0-0)
+  16.09.
+    16:00  Gombe United FC            v Wikki Tourists FC          0-2 (0-2)
+

--- a/africa/nigeria/2017-18_ng1.txt
+++ b/africa/nigeria/2017-18_ng1.txt
@@ -1,0 +1,402 @@
+= Nigeria | Premier Football League 2017/2018
+
+# Date       Fri Jan/13 2017 - Tue Jun/13 2017 (151d)
+# Teams      20
+# Matches    240
+
+
+
+» Matchday 1
+  13.01.
+    16:00  Katsina United FC          v Kano Pillars FC            2-2 (1-1)
+  14.01.
+    16:00  Abia Warriors FC           v MFM FC                     2-0 (0-0)
+    16:00  Akwa United FC             v Rangers International FC   2-0 (1-0)
+    16:00  Heartland FC               v Sunshine Stars FC          0-0 (0-0)
+    16:00  Ifeanyi Ubah FC            v Yobe Stars FC              2-1 (1-0)
+    16:00  Kwara United FC            v Niger Tornadoes FC         0-2 (0-1)
+    16:00  Lobi Stars FC              v Enyimba FC                 1-1 (0-1)
+    16:00  Nasarawa United FC         v Plateau United FC          0-1 (0-0)
+    16:00  Rivers United FC           v El-Kanemi Warriors FC      1-0 (0-0)
+    16:00  Wikki Tourists FC          v Go Round FC                1-0 (1-0)
+
+
+
+» Matchday 2
+  17.01.
+    16:00  El-Kanemi Warriors FC      v Abia Warriors FC           1-0 (1-0)
+    16:00  Enyimba FC                 v Heartland FC               0-0 (0-0)
+    16:00  Go Round FC                v Akwa United FC             1-0 (1-0)
+    16:00  Kano Pillars FC            v Nasarawa United FC         2-0 (1-0)
+    16:00  MFM FC                     v Kwara United FC            1-0 (0-0)
+    16:00  Niger Tornadoes FC         v Ifeanyi Ubah FC            2-1 (1-1)
+    16:00  Plateau United FC          v Rivers United FC           2-0 (1-0)
+    16:00  Rangers International FC   v Lobi Stars FC              1-2 (0-1)
+    16:00  Sunshine Stars FC          v Katsina United FC          2-1 (1-0)
+    16:00  Yobe Stars FC              v Wikki Tourists FC          2-0 (1-0)
+
+
+
+» Matchday 3
+  21.01.
+    16:00  Abia Warriors FC           v Plateau United FC          1-0 (1-0)
+    16:00  Akwa United FC             v Yobe Stars FC              2-0 (2-0)
+    16:00  El-Kanemi Warriors FC      v MFM FC                     3-1 (0-0)
+    16:00  Heartland FC               v Rangers International FC   0-1 (0-1)
+    16:00  Ifeanyi Ubah FC            v Kwara United FC            2-0 (1-0)
+    16:00  Katsina United FC          v Enyimba FC                 2-0 (1-0)
+    16:00  Lobi Stars FC              v Go Round FC                1-0 (1-0)
+    16:00  Nasarawa United FC         v Sunshine Stars FC          2-0 (1-0)
+    16:00  Rivers United FC           v Kano Pillars FC            2-1 (1-1)
+    16:00  Wikki Tourists FC          v Niger Tornadoes FC         1-0 (0-0)
+
+
+
+» Matchday 4
+  24.01.
+    16:00  Go Round FC                v Heartland FC               1-1 (1-0)
+    16:00  Kano Pillars FC            v Abia Warriors FC           2-1 (1-0)
+    16:00  Kwara United FC            v Wikki Tourists FC          1-0 (1-0)
+    16:00  MFM FC                     v Ifeanyi Ubah FC            2-1 (2-1)
+    16:00  Niger Tornadoes FC         v Akwa United FC             1-2 (1-1)
+    16:00  Plateau United FC          v El-Kanemi Warriors FC      3-0 (2-0)
+    16:00  Rangers International FC   v Katsina United FC          1-0 (0-0)
+    16:00  Sunshine Stars FC          v Rivers United FC           2-0 (0-0)
+    16:00  Yobe Stars FC              v Lobi Stars FC              1-0 (0-0)
+  25.01.
+    16:00  Enyimba FC                 v Nasarawa United FC         1-0 (0-0)
+
+
+
+» Matchday 5
+  27.01.
+    16:00  Plateau United FC          v MFM FC                     1-0 (1-0)
+  28.01.
+    16:00  Abia Warriors FC           v Sunshine Stars FC          0-0 (0-0)
+    16:00  Akwa United FC             v Kwara United FC            3-0 (2-0)
+    16:00  El-Kanemi Warriors FC      v Kano Pillars FC            0-0 (0-0)
+    16:00  Heartland FC               v Yobe Stars FC              1-1 (1-1)
+    16:00  Katsina United FC          v Go Round FC                3-0 (2-0)
+    16:00  Lobi Stars FC              v Niger Tornadoes FC         3-1 (2-1)
+    16:00  Rivers United FC           v Enyimba FC                 1-1 (0-1)
+    16:00  Wikki Tourists FC          v Ifeanyi Ubah FC            1-0 (1-0)
+  29.01.
+    16:00  Nasarawa United FC         v Rangers International FC   2-1 (1-0)
+
+
+
+» Matchday 6
+  01.02.
+    16:00  Go Round FC                v Nasarawa United FC         2-1 (0-0)
+    16:00  Kwara United FC            v Lobi Stars FC              1-0 (1-0)
+    16:00  Rangers International FC   v Rivers United FC           1-0 (0-0)
+  07.02.
+    16:00  Niger Tornadoes FC         v Heartland FC               1-2 (0-2)
+  31.01.
+    16:00  Enyimba FC                 v Abia Warriors FC           1-0 (0-0)
+    16:00  Ifeanyi Ubah FC            v Akwa United FC             1-1 (0-1)
+    16:00  Kano Pillars FC            v Plateau United FC          2-0 (2-0)
+    16:00  MFM FC                     v Wikki Tourists FC          2-1 (2-1)
+    16:00  Sunshine Stars FC          v El-Kanemi Warriors FC      1-0 (1-0)
+    16:00  Yobe Stars FC              v Katsina United FC          1-0 (0-0)
+
+
+
+» Matchday 7
+  04.02.
+    16:00  Abia Warriors FC           v Rangers International FC   0-0 (0-0)
+    16:00  Akwa United FC             v Wikki Tourists FC          4-0 (1-0)
+    16:00  El-Kanemi Warriors FC      v Enyimba FC                 0-0 (0-0)
+    16:00  Heartland FC               v Kwara United FC            2-0 (1-0)
+    16:00  Kano Pillars FC            v MFM FC                     2-0 (0-0)
+    16:00  Katsina United FC          v Niger Tornadoes FC         2-0 (1-0)
+    16:00  Lobi Stars FC              v Ifeanyi Ubah FC            1-0 (1-0)
+    16:00  Plateau United FC          v Sunshine Stars FC          5-0 (3-0)
+    16:00  Rivers United FC           v Go Round FC                1-0 (0-0)
+  05.02.
+    16:00  Nasarawa United FC         v Yobe Stars FC              3-0 (2-0)
+
+
+
+» Matchday 8
+  11.02.
+    16:00  Go Round FC                v Abia Warriors FC           1-0 (1-0)
+    16:00  Ifeanyi Ubah FC            v Heartland FC               2-0 (1-0)
+    16:00  Kwara United FC            v Katsina United FC          2-1 (0-0)
+    16:00  Niger Tornadoes FC         v Nasarawa United FC         1-0 (1-0)
+    16:00  Rangers International FC   v El-Kanemi Warriors FC      1-0 (0-0)
+    16:00  Sunshine Stars FC          v Kano Pillars FC            0-0 (0-0)
+    16:00  Yobe Stars FC              v Rivers United FC           1-0 (0-0)
+  12.02.
+    16:00  Wikki Tourists FC          v Lobi Stars FC              1-0 (0-0)
+  14.02.
+    16:00  Enyimba FC                 v Plateau United FC          1-0 (1-0)
+  16.02.
+    16:00  MFM FC                     v Akwa United FC             1-0 (1-0)
+
+
+
+» Matchday 9
+  18.02.
+    16:00  Abia Warriors FC           v Yobe Stars FC              3-1 (3-0)
+    16:00  El-Kanemi Warriors FC      v Go Round FC                2-1 (1-1)
+    16:00  Heartland FC               v Wikki Tourists FC          2-1 (1-1)
+    16:00  Kano Pillars FC            v Enyimba FC                 1-1 (1-1)
+    16:00  Katsina United FC          v Ifeanyi Ubah FC            3-0 (2-0)
+    16:00  Nasarawa United FC         v Kwara United FC            3-3 (1-0)
+    16:00  Rivers United FC           v Niger Tornadoes FC         2-0 (2-0)
+  28.02.
+    16:00  Lobi Stars FC              v Akwa United FC             1-0 (1-0)
+    16:00  Plateau United FC          v Rangers International FC   1-0 (0-0)
+    16:00  Sunshine Stars FC          v MFM FC                     2-1 (1-0)
+
+
+
+» Matchday 10
+  21.03.
+    16:00  Akwa United FC             v Heartland FC               2-1 (1-1)
+  22.03.
+    16:00  Go Round FC                v Plateau United FC          1-0 (1-0)
+  25.02.
+    16:00  Enyimba FC                 v Sunshine Stars FC          2-1 (1-0)
+    16:00  Ifeanyi Ubah FC            v Nasarawa United FC         1-0 (0-0)
+    16:00  Kwara United FC            v Rivers United FC           0-1 (0-0)
+    16:00  MFM FC                     v Lobi Stars FC              0-0 (0-0)
+    16:00  Niger Tornadoes FC         v Abia Warriors FC           2-0 (0-0)
+    16:00  Rangers International FC   v Kano Pillars FC            1-1 (1-0)
+    16:00  Wikki Tourists FC          v Katsina United FC          1-1 (1-0)
+    16:00  Yobe Stars FC              v El-Kanemi Warriors FC      2-0 (2-0)
+
+
+
+» Matchday 11
+  04.03.
+    16:00  Abia Warriors FC           v Kwara United FC            1-0 (0-0)
+    16:00  El-Kanemi Warriors FC      v Niger Tornadoes FC         0-0 (0-0)
+    16:00  Heartland FC               v Lobi Stars FC              0-1 (0-1)
+    16:00  Kano Pillars FC            v Go Round FC                2-0 (0-0)
+    16:00  Nasarawa United FC         v Wikki Tourists FC          1-0 (0-0)
+    16:00  Rivers United FC           v Ifeanyi Ubah FC            1-1 (0-0)
+    16:00  Sunshine Stars FC          v Rangers International FC   1-1 (1-1)
+  28.03.
+    16:00  Enyimba FC                 v MFM FC                     2-0 (2-0)
+    16:00  Plateau United FC          v Yobe Stars FC              2-1 (1-1)
+  29.03.
+    16:00  Katsina United FC          v Akwa United FC             2-0 (2-0)
+
+
+
+» Matchday 12
+  11.03.
+    16:00  Go Round FC                v Sunshine Stars FC          1-0 (1-0)
+    16:00  Ifeanyi Ubah FC            v Abia Warriors FC           1-1 (1-0)
+    16:00  Kwara United FC            v El-Kanemi Warriors FC      1-1 (0-1)
+    16:00  Lobi Stars FC              v Katsina United FC          1-0 (0-0)
+    16:00  MFM FC                     v Heartland FC               3-0 (1-0)
+    16:00  Niger Tornadoes FC         v Plateau United FC          1-0 (1-0)
+    16:00  Rangers International FC   v Enyimba FC                 1-0 (1-0)
+    16:00  Wikki Tourists FC          v Rivers United FC           3-0 (0-0)
+    16:00  Yobe Stars FC              v Kano Pillars FC            2-0 (1-0)
+  12.03.
+    16:00  Akwa United FC             v Nasarawa United FC         1-0 (1-0)
+
+
+
+» Matchday 13
+  12.04.
+    16:00  Rivers United FC           v Akwa United FC             2-0 (1-0)
+  18.03.
+    16:00  Abia Warriors FC           v Wikki Tourists FC          2-0 (0-0)
+    16:00  El-Kanemi Warriors FC      v Ifeanyi Ubah FC            1-0 (1-0)
+    16:00  Katsina United FC          v Heartland FC               1-0 (1-0)
+    16:00  Nasarawa United FC         v Lobi Stars FC              2-1 (2-1)
+    16:00  Sunshine Stars FC          v Yobe Stars FC              2-1 (1-1)
+  19.03.
+    16:00  Kano Pillars FC            v Niger Tornadoes FC         1-1 (0-1)
+  25.04.
+    16:00  Enyimba FC                 v Go Round FC                2-0 (0-0)
+  26.04.
+    16:00  Plateau United FC          v Kwara United FC            2-0 (1-0)
+    16:00  Rangers International FC   v MFM FC                     0-0 (0-0)
+
+
+
+» Matchday 14
+  25.03.
+    16:00  Akwa United FC             v Abia Warriors FC           1-1 (0-0)
+    16:00  Go Round FC                v Rangers International FC   2-2 (0-2)
+    16:00  Heartland FC               v Nasarawa United FC         2-1 (1-0)
+    16:00  Ifeanyi Ubah FC            v Plateau United FC          3-0 (1-0)
+    16:00  Kwara United FC            v Kano Pillars FC            2-1 (0-1)
+    16:00  Lobi Stars FC              v Rivers United FC           3-2 (1-2)
+    16:00  MFM FC                     v Katsina United FC          2-1 (0-1)
+    16:00  Niger Tornadoes FC         v Sunshine Stars FC          1-0 (1-0)
+    16:00  Wikki Tourists FC          v El-Kanemi Warriors FC      3-0 (1-0)
+    16:00  Yobe Stars FC              v Enyimba FC                 1-1 (0-1)
+
+
+
+» Matchday 15
+  02.05.
+    16:00  Go Round FC                v MFM FC                     1-0 (0-0)
+    16:00  Plateau United FC          v Wikki Tourists FC          1-1 (1-0)
+  04.04.
+    16:00  Abia Warriors FC           v Lobi Stars FC              1-1 (1-0)
+    16:00  Kano Pillars FC            v Ifeanyi Ubah FC            4-0 (0-0)
+    16:00  Nasarawa United FC         v Katsina United FC          2-1 (2-1)
+    16:00  Rangers International FC   v Yobe Stars FC              3-0 (2-0)
+    16:00  Rivers United FC           v Heartland FC               2-0 (0-0)
+    16:00  Sunshine Stars FC          v Kwara United FC            2-2 (1-1)
+  17.05.
+    16:00  El-Kanemi Warriors FC      v Akwa United FC             2-0 (1-0)
+  23.05.
+    16:00  Enyimba FC                 v Niger Tornadoes FC         1-0 (0-0)
+
+
+
+» Matchday 16
+  08.04.
+    16:00  Heartland FC               v Abia Warriors FC           0-0 (0-0)
+    16:00  Ifeanyi Ubah FC            v Sunshine Stars FC          3-1 (1-1)
+    16:00  Katsina United FC          v Rivers United FC           2-1 (1-1)
+    16:00  Lobi Stars FC              v El-Kanemi Warriors FC      1-0 (0-0)
+    16:00  Niger Tornadoes FC         v Rangers International FC   1-0 (1-0)
+    16:00  Wikki Tourists FC          v Kano Pillars FC            1-1 (1-1)
+    16:00  Yobe Stars FC              v Go Round FC                1-0 (0-0)
+  09.05.
+    16:00  Akwa United FC             v Plateau United FC          1-1 (0-0)
+  11.04.
+    16:00  Kwara United FC            v Enyimba FC                 1-1 (0-1)
+  12.04.
+    16:00  MFM FC                     v Nasarawa United FC         2-1 (2-0)
+
+
+
+» Matchday 17
+  02.05.
+    16:00  Kano Pillars FC            v Akwa United FC             1-0 (1-0)
+  09.05.
+    16:00  Enyimba FC                 v Ifeanyi Ubah FC            1-1 (0-1)
+    16:00  Yobe Stars FC              v MFM FC                     1-0 (0-0)
+  15.04.
+    16:00  Abia Warriors FC           v Katsina United FC          1-1 (1-1)
+    16:00  El-Kanemi Warriors FC      v Heartland FC               3-0 (1-0)
+    16:00  Go Round FC                v Niger Tornadoes FC         1-1 (1-1)
+    16:00  Rangers International FC   v Kwara United FC            0-0 (0-0)
+    16:00  Rivers United FC           v Nasarawa United FC         1-0 (1-0)
+    16:00  Sunshine Stars FC          v Wikki Tourists FC          2-1 (1-1)
+  16.05.
+    16:00  Plateau United FC          v Lobi Stars FC              2-1 (1-1)
+
+
+
+» Matchday 18
+  22.04.
+    16:00  Akwa United FC             v Sunshine Stars FC          2-1 (1-0)
+    16:00  Ifeanyi Ubah FC            v Rangers International FC   0-0 (0-0)
+    16:00  Katsina United FC          v El-Kanemi Warriors FC      1-0 (0-0)
+    16:00  Kwara United FC            v Go Round FC                1-1 (1-0)
+    16:00  Lobi Stars FC              v Kano Pillars FC            1-0 (0-0)
+    16:00  Nasarawa United FC         v Abia Warriors FC           1-0 (1-0)
+    16:00  Niger Tornadoes FC         v Yobe Stars FC              1-0 (0-0)
+    16:00  Wikki Tourists FC          v Enyimba FC                 0-0 (0-0)
+  23.04.
+    16:00  Heartland FC               v Plateau United FC          1-1 (1-0)
+    16:00  MFM FC                     v Rivers United FC           1-1 (1-0)
+
+
+
+» Matchday 19
+  29.04.
+    16:00  Abia Warriors FC           v Rivers United FC           2-1 (1-0)
+    16:00  El-Kanemi Warriors FC      v Nasarawa United FC         2-0 (1-0)
+    16:00  Enyimba FC                 v Akwa United FC             0-0 (0-0)
+    16:00  Go Round FC                v Ifeanyi Ubah FC            0-0 (0-0)
+    16:00  Kano Pillars FC            v Heartland FC               2-0 (1-0)
+    16:00  Niger Tornadoes FC         v MFM FC                     1-0 (1-0)
+    16:00  Plateau United FC          v Katsina United FC          1-0 (0-0)
+    16:00  Rangers International FC   v Wikki Tourists FC          3-0 (1-0)
+    16:00  Sunshine Stars FC          v Lobi Stars FC              1-1 (0-0)
+    16:00  Yobe Stars FC              v Kwara United FC            0-0 (0-0)
+
+
+
+» Matchday 20
+  06.05.
+    16:00  Heartland FC               v Kano Pillars FC            1-1 (1-0)
+    16:00  Ifeanyi Ubah FC            v Go Round FC                2-1 (1-1)
+    16:00  Katsina United FC          v Plateau United FC          1-0 (1-0)
+    16:00  Kwara United FC            v Yobe Stars FC              2-1 (1-1)
+    16:00  Lobi Stars FC              v Sunshine Stars FC          1-0 (0-0)
+    16:00  MFM FC                     v Niger Tornadoes FC         3-0 (2-0)
+    16:00  Nasarawa United FC         v El-Kanemi Warriors FC      2-0 (2-0)
+    16:00  Rivers United FC           v Abia Warriors FC           0-0 (0-0)
+    16:00  Wikki Tourists FC          v Rangers International FC   1-1 (1-1)
+  30.05.
+    16:00  Akwa United FC             v Enyimba FC                 2-1 (1-0)
+
+
+
+» Matchday 21
+  06.06.
+    16:00  Enyimba FC                 v Lobi Stars FC              1-0 (0-0)
+  13.05.
+    16:00  El-Kanemi Warriors FC      v Rivers United FC           1-1 (0-1)
+    16:00  Go Round FC                v Wikki Tourists FC          1-0 (0-0)
+    16:00  Kano Pillars FC            v Katsina United FC          3-1 (2-0)
+    16:00  MFM FC                     v Abia Warriors FC           0-1 (0-0)
+    16:00  Niger Tornadoes FC         v Kwara United FC            1-1 (0-1)
+    16:00  Plateau United FC          v Nasarawa United FC         2-1 (1-0)
+    16:00  Rangers International FC   v Akwa United FC             0-0 (0-0)
+    16:00  Sunshine Stars FC          v Heartland FC               2-1 (2-0)
+    16:00  Yobe Stars FC              v Ifeanyi Ubah FC            1-1 (0-1)
+
+
+
+» Matchday 22
+  13.06.
+    16:00  Heartland FC               v Enyimba FC                 0-0 (0-0)
+  20.05.
+    16:00  Ifeanyi Ubah FC            v Niger Tornadoes FC         1-2 (0-0)
+    16:00  Katsina United FC          v Sunshine Stars FC          1-0 (0-0)
+    16:00  Kwara United FC            v MFM FC                     3-1 (1-1)
+    16:00  Lobi Stars FC              v Rangers International FC   1-0 (0-0)
+    16:00  Nasarawa United FC         v Kano Pillars FC            0-0 (0-0)
+    16:00  Rivers United FC           v Plateau United FC          1-0 (1-0)
+    16:00  Wikki Tourists FC          v Yobe Stars FC              3-1 (1-0)
+  21.05.
+    16:00  Abia Warriors FC           v El-Kanemi Warriors FC      1-0 (0-0)
+  23.05.
+    16:00  Akwa United FC             v Go Round FC                1-0 (1-0)
+
+
+
+» Matchday 23
+  10.06.
+    16:00  Enyimba FC                 v Katsina United FC          2-0 (1-0)
+    16:00  Go Round FC                v Lobi Stars FC              1-0 (0-0)
+    16:00  Kano Pillars FC            v Rivers United FC           1-1 (0-1)
+    16:00  Kwara United FC            v Ifeanyi Ubah FC            1-0 (1-0)
+    16:00  Niger Tornadoes FC         v Wikki Tourists FC          1-0 (1-0)
+    16:00  Plateau United FC          v Abia Warriors FC           2-2 (0-0)
+    16:00  Rangers International FC   v Heartland FC               1-0 (1-0)
+    16:00  Sunshine Stars FC          v Nasarawa United FC         2-0 (1-0)
+    16:00  Yobe Stars FC              v Akwa United FC             0-1 (0-0)
+  11.06.
+    08:00  MFM FC                     v El-Kanemi Warriors FC      1-0 (1-0)
+
+
+
+» Matchday 24
+  03.06.
+    16:00  Abia Warriors FC           v Kano Pillars FC            0-0 (0-0)
+    16:00  Akwa United FC             v Niger Tornadoes FC         2-0 (1-0)
+    16:00  El-Kanemi Warriors FC      v Plateau United FC          1-0 (0-0)
+    16:00  Heartland FC               v Go Round FC                1-0 (0-0)
+    16:00  Ifeanyi Ubah FC            v MFM FC                     0-1 (0-0)
+    16:00  Katsina United FC          v Rangers International FC   1-0 (1-0)
+    16:00  Lobi Stars FC              v Yobe Stars FC              3-0 (2-0)
+    16:00  Nasarawa United FC         v Enyimba FC                 4-3 (3-1)
+    16:00  Rivers United FC           v Sunshine Stars FC          0-0 (0-0)
+    16:00  Wikki Tourists FC          v Kwara United FC            1-0 (1-0)
+

--- a/africa/nigeria/2018-19_ng1.txt
+++ b/africa/nigeria/2018-19_ng1.txt
@@ -1,0 +1,468 @@
+= Nigeria | Premier Football League 2018/2019
+
+# Date       Sat Jan/13 2018 - Tue Jun/12 2018 (150d)
+# Teams      25
+# Matches    279
+# Stages     NPFL - Championship Group (15)  NPFL (264)
+
+
+
+======================================================================
+  NPFL - CHAMPIONSHIP GROUP
+======================================================================
+
+
+
+» Matchday 1
+  04.06.
+    15:00  Enyimba FC                 v Rangers International FC   1-0 (0-0)
+    17:00  Kano Pillars FC            v Akwa United FC             2-2 (2-2)
+    19:00  Ifeanyi Ubah FC            v Lobi Stars FC              1-3 (1-1)
+
+
+
+» Matchday 2
+  06.06.
+    15:00  Akwa United FC             v Ifeanyi Ubah FC            2-1 (0-1)
+    17:00  Rangers International FC   v Lobi Stars FC              2-1 (2-0)
+  07.06.
+    09:00  Kano Pillars FC            v Enyimba FC                 2-0 (0-0)
+
+
+
+» Matchday 3
+  08.06.
+    15:00  Kano Pillars FC            v Ifeanyi Ubah FC            2-1 (1-0)
+    17:00  Lobi Stars FC              v Enyimba FC                 1-3 (1-2)
+    19:00  Akwa United FC             v Rangers International FC   3-3 (0-0)
+
+
+
+» Matchday 4
+  10.06.
+    15:00  Rangers International FC   v Kano Pillars FC            1-1 (0-0)
+    17:00  Akwa United FC             v Lobi Stars FC              0-0 (0-0)
+    19:00  Enyimba FC                 v Ifeanyi Ubah FC            3-1 (2-1)
+
+
+
+» Matchday 5
+  12.06.
+    15:00  Ifeanyi Ubah FC            v Rangers International FC   2-4 (0-2)
+    17:00  Enyimba FC                 v Akwa United FC             3-0 (1-0)
+    19:00  Lobi Stars FC              v Kano Pillars FC            0-1 (0-0)
+
+
+======================================================================
+  NPFL
+======================================================================
+
+
+
+» Matchday 1
+  03.03.
+    16:00  Lobi Stars FC              v Katsina United FC          1-1 (0-1)
+  13.01.
+    16:00  Akwa United FC             v El-Kanemi Warriors FC      0-1 (0-0)
+    16:00  Enyimba FC                 v MFM FC                     2-0 (1-0)
+    16:00  Kano Pillars FC            v Heartland FC               1-0 (1-0)
+    16:00  Kwara United FC            v Sunshine Stars FC          1-1 (0-1)
+    16:00  Nasarawa United FC         v Abia Warriors FC           1-0 (1-0)
+    16:00  Plateau United FC          v Ifeanyi Ubah FC            0-0 (0-0)
+  30.01.
+    16:00  Rangers International FC   v Niger Tornadoes FC         1-0 (1-0)
+    16:00  Rivers United FC           v Remo Stars FC              1-0 (0-0)
+    16:00  Wikki Tourists FC          v Bendel FC                  1-0 (0-0)
+    16:00  Yobe Stars FC              v Gombe United FC            1-0 (1-0)
+  31.01.
+    16:00  Go Round FC                v Kada City FC               0-0 (0-0)
+
+
+
+» Matchday 2
+  03.03.
+    16:00  Bendel FC                  v Enyimba FC                 0-0 (0-0)
+    16:00  Gombe United FC            v Akwa United FC             2-2 (1-0)
+    16:00  Kada City FC               v Yobe Stars FC              2-1 (1-0)
+    16:00  Remo Stars FC              v Wikki Tourists FC          2-1 (1-1)
+  03.04.
+    16:00  Katsina United FC          v Rangers International FC   1-1 (1-0)
+  11.04.
+    16:00  Sunshine Stars FC          v Lobi Stars FC              3-0 (0-0)
+  16.01.
+    16:00  Abia Warriors FC           v Go Round FC                1-2 (0-1)
+    16:00  Heartland FC               v Plateau United FC          3-0 (0-0)
+    16:00  Ifeanyi Ubah FC            v Nasarawa United FC         1-0 (0-0)
+    16:00  MFM FC                     v Kwara United FC            2-0 (0-0)
+    16:00  Niger Tornadoes FC         v Rivers United FC           1-1 (0-0)
+  17.01.
+    16:00  El-Kanemi Warriors FC      v Kano Pillars FC            2-1 (1-1)
+
+
+
+» Matchday 3
+  06.03.
+    16:00  Rivers United FC           v Katsina United FC          1-0 (1-0)
+  13.03.
+    16:00  Lobi Stars FC              v MFM FC                     2-1 (1-1)
+  20.01.
+    14:00  Plateau United FC          v El-Kanemi Warriors FC      2-0 (0-0)
+    16:00  Go Round FC                v Ifeanyi Ubah FC            0-0 (0-0)
+    16:00  Kada City FC               v Gombe United FC            2-1 (2-1)
+    16:00  Kano Pillars FC            v Akwa United FC             1-1 (1-1)
+    16:00  Kwara United FC            v Enyimba FC                 3-2 (1-1)
+    16:00  Nasarawa United FC         v Heartland FC               0-1 (0-1)
+    16:00  Remo Stars FC              v Bendel FC                  1-1 (0-0)
+    16:00  Wikki Tourists FC          v Niger Tornadoes FC         2-1 (0-0)
+  20.03.
+    16:00  Yobe Stars FC              v Abia Warriors FC           1-3 (0-1)
+  21.03.
+    16:00  Rangers International FC   v Sunshine Stars FC          1-0 (1-0)
+
+
+
+» Matchday 4
+  23.01.
+    16:00  Abia Warriors FC           v Kada City FC               1-0 (0-0)
+    16:00  Akwa United FC             v Plateau United FC          2-2 (1-0)
+    16:00  Bendel FC                  v Kwara United FC            0-0 (0-0)
+    16:00  Enyimba FC                 v Lobi Stars FC              0-0 (0-0)
+    16:00  Gombe United FC            v Kano Pillars FC            2-0 (1-0)
+    16:00  Heartland FC               v Go Round FC                1-0 (0-0)
+    16:00  Ifeanyi Ubah FC            v Yobe Stars FC              1-0 (1-0)
+    16:00  Katsina United FC          v Wikki Tourists FC          1-0 (0-0)
+    16:00  MFM FC                     v Rangers International FC   1-0 (1-0)
+    16:00  Niger Tornadoes FC         v Remo Stars FC              0-0 (0-0)
+    16:00  Sunshine Stars FC          v Rivers United FC           1-1 (0-0)
+  24.01.
+    16:00  El-Kanemi Warriors FC      v Nasarawa United FC         1-0 (0-0)
+
+
+
+» Matchday 5
+  27.01.
+    16:00  Abia Warriors FC           v Gombe United FC            0-0 (0-0)
+    16:00  Kada City FC               v Ifeanyi Ubah FC            0-1 (0-0)
+    16:00  Lobi Stars FC              v Kwara United FC            3-0 (3-0)
+    16:00  Niger Tornadoes FC         v Bendel FC                  0-0 (0-0)
+    16:00  Plateau United FC          v Kano Pillars FC            0-0 (0-0)
+    16:00  Rangers International FC   v Enyimba FC                 1-0 (1-0)
+    16:00  Remo Stars FC              v Katsina United FC          2-0 (1-0)
+    16:00  Rivers United FC           v MFM FC                     1-0 (0-0)
+    16:00  Wikki Tourists FC          v Sunshine Stars FC          0-1 (0-0)
+    16:00  Yobe Stars FC              v Heartland FC               1-0 (0-0)
+  28.01.
+    16:00  Go Round FC                v El-Kanemi Warriors FC      1-0 (0-0)
+    16:00  Nasarawa United FC         v Akwa United FC             2-0 (0-0)
+
+
+
+» Matchday 6
+  03.02.
+    16:00  Akwa United FC             v Go Round FC                3-0 (0-0)
+    16:00  El-Kanemi Warriors FC      v Yobe Stars FC              2-1 (1-1)
+    16:00  Enyimba FC                 v Rivers United FC           2-0 (1-0)
+    16:00  Gombe United FC            v Plateau United FC          0-0 (0-0)
+    16:00  Heartland FC               v Kada City FC               3-2 (1-2)
+    16:00  Ifeanyi Ubah FC            v Abia Warriors FC           1-2 (1-1)
+    16:00  Kano Pillars FC            v Nasarawa United FC         3-0 (3-0)
+    16:00  Katsina United FC          v Niger Tornadoes FC         3-1 (1-0)
+    16:00  MFM FC                     v Wikki Tourists FC          1-0 (0-0)
+    16:00  Sunshine Stars FC          v Remo Stars FC              2-1 (1-1)
+  04.02.
+    16:00  Bendel FC                  v Lobi Stars FC              1-0 (0-0)
+  10.04.
+    16:00  Kwara United FC            v Rangers International FC   1-2 (0-2)
+
+
+
+» Matchday 7
+  06.02.
+    16:00  Abia Warriors FC           v Heartland FC               1-0 (1-0)
+    16:00  Go Round FC                v Kano Pillars FC            2-1 (1-1)
+    16:00  Ifeanyi Ubah FC            v Gombe United FC            2-0 (0-0)
+    16:00  Kada City FC               v El-Kanemi Warriors FC      2-1 (0-1)
+    16:00  Remo Stars FC              v MFM FC                     0-1 (0-1)
+    16:00  Rivers United FC           v Kwara United FC            0-0 (0-0)
+  07.02.
+    16:00  Nasarawa United FC         v Plateau United FC          2-1 (1-0)
+    16:00  Niger Tornadoes FC         v Sunshine Stars FC          1-0 (1-0)
+    16:00  Wikki Tourists FC          v Enyimba FC                 2-1 (1-1)
+    16:00  Yobe Stars FC              v Akwa United FC             0-1 (0-1)
+  08.02.
+    16:00  Katsina United FC          v Bendel FC                  2-1 (1-1)
+  17.04.
+    16:00  Rangers International FC   v Lobi Stars FC              1-1 (0-0)
+
+
+
+» Matchday 8
+  10.02.
+    16:00  El-Kanemi Warriors FC      v Abia Warriors FC           1-0 (0-0)
+    16:00  Enyimba FC                 v Remo Stars FC              1-0 (0-0)
+    16:00  Heartland FC               v Ifeanyi Ubah FC            1-1 (1-0)
+    16:00  Kano Pillars FC            v Yobe Stars FC              3-1 (2-0)
+    16:00  Kwara United FC            v Wikki Tourists FC          1-0 (1-0)
+    16:00  MFM FC                     v Niger Tornadoes FC         3-2 (1-2)
+    16:00  Plateau United FC          v Go Round FC                1-0 (0-0)
+  11.02.
+    16:00  Akwa United FC             v Kada City FC               4-0 (2-0)
+    16:00  Gombe United FC            v Nasarawa United FC         5-2 (3-1)
+    16:00  Sunshine Stars FC          v Katsina United FC          2-0 (0-0)
+  20.03.
+    16:00  Lobi Stars FC              v Rivers United FC           2-1 (1-0)
+  25.04.
+    16:00  Bendel FC                  v Rangers International FC   2-1 (1-1)
+
+
+
+» Matchday 9
+  02.05.
+    16:00  Rivers United FC           v Rangers International FC   3-0 (1-0)
+  04.04.
+    16:00  Wikki Tourists FC          v Lobi Stars FC              1-1 (1-1)
+  13.02.
+    16:00  Niger Tornadoes FC         v Enyimba FC                 0-0 (0-0)
+    16:00  Yobe Stars FC              v Plateau United FC          0-0 (0-0)
+  14.02.
+    16:00  Abia Warriors FC           v Akwa United FC             1-1 (1-1)
+    16:00  Go Round FC                v Nasarawa United FC         1-1 (1-1)
+    16:00  Heartland FC               v Gombe United FC            1-1 (1-0)
+    16:00  Ifeanyi Ubah FC            v El-Kanemi Warriors FC      1-0 (1-0)
+    16:00  Remo Stars FC              v Kwara United FC            2-1 (1-1)
+    16:00  Sunshine Stars FC          v Bendel FC                  1-1 (0-0)
+  20.03.
+    16:00  Kada City FC               v Kano Pillars FC            0-2 (0-1)
+    16:00  Katsina United FC          v MFM FC                     1-1 (0-1)
+
+
+
+» Matchday 10
+  20.02.
+    16:00  Akwa United FC             v Ifeanyi Ubah FC            1-0 (1-0)
+    16:00  Bendel FC                  v Rivers United FC           1-1 (1-0)
+    16:00  El-Kanemi Warriors FC      v Heartland FC               2-0 (0-0)
+    16:00  Enyimba FC                 v Katsina United FC          2-0 (1-0)
+    16:00  Gombe United FC            v Go Round FC                0-1 (0-1)
+    16:00  Kano Pillars FC            v Abia Warriors FC           2-0 (0-0)
+    16:00  Kwara United FC            v Niger Tornadoes FC         2-0 (0-0)
+    16:00  Lobi Stars FC              v Remo Stars FC              2-1 (1-1)
+    16:00  MFM FC                     v Sunshine Stars FC          2-0 (1-0)
+    16:00  Nasarawa United FC         v Yobe Stars FC              1-0 (1-0)
+    16:00  Plateau United FC          v Kada City FC               0-1 (0-0)
+    16:00  Rangers International FC   v Wikki Tourists FC          2-1 (0-0)
+
+
+
+» Matchday 11
+  17.03.
+    16:00  Abia Warriors FC           v Plateau United FC          1-1 (0-0)
+    16:00  El-Kanemi Warriors FC      v Gombe United FC            0-0 (0-0)
+    16:00  Heartland FC               v Akwa United FC             1-2 (0-1)
+    16:00  Ifeanyi Ubah FC            v Kano Pillars FC            1-0 (0-0)
+    16:00  Kada City FC               v Nasarawa United FC         2-1 (0-0)
+    16:00  Katsina United FC          v Kwara United FC            1-0 (1-0)
+    16:00  MFM FC                     v Bendel FC                  2-0 (1-0)
+    16:00  Sunshine Stars FC          v Enyimba FC                 0-0 (0-0)
+    16:00  Wikki Tourists FC          v Rivers United FC           2-0 (1-0)
+    16:00  Yobe Stars FC              v Go Round FC                2-0 (1-0)
+  27.03.
+    16:00  Lobi Stars FC              v Niger Tornadoes FC         2-2 (1-1)
+    16:00  Remo Stars FC              v Rangers International FC   0-0 (0-0)
+
+
+
+» Matchday 12
+  03.04.
+    16:00  Nasarawa United FC         v Delta Force FC             4-1 (3-0)
+  23.03.
+    16:00  Bendel FC                  v MFM FC                     1-0 (1-0)
+  24.03.
+    16:00  Akwa United FC             v Heartland FC               1-0 (0-0)
+    16:00  Enyimba FC                 v Sunshine Stars FC          2-1 (1-0)
+    16:00  Go Round FC                v Yobe Stars FC              1-0 (0-0)
+    16:00  Gombe United FC            v El-Kanemi Warriors FC      0-1 (0-0)
+    16:00  Kwara United FC            v Katsina United FC          1-0 (1-0)
+    16:00  Niger Tornadoes FC         v Lobi Stars FC              2-2 (1-0)
+    16:00  Plateau United FC          v Abia Warriors FC           1-0 (1-0)
+    16:00  Rangers International FC   v Remo Stars FC              5-2 (2-1)
+    16:00  Rivers United FC           v Wikki Tourists FC          1-2 (1-2)
+  27.03.
+    16:00  Kano Pillars FC            v Ifeanyi Ubah FC            3-0 (1-0)
+
+
+
+» Matchday 13
+  31.03.
+    16:00  Abia Warriors FC           v Nasarawa United FC         0-1 (0-0)
+    16:00  Bendel FC                  v Wikki Tourists FC          2-0 (0-0)
+    16:00  El-Kanemi Warriors FC      v Akwa United FC             4-1 (1-0)
+    16:00  Gombe United FC            v Yobe Stars FC              1-0 (1-0)
+    16:00  Heartland FC               v Kano Pillars FC            2-1 (2-1)
+    16:00  Ifeanyi Ubah FC            v Plateau United FC          1-0 (0-0)
+    16:00  Katsina United FC          v Lobi Stars FC              2-0 (1-0)
+    16:00  MFM FC                     v Enyimba FC                 1-1 (0-0)
+    16:00  Niger Tornadoes FC         v Rangers International FC   0-0 (0-0)
+    16:00  Remo Stars FC              v Rivers United FC           0-1 (0-0)
+    16:00  Sunshine Stars FC          v Kwara United FC            1-0 (0-0)
+    18:00  Delta Force FC             v Go Round FC                1-0 (1-0)
+
+
+
+» Matchday 14
+  07.04.
+    16:00  Akwa United FC             v Gombe United FC            2-0 (0-0)
+    16:00  Enyimba FC                 v Bendel FC                  0-0 (0-0)
+    16:00  Go Round FC                v Abia Warriors FC           1-0 (0-0)
+    16:00  Kano Pillars FC            v El-Kanemi Warriors FC      2-1 (1-0)
+    16:00  Kwara United FC            v MFM FC                     1-0 (0-0)
+    16:00  Nasarawa United FC         v Ifeanyi Ubah FC            1-0 (0-0)
+    16:00  Plateau United FC          v Heartland FC               0-0 (0-0)
+    16:00  Rangers International FC   v Katsina United FC          1-0 (1-0)
+    16:00  Rivers United FC           v Niger Tornadoes FC         1-0 (1-0)
+    16:00  Wikki Tourists FC          v Remo Stars FC              2-1 (1-0)
+    16:00  Yobe Stars FC              v Delta Force FC             0-0 (0-0)
+  08.04.
+    16:00  Lobi Stars FC              v Sunshine Stars FC          1-0 (1-0)
+
+
+
+» Matchday 15
+  13.04.
+    16:00  Bendel FC                  v Remo Stars FC              0-0 (0-0)
+  14.04.
+    16:00  Abia Warriors FC           v Yobe Stars FC              1-0 (0-0)
+    16:00  Akwa United FC             v Kano Pillars FC            3-0 (1-0)
+    16:00  El-Kanemi Warriors FC      v Plateau United FC          1-0 (0-0)
+    16:00  Enyimba FC                 v Kwara United FC            2-0 (1-0)
+    16:00  Gombe United FC            v Delta Force FC             1-0 (0-0)
+    16:00  Heartland FC               v Nasarawa United FC         3-1 (2-1)
+    16:00  Ifeanyi Ubah FC            v Go Round FC                2-0 (1-0)
+    16:00  Katsina United FC          v Rivers United FC           2-1 (1-0)
+    16:00  MFM FC                     v Lobi Stars FC              0-0 (0-0)
+    16:00  Niger Tornadoes FC         v Wikki Tourists FC          2-0 (1-0)
+    16:00  Sunshine Stars FC          v Rangers International FC   1-2 (1-2)
+
+
+
+» Matchday 16
+  21.04.
+    16:00  Go Round FC                v Heartland FC               2-1 (1-0)
+    16:00  Kano Pillars FC            v Gombe United FC            1-1 (1-0)
+    16:00  Kwara United FC            v Bendel FC                  0-0 (0-0)
+    16:00  Lobi Stars FC              v Enyimba FC                 0-0 (0-0)
+    16:00  Nasarawa United FC         v El-Kanemi Warriors FC      5-1 (3-0)
+    16:00  Plateau United FC          v Akwa United FC             3-0 (1-0)
+    16:00  Rangers International FC   v MFM FC                     1-0 (1-0)
+    16:00  Remo Stars FC              v Niger Tornadoes FC         0-0 (0-0)
+    16:00  Rivers United FC           v Sunshine Stars FC          1-1 (0-0)
+    16:00  Wikki Tourists FC          v Katsina United FC          1-0 (0-0)
+    16:00  Yobe Stars FC              v Ifeanyi Ubah FC            2-0 (1-0)
+    18:00  Delta Force FC             v Abia Warriors FC           1-0 (0-0)
+
+
+
+» Matchday 17
+  04.05.
+    16:00  Bendel FC                  v Niger Tornadoes FC         0-0 (0-0)
+    16:00  El-Kanemi Warriors FC      v Go Round FC                2-2 (1-1)
+  05.05.
+    16:00  Akwa United FC             v Nasarawa United FC         2-1 (2-1)
+    16:00  Enyimba FC                 v Rangers International FC   3-1 (2-0)
+    16:00  Gombe United FC            v Abia Warriors FC           1-0 (0-0)
+    16:00  Heartland FC               v Yobe Stars FC              2-0 (0-0)
+    16:00  Ifeanyi Ubah FC            v Delta Force FC             2-1 (1-1)
+    16:00  Kano Pillars FC            v Plateau United FC          1-0 (1-0)
+    16:00  Katsina United FC          v Remo Stars FC              3-2 (3-1)
+    16:00  Kwara United FC            v Lobi Stars FC              0-0 (0-0)
+    16:00  MFM FC                     v Rivers United FC           1-0 (1-0)
+    16:00  Sunshine Stars FC          v Wikki Tourists FC          2-1 (2-1)
+
+
+
+» Matchday 18
+  08.05.
+    16:00  Go Round FC                v Akwa United FC             0-1 (0-0)
+    16:00  Niger Tornadoes FC         v Katsina United FC          1-0 (0-0)
+    16:00  Plateau United FC          v Gombe United FC            2-0 (0-0)
+    16:00  Rangers International FC   v Kwara United FC            1-0 (0-0)
+    16:00  Rivers United FC           v Enyimba FC                 1-0 (1-0)
+    16:00  Wikki Tourists FC          v MFM FC                     1-1 (1-0)
+    16:00  Yobe Stars FC              v El-Kanemi Warriors FC      0-0 (0-0)
+    18:30  Delta Force FC             v Heartland FC               0-0 (0-0)
+  09.05.
+    16:00  Abia Warriors FC           v Ifeanyi Ubah FC            3-0 (1-0)
+    16:00  Lobi Stars FC              v Bendel FC                  1-0 (0-0)
+    16:00  Nasarawa United FC         v Kano Pillars FC            0-0 (0-0)
+    16:00  Remo Stars FC              v Sunshine Stars FC          1-0 (0-0)
+
+
+
+» Matchday 19
+  12.05.
+    16:00  Akwa United FC             v Yobe Stars FC              1-0 (1-0)
+    16:00  Bendel FC                  v Katsina United FC          2-1 (2-0)
+    16:00  El-Kanemi Warriors FC      v Delta Force FC             0-2 (0-1)
+    16:00  Enyimba FC                 v Wikki Tourists FC          1-1 (1-0)
+    16:00  Heartland FC               v Abia Warriors FC           2-4 (1-1)
+    16:00  Kano Pillars FC            v Go Round FC                2-0 (2-0)
+    16:00  Kwara United FC            v Rivers United FC           0-0 (0-0)
+    16:00  Lobi Stars FC              v Rangers International FC   1-0 (1-0)
+    16:00  MFM FC                     v Remo Stars FC              1-1 (0-1)
+    16:00  Plateau United FC          v Nasarawa United FC         2-1 (2-1)
+    16:00  Sunshine Stars FC          v Niger Tornadoes FC         1-0 (0-0)
+  13.05.
+    16:00  Gombe United FC            v Ifeanyi Ubah FC            1-0 (1-0)
+
+
+
+» Matchday 20
+  15.05.
+    16:00  Abia Warriors FC           v El-Kanemi Warriors FC      2-1 (1-1)
+    16:00  Niger Tornadoes FC         v MFM FC                     1-0 (1-0)
+    16:00  Rangers International FC   v Bendel FC                  1-0 (0-0)
+  16.05.
+    16:00  Go Round FC                v Plateau United FC          1-1 (1-0)
+    16:00  Ifeanyi Ubah FC            v Heartland FC               1-2 (0-1)
+    16:00  Katsina United FC          v Sunshine Stars FC          3-1 (3-0)
+    16:00  Nasarawa United FC         v Gombe United FC            2-1 (2-0)
+    16:00  Remo Stars FC              v Enyimba FC                 0-0 (0-0)
+    16:00  Rivers United FC           v Lobi Stars FC              1-1 (0-1)
+    16:00  Wikki Tourists FC          v Kwara United FC            2-1 (1-0)
+    16:00  Yobe Stars FC              v Kano Pillars FC            0-1 (0-1)
+    18:00  Delta Force FC             v Akwa United FC             2-1 (1-0)
+
+
+
+» Matchday 21
+  20.05.
+    16:00  Akwa United FC             v Abia Warriors FC           2-2 (1-1)
+    16:00  Bendel FC                  v Sunshine Stars FC          1-0 (1-0)
+    16:00  El-Kanemi Warriors FC      v Ifeanyi Ubah FC            0-1 (0-0)
+    16:00  Enyimba FC                 v Niger Tornadoes FC         2-0 (1-0)
+    16:00  Gombe United FC            v Heartland FC               1-0 (0-0)
+    16:00  Kano Pillars FC            v Delta Force FC             3-0 (1-0)
+    16:00  Kwara United FC            v Remo Stars FC              2-1 (0-0)
+    16:00  Lobi Stars FC              v Wikki Tourists FC          2-1 (0-0)
+    16:00  MFM FC                     v Katsina United FC          2-1 (1-0)
+    16:00  Nasarawa United FC         v Go Round FC                2-2 (0-1)
+    16:00  Plateau United FC          v Yobe Stars FC              2-0 (1-0)
+    16:00  Rangers International FC   v Rivers United FC           1-0 (0-0)
+
+
+
+» Matchday 22
+  26.05.
+    16:00  Abia Warriors FC           v Kano Pillars FC            3-0 (1-0)
+    16:00  Delta Force FC             v Plateau United FC          0-0 (0-0)
+    16:00  Go Round FC                v Gombe United FC            0-1 (0-1)
+    16:00  Heartland FC               v El-Kanemi Warriors FC      2-0 (1-0)
+    16:00  Ifeanyi Ubah FC            v Akwa United FC             2-1 (1-0)
+    16:00  Katsina United FC          v Enyimba FC                 2-1 (1-0)
+    16:00  Niger Tornadoes FC         v Kwara United FC            0-1 (0-1)
+    16:00  Remo Stars FC              v Lobi Stars FC              0-0 (0-0)
+    16:00  Rivers United FC           v Bendel FC                  1-0 (0-0)
+    16:00  Sunshine Stars FC          v MFM FC                     4-2 (3-1)
+    16:00  Wikki Tourists FC          v Rangers International FC   1-0 (0-0)
+    16:00  Yobe Stars FC              v Nasarawa United FC         1-2 (1-2)
+

--- a/africa/nigeria/2020-21_ng1.txt
+++ b/africa/nigeria/2020-21_ng1.txt
@@ -1,0 +1,629 @@
+= Nigeria | Premier Football League 2020/2021
+
+# Date       Thu Jan/02 2020 - Wed Dec/30 2020 (363d)
+# Teams      20
+# Matches    380
+
+
+
+» Matchday 1
+  27.12.
+    16:00  Adamawa United FC          v Kano Pillars FC            1-1 (0-1)
+    16:00  Ifeanyi Ubah FC            v Lobi Stars FC              1-0 (0-0)
+    16:00  Jigawa Golden Stars FC     v Sunshine Stars FC          1-0 (0-0)
+    16:00  MFM FC                     v Warri Wolves FC            2-1 (2-1)
+    16:00  Nasarawa United FC         v Wikki Tourists FC          2-1 (1-1)
+    16:00  Plateau United FC          v Kwara United FC            0-2 (0-0)
+  28.12.
+    16:00  Akwa United FC             v Dakkada FC                 0-0 (0-0)
+    16:00  Katsina United FC          v Heartland FC               3-2 (1-1)
+  29.12.
+    16:00  Enyimba FC                 v Abia Warriors FC           1-0 (0-0)
+  30.12.
+    16:00  Rivers United FC           v Rangers International FC   1-0 (1-0)
+
+
+
+» Matchday 2
+  02.01.
+    16:00  Abia Warriors FC           v Rivers United FC           0-1 (0-1)
+  03.01.
+    16:00  Dakkada FC                 v Jigawa Golden Stars FC     2-1 (1-1)
+    16:00  Heartland FC               v Nasarawa United FC         1-2 (0-1)
+    16:00  Kano Pillars FC            v Katsina United FC          2-0 (2-0)
+    16:00  Lobi Stars FC              v MFM FC                     1-0 (0-0)
+    16:00  Rangers International FC   v Akwa United FC             1-0 (0-0)
+    16:00  Sunshine Stars FC          v Ifeanyi Ubah FC            1-0 (1-0)
+    16:00  Warri Wolves FC            v Adamawa United FC          1-0 (0-0)
+  04.01.
+    16:00  Wikki Tourists FC          v Plateau United FC          0-0 (0-0)
+  20.01.
+    16:00  Kwara United FC            v Enyimba FC                 1-0 (1-0)
+
+
+
+» Matchday 3
+  09.01.
+    16:00  Akwa United FC             v Abia Warriors FC           2-1 (1-1)
+  10.01.
+    16:00  Enyimba FC                 v Wikki Tourists FC          1-0 (1-0)
+    16:00  Ifeanyi Ubah FC            v Dakkada FC                 0-1 (0-1)
+    16:00  Jigawa Golden Stars FC     v Rangers International FC   0-1 (0-0)
+    16:00  Katsina United FC          v Adamawa United FC          2-0 (1-0)
+    16:00  Lobi Stars FC              v Warri Wolves FC            3-0 (1-0)
+    16:00  MFM FC                     v Sunshine Stars FC          1-0 (1-0)
+    16:00  Nasarawa United FC         v Kano Pillars FC            1-1 (0-0)
+    16:00  Plateau United FC          v Heartland FC               3-0 (1-0)
+    16:00  Rivers United FC           v Kwara United FC            3-0 (2-0)
+
+
+
+» Matchday 4
+  13.01.
+    16:00  Abia Warriors FC           v Jigawa Golden Stars FC     1-3 (1-1)
+    16:00  Adamawa United FC          v Nasarawa United FC         0-0 (0-0)
+    16:00  Dakkada FC                 v MFM FC                     1-1 (1-0)
+    16:00  Heartland FC               v Enyimba FC                 2-0 (1-0)
+    16:00  Kano Pillars FC            v Plateau United FC          1-0 (0-0)
+    16:00  Kwara United FC            v Akwa United FC             1-1 (0-0)
+    16:00  Rangers International FC   v Ifeanyi Ubah FC            2-1 (1-0)
+    16:00  Sunshine Stars FC          v Lobi Stars FC              2-2 (1-1)
+    16:00  Warri Wolves FC            v Katsina United FC          3-0 (0-0)
+    16:00  Wikki Tourists FC          v Rivers United FC           1-0 (1-0)
+
+
+
+» Matchday 5
+  17.01.
+    16:00  Enyimba FC                 v Kano Pillars FC            2-1 (2-0)
+    16:00  Ifeanyi Ubah FC            v Abia Warriors FC           1-1 (0-1)
+    16:00  Jigawa Golden Stars FC     v Kwara United FC            0-0 (0-0)
+    16:00  Lobi Stars FC              v Dakkada FC                 2-1 (1-0)
+    16:00  MFM FC                     v Rangers International FC   1-1 (1-1)
+    16:00  Nasarawa United FC         v Katsina United FC          1-0 (0-0)
+    16:00  Plateau United FC          v Adamawa United FC          3-0 (1-0)
+    16:00  Rivers United FC           v Heartland FC               3-1 (1-0)
+    16:00  Sunshine Stars FC          v Warri Wolves FC            1-0 (0-0)
+  18.01.
+    16:00  Akwa United FC             v Wikki Tourists FC          1-1 (1-1)
+
+
+
+» Matchday 6
+  23.01.
+    16:00  Katsina United FC          v Plateau United FC          0-0 (0-0)
+  24.01.
+    16:00  Abia Warriors FC           v MFM FC                     0-0 (0-0)
+    16:00  Dakkada FC                 v Sunshine Stars FC          1-2 (0-1)
+    16:00  Heartland FC               v Akwa United FC             2-1 (0-1)
+    16:00  Kwara United FC            v Ifeanyi Ubah FC            1-0 (0-0)
+    16:00  Rangers International FC   v Lobi Stars FC              0-0 (0-0)
+    16:00  Warri Wolves FC            v Nasarawa United FC         1-2 (1-0)
+  25.01.
+    15:00  Adamawa United FC          v Enyimba FC                 1-2 (0-2)
+    17:00  Wikki Tourists FC          v Jigawa Golden Stars FC     2-0 (1-0)
+  27.01.
+    16:00  Kano Pillars FC            v Rivers United FC           1-0 (1-0)
+
+
+
+» Matchday 7
+  29.01.
+    16:00  Plateau United FC          v Nasarawa United FC         1-0 (1-0)
+  30.01.
+    16:00  Akwa United FC             v Kano Pillars FC            1-0 (1-0)
+  31.01.
+    16:00  Dakkada FC                 v Warri Wolves FC            2-0 (1-0)
+    16:00  Enyimba FC                 v Katsina United FC          1-0 (1-0)
+    16:00  Ifeanyi Ubah FC            v Wikki Tourists FC          1-0 (1-0)
+    16:00  Jigawa Golden Stars FC     v Heartland FC               2-1 (0-0)
+    16:00  Lobi Stars FC              v Abia Warriors FC           0-0 (0-0)
+    16:00  MFM FC                     v Kwara United FC            0-0 (0-0)
+    16:00  Rivers United FC           v Adamawa United FC          1-0 (0-0)
+    16:00  Sunshine Stars FC          v Rangers International FC   3-1 (2-0)
+
+
+
+» Matchday 8
+  03.02.
+    16:00  Abia Warriors FC           v Sunshine Stars FC          4-1 (2-0)
+    16:00  Adamawa United FC          v Akwa United FC             0-1 (0-0)
+    16:00  Kano Pillars FC            v Jigawa Golden Stars FC     2-0 (2-0)
+    16:00  Kwara United FC            v Lobi Stars FC              2-1 (0-0)
+    16:00  Nasarawa United FC         v Enyimba FC                 1-2 (1-2)
+    16:00  Rangers International FC   v Dakkada FC                 3-0 (1-0)
+    16:00  Warri Wolves FC            v Plateau United FC          1-0 (0-0)
+    16:00  Wikki Tourists FC          v MFM FC                     2-0 (1-0)
+  04.02.
+    16:00  Heartland FC               v Ifeanyi Ubah FC            1-1 (1-0)
+    16:00  Katsina United FC          v Rivers United FC           2-1 (2-0)
+
+
+
+» Matchday 9
+  06.02.
+    16:00  Enyimba FC                 v Plateau United FC          2-1 (2-0)
+  07.02.
+    14:00  Dakkada FC                 v Abia Warriors FC           2-1 (0-0)
+    16:00  Akwa United FC             v Katsina United FC          3-0 (1-0)
+    16:00  Jigawa Golden Stars FC     v Adamawa United FC          1-0 (0-0)
+    16:00  Lobi Stars FC              v Wikki Tourists FC          0-0 (0-0)
+    16:00  MFM FC                     v Heartland FC               1-2 (0-1)
+    16:00  Rangers International FC   v Warri Wolves FC            1-0 (1-0)
+    16:00  Sunshine Stars FC          v Kwara United FC            1-2 (0-0)
+  08.02.
+    14:00  Ifeanyi Ubah FC            v Kano Pillars FC            0-1 (0-1)
+    16:00  Rivers United FC           v Nasarawa United FC         2-0 (1-0)
+
+
+
+» Matchday 10
+  03.03.
+    16:00  Plateau United FC          v Rivers United FC           1-1 (0-1)
+    16:00  Warri Wolves FC            v Enyimba FC                 1-1 (1-1)
+  14.02.
+    16:00  Adamawa United FC          v Ifeanyi Ubah FC            1-1 (1-0)
+    16:00  Kano Pillars FC            v MFM FC                     1-0 (0-0)
+    16:00  Katsina United FC          v Jigawa Golden Stars FC     1-0 (1-0)
+    16:00  Kwara United FC            v Dakkada FC                 3-0 (1-0)
+    16:00  Nasarawa United FC         v Akwa United FC             2-1 (0-0)
+    16:00  Wikki Tourists FC          v Sunshine Stars FC          0-0 (0-0)
+  15.02.
+    14:00  Heartland FC               v Lobi Stars FC              2-0 (1-0)
+    16:00  Abia Warriors FC           v Rangers International FC   1-0 (1-0)
+
+
+
+» Matchday 11
+  02.05.
+    16:00  Rivers United FC           v Enyimba FC                 1-0 (0-0)
+  03.03.
+    16:00  Dakkada FC                 v Wikki Tourists FC          2-1 (1-1)
+  20.02.
+    16:00  Akwa United FC             v Plateau United FC          1-0 (0-0)
+  21.02.
+    16:00  Abia Warriors FC           v Warri Wolves FC            4-1 (2-1)
+    16:00  Ifeanyi Ubah FC            v Katsina United FC          3-0 (1-0)
+    16:00  Jigawa Golden Stars FC     v Nasarawa United FC         1-0 (0-0)
+    16:00  Lobi Stars FC              v Kano Pillars FC            1-0 (1-0)
+    16:00  MFM FC                     v Adamawa United FC          2-0 (2-0)
+    16:00  Rangers International FC   v Kwara United FC            1-0 (1-0)
+    16:00  Sunshine Stars FC          v Heartland FC               1-1 (0-1)
+
+
+
+» Matchday 12
+  24.02.
+    16:00  Enyimba FC                 v Akwa United FC             1-1 (0-0)
+    16:00  Kano Pillars FC            v Sunshine Stars FC          1-0 (1-0)
+    16:00  Kwara United FC            v Abia Warriors FC           1-1 (0-0)
+    16:00  Nasarawa United FC         v Ifeanyi Ubah FC            3-0 (1-0)
+    16:00  Plateau United FC          v Jigawa Golden Stars FC     3-0 (3-0)
+    16:00  Warri Wolves FC            v Rivers United FC           1-0 (0-0)
+    16:00  Wikki Tourists FC          v Rangers International FC   2-1 (1-0)
+  25.02.
+    16:00  Adamawa United FC          v Lobi Stars FC              1-0 (0-0)
+    16:00  Heartland FC               v Dakkada FC                 2-1 (0-1)
+    16:00  Katsina United FC          v MFM FC                     0-0 (0-0)
+
+
+
+» Matchday 13
+  01.03.
+    16:00  MFM FC                     v Nasarawa United FC         1-0 (0-0)
+  27.02.
+    14:00  Abia Warriors FC           v Wikki Tourists FC          1-0 (1-0)
+  28.02.
+    14:00  Dakkada FC                 v Kano Pillars FC            3-2 (1-2)
+    16:00  Akwa United FC             v Rivers United FC           3-0 (1-0)
+    16:00  Ifeanyi Ubah FC            v Plateau United FC          0-0 (0-0)
+    16:00  Jigawa Golden Stars FC     v Enyimba FC                 0-0 (0-0)
+    16:00  Kwara United FC            v Warri Wolves FC            2-0 (1-0)
+    16:00  Lobi Stars FC              v Katsina United FC          2-1 (1-0)
+    16:00  Rangers International FC   v Heartland FC               2-0 (2-0)
+    16:00  Sunshine Stars FC          v Adamawa United FC          0-0 (0-0)
+
+
+
+» Matchday 14
+  05.05.
+    16:00  Enyimba FC                 v Ifeanyi Ubah FC            2-2 (0-1)
+  07.03.
+    16:00  Adamawa United FC          v Dakkada FC                 2-0 (1-0)
+    16:00  Heartland FC               v Abia Warriors FC           2-2 (1-2)
+    16:00  Kano Pillars FC            v Rangers International FC   1-1 (1-1)
+    16:00  Katsina United FC          v Sunshine Stars FC          0-0 (0-0)
+    16:00  Nasarawa United FC         v Lobi Stars FC              1-0 (0-0)
+    16:00  Plateau United FC          v MFM FC                     3-1 (0-0)
+    16:00  Rivers United FC           v Jigawa Golden Stars FC     2-0 (1-0)
+    16:00  Wikki Tourists FC          v Kwara United FC            1-1 (1-0)
+  08.03.
+    16:00  Warri Wolves FC            v Akwa United FC             0-0 (0-0)
+
+
+
+» Matchday 15
+  11.04.
+    16:00  Jigawa Golden Stars FC     v Akwa United FC             1-1 (0-0)
+  14.03.
+    16:00  Abia Warriors FC           v Kano Pillars FC            4-1 (2-1)
+    16:00  Dakkada FC                 v Katsina United FC          1-0 (1-0)
+    16:00  Ifeanyi Ubah FC            v Rivers United FC           0-0 (0-0)
+    16:00  Kwara United FC            v Heartland FC               0-0 (0-0)
+    16:00  Lobi Stars FC              v Plateau United FC          3-2 (0-0)
+    16:00  Rangers International FC   v Adamawa United FC          1-0 (0-0)
+    16:00  Wikki Tourists FC          v Warri Wolves FC            1-0 (0-0)
+  15.03.
+    08:00  Sunshine Stars FC          v Nasarawa United FC         0-0 (0-0)
+  25.03.
+    16:00  MFM FC                     v Enyimba FC                 1-0 (1-0)
+
+
+
+» Matchday 16
+  02.06.
+    16:00  Enyimba FC                 v Lobi Stars FC              2-1 (2-0)
+  17.03.
+    16:00  Adamawa United FC          v Abia Warriors FC           1-1 (0-0)
+    16:00  Akwa United FC             v Ifeanyi Ubah FC            1-0 (1-0)
+    16:00  Heartland FC               v Wikki Tourists FC          2-0 (2-0)
+    16:00  Kano Pillars FC            v Kwara United FC            2-0 (0-0)
+    16:00  Rivers United FC           v MFM FC                     2-0 (0-0)
+    16:00  Warri Wolves FC            v Jigawa Golden Stars FC     0-0 (0-0)
+  18.03.
+    16:00  Katsina United FC          v Rangers International FC   2-0 (1-0)
+    16:00  Nasarawa United FC         v Dakkada FC                 3-0 (3-0)
+    16:00  Plateau United FC          v Sunshine Stars FC          3-1 (3-0)
+
+
+
+» Matchday 17
+  21.03.
+    16:00  Abia Warriors FC           v Katsina United FC          3-1 (2-0)
+    16:00  Heartland FC               v Warri Wolves FC            1-1 (1-1)
+    16:00  Kwara United FC            v Adamawa United FC          5-0 (2-0)
+    16:00  Lobi Stars FC              v Rivers United FC           4-1 (1-0)
+    16:00  MFM FC                     v Akwa United FC             1-2 (1-1)
+    16:00  Wikki Tourists FC          v Kano Pillars FC            1-2 (0-2)
+  22.03.
+    16:00  Dakkada FC                 v Plateau United FC          1-0 (1-0)
+    16:00  Rangers International FC   v Nasarawa United FC         2-0 (2-0)
+    16:00  Sunshine Stars FC          v Enyimba FC                 0-1 (0-0)
+  23.03.
+    08:00  Ifeanyi Ubah FC            v Jigawa Golden Stars FC     2-2 (1-0)
+
+
+
+» Matchday 18
+  28.03.
+    16:00  Adamawa United FC          v Wikki Tourists FC          0-0 (0-0)
+    16:00  Akwa United FC             v Lobi Stars FC              3-0 (3-0)
+    16:00  Kano Pillars FC            v Heartland FC               2-1 (1-1)
+    16:00  Katsina United FC          v Kwara United FC            1-2 (1-1)
+    16:00  Nasarawa United FC         v Abia Warriors FC           5-3 (2-2)
+    16:00  Plateau United FC          v Rangers International FC   2-1 (1-1)
+    16:00  Rivers United FC           v Sunshine Stars FC          1-0 (1-0)
+    16:00  Warri Wolves FC            v Ifeanyi Ubah FC            3-1 (2-0)
+  29.03.
+    16:00  Enyimba FC                 v Dakkada FC                 1-0 (1-0)
+    16:00  Jigawa Golden Stars FC     v MFM FC                     1-0 (1-0)
+
+
+
+» Matchday 19
+  03.04.
+    16:00  Sunshine Stars FC          v Akwa United FC             0-0 (0-0)
+  04.04.
+    16:00  Dakkada FC                 v Rivers United FC           4-2 (2-2)
+    16:00  Kano Pillars FC            v Warri Wolves FC            1-0 (0-0)
+    16:00  Kwara United FC            v Nasarawa United FC         2-0 (0-0)
+    16:00  Lobi Stars FC              v Jigawa Golden Stars FC     2-1 (0-1)
+    16:00  MFM FC                     v Ifeanyi Ubah FC            1-1 (1-0)
+    16:00  Wikki Tourists FC          v Katsina United FC          3-1 (2-1)
+  05.04.
+    14:00  Abia Warriors FC           v Plateau United FC          2-1 (2-1)
+    16:00  Heartland FC               v Adamawa United FC          2-1 (1-0)
+  09.05.
+    16:00  Rangers International FC   v Enyimba FC                 2-0 (0-0)
+
+
+
+» Matchday 20
+  08.05.
+    16:00  Jigawa Golden Stars FC     v Lobi Stars FC              2-1 (0-0)
+  09.05.
+    16:00  Adamawa United FC          v Heartland FC               0-1 (0-0)
+    16:00  Akwa United FC             v Sunshine Stars FC          2-1 (1-1)
+    16:00  Katsina United FC          v Wikki Tourists FC          5-1 (3-0)
+    16:00  Nasarawa United FC         v Kwara United FC            2-1 (0-0)
+    16:00  Plateau United FC          v Abia Warriors FC           2-1 (1-0)
+    16:00  Rivers United FC           v Dakkada FC                 2-0 (2-0)
+    16:00  Warri Wolves FC            v Kano Pillars FC            1-1 (0-0)
+    16:00  Ifeanyi Ubah FC            v MFM FC                     0-3
+  17.06.
+    16:00  Enyimba FC                 v Rangers International FC   2-1 (2-1)
+
+
+
+» Matchday 21
+  16.05.
+    16:00  Dakkada FC                 v Akwa United FC             0-2 (0-1)
+    16:00  Heartland FC               v Katsina United FC          2-0 (2-0)
+    16:00  Kano Pillars FC            v Adamawa United FC          1-0 (0-0)
+    16:00  Kwara United FC            v Plateau United FC          2-0 (0-0)
+    16:00  Lobi Stars FC              v Ifeanyi Ubah FC            2-0 (1-0)
+    16:00  Rangers International FC   v Rivers United FC           0-1 (0-1)
+    16:00  Sunshine Stars FC          v Jigawa Golden Stars FC     0-0 (0-0)
+    16:00  Warri Wolves FC            v MFM FC                     0-2 (0-2)
+    16:00  Wikki Tourists FC          v Nasarawa United FC         1-2 (1-1)
+  24.06.
+    08:00  Abia Warriors FC           v Enyimba FC                 0-1 (0-1)
+
+
+
+» Matchday 22
+  07.07.
+    16:00  Enyimba FC                 v Kwara United FC            1-0 (1-0)
+  23.05.
+    16:00  Adamawa United FC          v Warri Wolves FC            3-3 (2-2)
+    16:00  Ifeanyi Ubah FC            v Sunshine Stars FC          1-0 (1-0)
+    16:00  Jigawa Golden Stars FC     v Dakkada FC                 1-1 (0-1)
+    16:00  Katsina United FC          v Kano Pillars FC            1-1 (1-1)
+    16:00  MFM FC                     v Lobi Stars FC              1-0 (1-0)
+    16:00  Nasarawa United FC         v Heartland FC               3-1 (1-0)
+    16:00  Plateau United FC          v Wikki Tourists FC          4-1 (2-1)
+    16:00  Rivers United FC           v Abia Warriors FC           0-0 (0-0)
+  24.05.
+    16:00  Akwa United FC             v Rangers International FC   0-0 (0-0)
+
+
+
+» Matchday 23
+  26.05.
+    16:00  Adamawa United FC          v Katsina United FC          1-0 (0-0)
+    16:00  Dakkada FC                 v Ifeanyi Ubah FC            2-1 (2-0)
+    16:00  Kano Pillars FC            v Nasarawa United FC         1-0 (1-0)
+    16:00  Kwara United FC            v Rivers United FC           1-1 (0-0)
+    16:00  Sunshine Stars FC          v MFM FC                     0-0 (0-0)
+    16:00  Warri Wolves FC            v Lobi Stars FC              1-0 (1-0)
+    16:00  Wikki Tourists FC          v Enyimba FC                 1-2 (1-1)
+    19:20  Heartland FC               v Plateau United FC          0-0 (0-0)
+  27.05.
+    16:00  Abia Warriors FC           v Akwa United FC             0-0 (0-0)
+    16:00  Rangers International FC   v Jigawa Golden Stars FC     3-0 (1-0)
+
+
+
+» Matchday 24
+  30.05.
+    14:30  Ifeanyi Ubah FC            v Rangers International FC   0-0 (0-0)
+    16:00  Akwa United FC             v Kwara United FC            2-1 (1-0)
+    16:00  Enyimba FC                 v Heartland FC               0-0 (0-0)
+    16:00  Katsina United FC          v Warri Wolves FC            1-0 (1-0)
+    16:00  Lobi Stars FC              v Sunshine Stars FC          2-1 (2-1)
+    16:00  MFM FC                     v Dakkada FC                 1-0 (0-0)
+    16:00  Nasarawa United FC         v Adamawa United FC          1-0 (1-0)
+    16:00  Plateau United FC          v Kano Pillars FC            0-0 (0-0)
+  31.05.
+    16:00  Jigawa Golden Stars FC     v Abia Warriors FC           0-0 (0-0)
+    16:00  Rivers United FC           v Wikki Tourists FC          1-1 (0-1)
+
+
+
+» Matchday 25
+  06.06.
+    16:00  Abia Warriors FC           v Ifeanyi Ubah FC            1-1 (1-1)
+    16:00  Adamawa United FC          v Plateau United FC          0-2 (0-1)
+    16:00  Dakkada FC                 v Lobi Stars FC              0-1 (0-1)
+    16:00  Heartland FC               v Rivers United FC           2-2 (1-1)
+    16:00  Kano Pillars FC            v Enyimba FC                 2-1 (0-1)
+    16:00  Katsina United FC          v Nasarawa United FC         2-1 (2-1)
+    16:00  Kwara United FC            v Jigawa Golden Stars FC     3-0 (1-0)
+    16:00  Rangers International FC   v MFM FC                     1-1 (0-0)
+    16:00  Warri Wolves FC            v Sunshine Stars FC          2-1 (1-0)
+    16:00  Wikki Tourists FC          v Akwa United FC             2-2 (1-1)
+
+
+
+» Matchday 26
+  09.06.
+    16:00  Enyimba FC                 v Adamawa United FC          2-1 (1-0)
+    16:00  Ifeanyi Ubah FC            v Kwara United FC            2-1 (1-1)
+    16:00  Jigawa Golden Stars FC     v Wikki Tourists FC          1-1 (0-0)
+    16:00  Lobi Stars FC              v Rangers International FC   1-0 (1-0)
+    16:00  Nasarawa United FC         v Warri Wolves FC            3-1 (0-0)
+    16:00  Plateau United FC          v Katsina United FC          2-0 (0-0)
+    16:00  Rivers United FC           v Kano Pillars FC            2-0 (1-0)
+    16:00  Sunshine Stars FC          v Dakkada FC                 1-0 (1-0)
+  10.06.
+    07:00  MFM FC                     v Abia Warriors FC           0-0 (0-0)
+    16:00  Akwa United FC             v Heartland FC               3-1 (2-1)
+
+
+
+» Matchday 27
+  13.06.
+    15:30  Heartland FC               v Jigawa Golden Stars FC     2-1 (2-1)
+    16:00  Abia Warriors FC           v Lobi Stars FC              2-0 (2-0)
+    16:00  Adamawa United FC          v Rivers United FC           2-0 (2-0)
+    16:00  Katsina United FC          v Enyimba FC                 3-1 (3-0)
+    16:00  Kwara United FC            v MFM FC                     1-0 (0-0)
+    16:00  Nasarawa United FC         v Plateau United FC          2-0 (0-0)
+    16:00  Rangers International FC   v Sunshine Stars FC          4-1 (3-0)
+    16:00  Warri Wolves FC            v Dakkada FC                 0-1 (0-0)
+    16:00  Wikki Tourists FC          v Ifeanyi Ubah FC            4-3 (1-0)
+  14.06.
+    07:00  Kano Pillars FC            v Akwa United FC             0-0 (0-0)
+
+
+
+» Matchday 28
+  19.06.
+    16:00  Akwa United FC             v Adamawa United FC          2-0 (2-0)
+  20.06.
+    16:00  Dakkada FC                 v Rangers International FC   1-1 (1-0)
+    16:00  Enyimba FC                 v Nasarawa United FC         0-0 (0-0)
+    16:00  Ifeanyi Ubah FC            v Heartland FC               2-1 (0-0)
+    16:00  Jigawa Golden Stars FC     v Kano Pillars FC            1-0 (0-0)
+    16:00  Lobi Stars FC              v Kwara United FC            2-0 (0-0)
+    16:00  Plateau United FC          v Warri Wolves FC            2-0 (0-0)
+    16:00  Rivers United FC           v Katsina United FC          1-0 (0-0)
+    16:00  Sunshine Stars FC          v Abia Warriors FC           2-1 (2-1)
+  21.06.
+    08:00  MFM FC                     v Wikki Tourists FC          1-0 (0-0)
+
+
+
+» Matchday 29
+  27.06.
+    14:30  Wikki Tourists FC          v Lobi Stars FC              1-0 (1-0)
+    16:00  Abia Warriors FC           v Dakkada FC                 0-1 (0-0)
+    16:00  Adamawa United FC          v Jigawa Golden Stars FC     2-0 (2-0)
+    16:00  Heartland FC               v MFM FC                     2-0 (1-0)
+    16:00  Kano Pillars FC            v Ifeanyi Ubah FC            1-0 (1-0)
+    16:00  Katsina United FC          v Akwa United FC             1-0 (1-0)
+    16:00  Kwara United FC            v Sunshine Stars FC          1-0 (1-0)
+    16:00  Nasarawa United FC         v Rivers United FC           2-1 (1-0)
+    16:00  Plateau United FC          v Enyimba FC                 0-0 (0-0)
+    16:00  Warri Wolves FC            v Rangers International FC   0-1 (0-0)
+
+
+
+» Matchday 30
+  01.07.
+    14:00  Dakkada FC                 v Kwara United FC            2-0 (1-0)
+    16:00  Akwa United FC             v Nasarawa United FC         2-1 (2-0)
+  30.06.
+    16:00  Enyimba FC                 v Warri Wolves FC            1-1 (0-0)
+    16:00  Ifeanyi Ubah FC            v Adamawa United FC          3-0 (1-0)
+    16:00  Jigawa Golden Stars FC     v Katsina United FC          0-1 (0-1)
+    16:00  Lobi Stars FC              v Heartland FC               3-0 (0-0)
+    16:00  MFM FC                     v Kano Pillars FC            2-1 (1-0)
+    16:00  Rangers International FC   v Abia Warriors FC           2-1 (0-1)
+    16:00  Rivers United FC           v Plateau United FC          3-1 (2-0)
+    16:00  Sunshine Stars FC          v Wikki Tourists FC          1-0 (0-0)
+
+
+
+» Matchday 31
+  04.07.
+    16:00  Adamawa United FC          v MFM FC                     1-1 (1-0)
+    16:00  Enyimba FC                 v Rivers United FC           1-1 (0-1)
+    16:00  Kano Pillars FC            v Lobi Stars FC              3-0 (1-0)
+    16:00  Katsina United FC          v Ifeanyi Ubah FC            3-0 (3-0)
+    16:00  Kwara United FC            v Rangers International FC   2-0 (0-0)
+    16:00  Plateau United FC          v Akwa United FC             0-0 (0-0)
+    16:00  Warri Wolves FC            v Abia Warriors FC           2-0 (2-0)
+    16:00  Wikki Tourists FC          v Dakkada FC                 2-1 (1-1)
+    19:00  Heartland FC               v Sunshine Stars FC          0-1 (0-0)
+  05.07.
+    16:00  Nasarawa United FC         v Jigawa Golden Stars FC     3-1 (2-0)
+
+
+
+» Matchday 32
+  10.07.
+    16:00  Dakkada FC                 v Heartland FC               1-0 (1-0)
+  11.07.
+    16:00  Abia Warriors FC           v Kwara United FC            2-1 (0-1)
+    16:00  Akwa United FC             v Enyimba FC                 1-0 (0-0)
+    16:00  Ifeanyi Ubah FC            v Nasarawa United FC         2-1 (1-1)
+    16:00  Jigawa Golden Stars FC     v Plateau United FC          1-0 (0-0)
+    16:00  Lobi Stars FC              v Adamawa United FC          1-0 (1-0)
+    16:00  MFM FC                     v Katsina United FC          0-0 (0-0)
+    16:00  Rangers International FC   v Wikki Tourists FC          2-1 (2-1)
+    16:00  Rivers United FC           v Warri Wolves FC            2-1 (1-1)
+    16:00  Sunshine Stars FC          v Kano Pillars FC            1-0 (0-0)
+
+
+
+» Matchday 33
+  18.07.
+    16:00  Adamawa United FC          v Sunshine Stars FC          0-0 (0-0)
+    16:00  Enyimba FC                 v Jigawa Golden Stars FC     2-1 (0-1)
+    16:00  Heartland FC               v Rangers International FC   2-1 (2-1)
+    16:00  Kano Pillars FC            v Dakkada FC                 2-0 (2-0)
+    16:00  Katsina United FC          v Lobi Stars FC              1-1 (1-1)
+    16:00  Nasarawa United FC         v MFM FC                     1-0 (1-0)
+    16:00  Plateau United FC          v Ifeanyi Ubah FC            4-0 (1-0)
+    16:00  Rivers United FC           v Akwa United FC             1-1 (0-0)
+    16:00  Warri Wolves FC            v Kwara United FC            1-0 (0-0)
+    16:00  Wikki Tourists FC          v Abia Warriors FC           1-0 (0-0)
+
+
+
+» Matchday 34
+  21.07.
+    16:00  Abia Warriors FC           v Heartland FC               2-1 (2-1)
+    16:00  Akwa United FC             v Warri Wolves FC            3-0 (2-0)
+    16:00  Jigawa Golden Stars FC     v Rivers United FC           2-1 (1-1)
+    16:00  Lobi Stars FC              v Nasarawa United FC         3-2 (3-2)
+    16:00  MFM FC                     v Plateau United FC          3-1 (1-0)
+    16:00  Rangers International FC   v Kano Pillars FC            2-0 (2-0)
+    16:00  Sunshine Stars FC          v Katsina United FC          0-0 (0-0)
+  22.07.
+    16:00  Dakkada FC                 v Adamawa United FC          4-0 (2-0)
+    16:00  Ifeanyi Ubah FC            v Enyimba FC                 1-1 (1-0)
+    16:00  Kwara United FC            v Wikki Tourists FC          3-1 (2-0)
+
+
+
+» Matchday 35
+  25.07.
+    16:00  Adamawa United FC          v Rangers International FC   1-1 (0-0)
+    16:00  Akwa United FC             v Jigawa Golden Stars FC     3-0 (1-0)
+    16:00  Enyimba FC                 v MFM FC                     2-1 (0-0)
+    16:00  Heartland FC               v Kwara United FC            0-0 (0-0)
+    16:00  Kano Pillars FC            v Abia Warriors FC           1-0 (0-0)
+    16:00  Katsina United FC          v Dakkada FC                 2-0 (1-0)
+    16:00  Nasarawa United FC         v Sunshine Stars FC          4-0 (4-0)
+    16:00  Plateau United FC          v Lobi Stars FC              0-0 (0-0)
+    16:00  Rivers United FC           v Ifeanyi Ubah FC            2-0 (2-0)
+    16:00  Warri Wolves FC            v Wikki Tourists FC          1-0 (1-0)
+
+
+
+» Matchday 36
+  28.07.
+    16:00  Abia Warriors FC           v Adamawa United FC          5-1 (2-1)
+    16:00  Dakkada FC                 v Nasarawa United FC         0-0 (0-0)
+    16:00  Ifeanyi Ubah FC            v Akwa United FC             1-1 (0-0)
+    16:00  Jigawa Golden Stars FC     v Warri Wolves FC            1-1 (1-1)
+    16:00  Kwara United FC            v Kano Pillars FC            1-0 (1-0)
+    16:00  Lobi Stars FC              v Enyimba FC                 1-1 (1-1)
+    16:00  MFM FC                     v Rivers United FC           2-2 (0-1)
+    16:00  Rangers International FC   v Katsina United FC          1-0 (0-0)
+    16:00  Sunshine Stars FC          v Plateau United FC          3-2 (1-1)
+    16:00  Wikki Tourists FC          v Heartland FC               4-2 (2-1)
+
+
+
+» Matchday 37
+  01.08.
+    16:00  Akwa United FC             v MFM FC                     5-2 (2-0)
+    16:00  Katsina United FC          v Abia Warriors FC           1-0 (1-0)
+    16:00  Plateau United FC          v Dakkada FC                 2-0 (0-0)
+    16:00  Warri Wolves FC            v Heartland FC               1-0 (0-0)
+  02.08.
+    09:00  Jigawa Golden Stars FC     v Ifeanyi Ubah FC            3-0 (0-0)
+    16:00  Adamawa United FC          v Kwara United FC            0-2 (0-1)
+    16:00  Enyimba FC                 v Sunshine Stars FC          1-1 (0-0)
+    16:00  Kano Pillars FC            v Wikki Tourists FC          1-0 (0-0)
+    16:00  Nasarawa United FC         v Rangers International FC   3-0 (2-0)
+    16:00  Rivers United FC           v Lobi Stars FC              3-1 (2-0)
+
+
+
+» Matchday 38
+  05.08.
+    16:00  Abia Warriors FC           v Nasarawa United FC         3-1 (2-0)
+    16:00  Dakkada FC                 v Enyimba FC                 1-3 (1-2)
+    16:00  Heartland FC               v Kano Pillars FC            1-0 (1-0)
+    16:00  Ifeanyi Ubah FC            v Warri Wolves FC            1-0 (1-0)
+    16:00  Kwara United FC            v Katsina United FC          3-0 (1-0)
+    16:00  Lobi Stars FC              v Akwa United FC             2-1 (2-1)
+    16:00  MFM FC                     v Jigawa Golden Stars FC     2-0 (0-0)
+    16:00  Rangers International FC   v Plateau United FC          2-0 (1-0)
+    16:00  Sunshine Stars FC          v Rivers United FC           1-0 (1-0)
+    16:00  Wikki Tourists FC          v Adamawa United FC          2-0 (2-0)
+


### PR DESCRIPTION
## Summary

Adds Nigeria Professional Football League (NPFL) seasons from 2017/18 to 2020/21 to the Open Football dataset.

## Details

- **Country:** Nigeria  
- **Competition:** Nigeria Professional Football League  
- **Seasons:** 2017/18 – 2020/21  
- **Tier:** 1 (`ng1`)  
- **Matches:** Full league seasons (excluding 2019/20)  
- **Source:** Soccerway  

## Notes

- The 2019/20 NPFL season is intentionally excluded due to COVID-19 disruption and league cancellation.
- Team names follow established NPFL canonical naming used in earlier seasons.
- Additional seasons will be submitted in follow-up PRs.