### PR TITLE
Add Nigeria Professional Football League seasons 2022-2025

### DIFF
--- a/africa/nigeria/2021-22_ng1.txt
+++ b/africa/nigeria/2021-22_ng1.txt
@@ -1,0 +1,624 @@
+= Nigeria Professional League 2021/2022
+
+# Date       Sat Jan/02 2021 - Thu Dec/30 2021 (362d)
+# Teams      20
+# Matches    380
+
+
+
+» Matchday 1
+  17.12.
+    18:00  MFM FC                     v Remo Stars FC              0-2 (0-0)
+  19.12.
+    14:00  Niger Tornadoes FC         v Plateau United FC          1-0 (1-0)
+    15:30  Gombe United FC            v Shooting Stars SC          0-0 (0-0)
+    16:00  Akwa United FC             v Kano Pillars FC            3-0 (1-0)
+    16:00  Enyimba FC                 v Abia Warriors FC           2-1 (1-0)
+    16:00  Heartland FC               v Nasarawa United FC         3-3 (1-2)
+    16:00  Katsina United FC          v Rangers International FC   1-2 (1-1)
+    16:00  Kwara United FC            v Dakkada FC                 3-0 (2-0)
+    16:00  Lobi Stars FC              v Rivers United FC           1-1 (0-1)
+  23.02.
+    16:00  Sunshine Stars FC          v Wikki Tourists FC          2-1 (0-0)
+
+
+
+» Matchday 2
+  26.12.
+    15:00  Rangers International FC   v Enyimba FC                 0-1 (0-0)
+    16:00  Abia Warriors FC           v Sunshine Stars FC          1-0 (1-0)
+    16:00  Dakkada FC                 v MFM FC                     2-0 (1-0)
+    16:00  Kano Pillars FC            v Lobi Stars FC              0-0 (0-0)
+    16:00  Nasarawa United FC         v Gombe United FC            1-1 (0-0)
+    16:00  Plateau United FC          v Kwara United FC            1-0 (1-0)
+    16:00  Remo Stars FC              v Heartland FC               3-0 (2-0)
+    16:00  Rivers United FC           v Katsina United FC          3-0 (1-0)
+    16:00  Shooting Stars SC          v Akwa United FC             1-1 (0-1)
+    16:00  Wikki Tourists FC          v Niger Tornadoes FC         1-0 (1-0)
+
+
+
+» Matchday 3
+  29.12.
+    16:00  Akwa United FC             v Gombe United FC            1-0 (0-0)
+    16:00  Enyimba FC                 v Rivers United FC           0-1 (0-0)
+    16:00  Heartland FC               v Dakkada FC                 1-0 (0-0)
+    16:00  Kwara United FC            v Wikki Tourists FC          1-0 (0-0)
+    16:00  Lobi Stars FC              v Shooting Stars SC          2-1 (0-1)
+    16:00  MFM FC                     v Plateau United FC          1-0 (0-0)
+    16:00  Remo Stars FC              v Nasarawa United FC         0-0 (0-0)
+    16:00  Sunshine Stars FC          v Rangers International FC   0-0 (0-0)
+  30.12.
+    16:00  Katsina United FC          v Kano Pillars FC            1-0 (1-0)
+    16:00  Niger Tornadoes FC         v Abia Warriors FC           1-1 (1-0)
+
+
+
+» Matchday 4
+  02.01.
+    16:00  Dakkada FC                 v Remo Stars FC              1-1 (1-1)
+    16:00  Kano Pillars FC            v Enyimba FC                 2-0 (1-0)
+    16:00  Nasarawa United FC         v Akwa United FC             2-0 (0-0)
+    16:00  Plateau United FC          v Heartland FC               3-0 (1-0)
+    16:00  Rangers International FC   v Niger Tornadoes FC         4-0 (0-0)
+    16:00  Rivers United FC           v Sunshine Stars FC          0-0 (0-0)
+    16:00  Wikki Tourists FC          v MFM FC                     3-0 (2-0)
+  03.01.
+    15:30  Gombe United FC            v Lobi Stars FC              3-0 (0-0)
+    16:00  Abia Warriors FC           v Kwara United FC            1-1 (1-0)
+    16:00  Shooting Stars SC          v Katsina United FC          1-0 (0-0)
+
+
+
+» Matchday 5
+  08.01.
+    16:00  Niger Tornadoes FC         v Rivers United FC           0-0 (0-0)
+  09.01.
+    16:00  Dakkada FC                 v Nasarawa United FC         2-1 (1-1)
+    16:00  Enyimba FC                 v Shooting Stars SC          1-0 (0-0)
+    16:00  Heartland FC               v Wikki Tourists FC          1-0 (1-0)
+    16:00  Katsina United FC          v Gombe United FC            2-1 (0-1)
+    16:00  Kwara United FC            v Rangers International FC   1-1 (1-0)
+    16:00  Lobi Stars FC              v Akwa United FC             1-0 (0-0)
+    16:00  MFM FC                     v Abia Warriors FC           2-1 (1-0)
+    16:00  Remo Stars FC              v Plateau United FC          1-0 (0-0)
+    16:00  Sunshine Stars FC          v Kano Pillars FC            3-0 (0-0)
+
+
+
+» Matchday 6
+  15.01.
+    14:00  Akwa United FC             v Katsina United FC          2-0 (1-0)
+  16.01.
+    15:30  Gombe United FC            v Enyimba FC                 0-0 (0-0)
+    16:00  Abia Warriors FC           v Heartland FC               1-0 (1-0)
+    16:00  Kano Pillars FC            v Niger Tornadoes FC         1-0 (0-0)
+    16:00  Nasarawa United FC         v Lobi Stars FC              2-1 (1-0)
+    16:00  Plateau United FC          v Dakkada FC                 5-0 (2-0)
+    16:00  Rangers International FC   v MFM FC                     2-0 (2-0)
+    16:00  Rivers United FC           v Kwara United FC            3-0 (1-0)
+    16:00  Shooting Stars SC          v Sunshine Stars FC          2-2 (1-1)
+    16:00  Wikki Tourists FC          v Remo Stars FC              1-2 (0-1)
+
+
+
+» Matchday 7
+  19.01.
+    16:00  Dakkada FC                 v Wikki Tourists FC          0-1 (0-0)
+    16:00  Katsina United FC          v Lobi Stars FC              0-0 (0-0)
+    16:00  MFM FC                     v Rivers United FC           1-3 (0-2)
+    16:00  Niger Tornadoes FC         v Shooting Stars SC          2-0 (1-0)
+    16:00  Plateau United FC          v Nasarawa United FC         3-2 (1-1)
+    16:00  Sunshine Stars FC          v Gombe United FC            2-0 (1-0)
+  20.01.
+    16:00  Kwara United FC            v Kano Pillars FC            1-0 (0-0)
+    16:00  Remo Stars FC              v Abia Warriors FC           1-0 (0-0)
+  21.01.
+    16:00  Heartland FC               v Rangers International FC   0-3 (0-1)
+  26.01.
+    16:00  Enyimba FC                 v Akwa United FC             1-0 (1-0)
+
+
+
+» Matchday 8
+  23.01.
+    16:00  Abia Warriors FC           v Dakkada FC                 1-1 (0-0)
+    16:00  Akwa United FC             v Sunshine Stars FC          0-0 (0-0)
+    16:00  Kano Pillars FC            v MFM FC                     1-0 (1-0)
+    16:00  Lobi Stars FC              v Enyimba FC                 1-0 (0-0)
+    16:00  Nasarawa United FC         v Katsina United FC          1-0 (0-0)
+    16:00  Wikki Tourists FC          v Plateau United FC          2-1 (1-1)
+  24.01.
+    16:00  Gombe United FC            v Niger Tornadoes FC         1-0 (1-0)
+    16:00  Rivers United FC           v Heartland FC               3-1 (2-0)
+  26.01.
+    16:00  Rangers International FC   v Remo Stars FC              0-0 (0-0)
+    16:00  Shooting Stars SC          v Kwara United FC            2-1 (0-0)
+
+
+
+» Matchday 9
+  29.01.
+    16:00  Enyimba FC                 v Katsina United FC          2-1 (1-0)
+    16:00  Heartland FC               v Kano Pillars FC            0-1 (0-0)
+    16:00  Sunshine Stars FC          v Lobi Stars FC              3-0 (3-0)
+  30.01.
+    16:00  Dakkada FC                 v Rangers International FC   0-0 (0-0)
+    16:00  Kwara United FC            v Gombe United FC            2-0 (2-0)
+    16:00  MFM FC                     v Shooting Stars SC          0-1 (0-1)
+    16:00  Niger Tornadoes FC         v Akwa United FC             0-1 (0-0)
+    16:00  Plateau United FC          v Abia Warriors FC           1-0 (0-0)
+    16:00  Remo Stars FC              v Rivers United FC           1-1 (1-1)
+    16:00  Wikki Tourists FC          v Nasarawa United FC         2-0 (1-0)
+
+
+
+» Matchday 10
+  02.02.
+    16:00  Abia Warriors FC           v Wikki Tourists FC          3-0 (1-0)
+    16:00  Akwa United FC             v Kwara United FC            1-1 (1-0)
+    16:00  Kano Pillars FC            v Remo Stars FC              0-0 (0-0)
+    16:00  Katsina United FC          v Sunshine Stars FC          1-0 (1-0)
+    16:00  Lobi Stars FC              v Niger Tornadoes FC         1-1 (0-0)
+    16:00  Nasarawa United FC         v Enyimba FC                 2-1 (1-1)
+    16:00  Rangers International FC   v Plateau United FC          0-1 (0-1)
+    16:00  Rivers United FC           v Dakkada FC                 2-1 (1-1)
+    16:00  Shooting Stars SC          v Heartland FC               4-0 (0-0)
+  03.02.
+    16:00  Gombe United FC            v MFM FC                     3-0 (3-0)
+
+
+
+» Matchday 11
+  05.02.
+    16:00  Abia Warriors FC           v Nasarawa United FC         1-1 (1-0)
+    16:00  Dakkada FC                 v Kano Pillars FC            1-0 (0-0)
+  06.02.
+    16:00  Kwara United FC            v Lobi Stars FC              1-0 (0-0)
+    16:00  MFM FC                     v Akwa United FC             0-0 (0-0)
+    16:00  Niger Tornadoes FC         v Katsina United FC          2-1 (2-1)
+    16:00  Plateau United FC          v Rivers United FC           1-0 (1-0)
+    16:00  Remo Stars FC              v Shooting Stars SC          1-0 (0-0)
+    16:00  Sunshine Stars FC          v Enyimba FC                 0-1 (0-0)
+    16:00  Wikki Tourists FC          v Rangers International FC   0-0 (0-0)
+  09.02.
+    16:00  Heartland FC               v Gombe United FC            1-1 (0-1)
+
+
+
+» Matchday 12
+  12.02.
+    16:00  Enyimba FC                 v Niger Tornadoes FC         1-1 (1-1)
+    16:00  Katsina United FC          v Kwara United FC            1-0 (0-0)
+    16:00  Rivers United FC           v Wikki Tourists FC          3-0 (1-0)
+  13.02.
+    16:00  Akwa United FC             v Heartland FC               0-0 (0-0)
+    16:00  Gombe United FC            v Remo Stars FC              1-0 (1-0)
+    16:00  Kano Pillars FC            v Plateau United FC          0-1 (0-0)
+    16:00  Lobi Stars FC              v MFM FC                     2-1 (2-0)
+    16:00  Nasarawa United FC         v Sunshine Stars FC          1-1 (1-1)
+    16:00  Rangers International FC   v Abia Warriors FC           2-1 (0-0)
+    16:00  Shooting Stars SC          v Dakkada FC                 1-0 (0-0)
+
+
+
+» Matchday 13
+  16.02.
+    16:00  Kwara United FC            v Enyimba FC                 1-0 (1-0)
+    16:00  MFM FC                     v Katsina United FC          1-0 (0-0)
+    16:00  Niger Tornadoes FC         v Sunshine Stars FC          1-0 (0-0)
+    16:00  Plateau United FC          v Shooting Stars SC          3-1 (1-1)
+    16:00  Remo Stars FC              v Akwa United FC             0-1 (0-1)
+    16:00  Wikki Tourists FC          v Kano Pillars FC            2-1 (0-1)
+  17.02.
+    16:00  Abia Warriors FC           v Rivers United FC           1-1 (1-0)
+    16:00  Dakkada FC                 v Gombe United FC            0-1 (0-0)
+    16:00  Heartland FC               v Lobi Stars FC              1-0 (0-0)
+    16:00  Rangers International FC   v Nasarawa United FC         1-0 (0-0)
+
+
+
+» Matchday 14
+  19.02.
+    16:00  Enyimba FC                 v MFM FC                     1-1 (1-1)
+  20.02.
+    16:00  Akwa United FC             v Dakkada FC                 3-2 (1-1)
+    16:00  Rivers United FC           v Rangers International FC   1-0 (0-0)
+    16:00  Shooting Stars SC          v Wikki Tourists FC          0-0 (0-0)
+    16:00  Sunshine Stars FC          v Kwara United FC            1-0 (1-0)
+  21.02.
+    16:00  Kano Pillars FC            v Abia Warriors FC           2-1 (1-1)
+    16:00  Katsina United FC          v Heartland FC               1-1 (1-1)
+    16:00  Lobi Stars FC              v Remo Stars FC              1-0 (1-0)
+    16:00  Nasarawa United FC         v Niger Tornadoes FC         1-0 (1-0)
+  23.02.
+    16:00  Gombe United FC            v Plateau United FC          1-1 (0-1)
+
+
+
+» Matchday 15
+  26.02.
+    16:00  Abia Warriors FC           v Shooting Stars SC          2-1 (1-1)
+    16:00  Dakkada FC                 v Lobi Stars FC              2-1 (1-1)
+    16:00  Heartland FC               v Enyimba FC                 1-0 (0-0)
+    16:00  Rangers International FC   v Kano Pillars FC            0-0 (0-0)
+    16:00  Remo Stars FC              v Katsina United FC          2-0 (1-0)
+    16:00  Rivers United FC           v Nasarawa United FC         2-1 (2-0)
+  27.02.
+    16:00  Kwara United FC            v Niger Tornadoes FC         1-0 (1-0)
+    16:00  MFM FC                     v Sunshine Stars FC          1-0 (0-0)
+    16:00  Plateau United FC          v Akwa United FC             3-0 (1-0)
+    16:00  Wikki Tourists FC          v Gombe United FC            1-0 (0-0)
+
+
+
+» Matchday 16
+  02.03.
+    16:00  Akwa United FC             v Wikki Tourists FC          2-0 (0-0)
+    16:00  Enyimba FC                 v Remo Stars FC              2-1 (1-0)
+    16:00  Gombe United FC            v Abia Warriors FC           1-0 (0-0)
+    16:00  Kano Pillars FC            v Rivers United FC           0-1 (0-0)
+    16:00  Katsina United FC          v Dakkada FC                 4-1 (2-0)
+    16:00  Lobi Stars FC              v Plateau United FC          0-2 (0-1)
+    16:00  Nasarawa United FC         v Kwara United FC            1-1 (0-1)
+    16:00  Niger Tornadoes FC         v MFM FC                     1-1 (1-1)
+    16:00  Sunshine Stars FC          v Heartland FC               3-1 (2-0)
+    19:00  Shooting Stars SC          v Rangers International FC   1-1 (0-1)
+
+
+
+» Matchday 17
+  05.03.
+    16:00  Heartland FC               v Niger Tornadoes FC         1-0 (1-0)
+    16:00  Rangers International FC   v Gombe United FC            1-0 (0-0)
+  06.03.
+    16:00  Abia Warriors FC           v Akwa United FC             0-0 (0-0)
+    16:00  Dakkada FC                 v Enyimba FC                 2-0 (2-0)
+    16:00  Kano Pillars FC            v Nasarawa United FC         2-0 (2-0)
+    16:00  MFM FC                     v Kwara United FC            1-2 (1-2)
+    16:00  Plateau United FC          v Katsina United FC          1-0 (0-0)
+    16:00  Remo Stars FC              v Sunshine Stars FC          3-0 (1-0)
+    16:00  Rivers United FC           v Shooting Stars SC          2-0 (2-0)
+    16:00  Wikki Tourists FC          v Lobi Stars FC              1-0 (1-0)
+
+
+
+» Matchday 18
+  12.03.
+    16:00  Enyimba FC                 v Plateau United FC          1-1 (1-0)
+    16:00  Niger Tornadoes FC         v Remo Stars FC              1-0 (1-0)
+  13.03.
+    16:00  Akwa United FC             v Rangers International FC   0-3 (0-0)
+    16:00  Gombe United FC            v Rivers United FC           0-0 (0-0)
+    16:00  Katsina United FC          v Wikki Tourists FC          1-0 (1-0)
+    16:00  Kwara United FC            v Heartland FC               2-1 (0-0)
+    16:00  Lobi Stars FC              v Abia Warriors FC           1-2 (0-0)
+    16:00  Nasarawa United FC         v MFM FC                     1-1 (1-1)
+    16:00  Sunshine Stars FC          v Dakkada FC                 2-1 (1-1)
+    19:00  Shooting Stars SC          v Kano Pillars FC            1-0 (1-0)
+
+
+
+» Matchday 19
+  19.03.
+    16:00  Abia Warriors FC           v Katsina United FC          2-2 (2-2)
+    16:00  Dakkada FC                 v Niger Tornadoes FC         2-1 (2-0)
+    16:00  Heartland FC               v MFM FC                     0-0 (0-0)
+    16:00  Rangers International FC   v Lobi Stars FC              5-3 (3-0)
+  20.03.
+    16:00  Kano Pillars FC            v Gombe United FC            3-1 (2-1)
+    16:00  Plateau United FC          v Sunshine Stars FC          2-0 (1-0)
+    16:00  Remo Stars FC              v Kwara United FC            3-0 (0-0)
+    16:00  Rivers United FC           v Akwa United FC             4-1 (4-0)
+    16:00  Wikki Tourists FC          v Enyimba FC                 0-0 (0-0)
+    19:00  Shooting Stars SC          v Nasarawa United FC         1-0 (1-0)
+
+
+
+» Matchday 20
+  02.04.
+    16:00  Akwa United FC             v Rivers United FC           1-1 (0-1)
+  03.04.
+    16:00  Enyimba FC                 v Wikki Tourists FC          2-0 (1-0)
+    16:00  Gombe United FC            v Kano Pillars FC            1-0 (0-0)
+    16:00  Kwara United FC            v Remo Stars FC              2-1 (1-1)
+    16:00  Lobi Stars FC              v Rangers International FC   2-0 (0-0)
+    16:00  MFM FC                     v Heartland FC               1-0 (1-0)
+    16:00  Nasarawa United FC         v Shooting Stars SC          2-0 (0-0)
+    16:00  Niger Tornadoes FC         v Dakkada FC                 1-0 (0-0)
+    16:00  Sunshine Stars FC          v Plateau United FC          1-0 (0-0)
+  27.04.
+    16:00  Katsina United FC          v Abia Warriors FC           2-1 (1-1)
+
+
+
+» Matchday 21
+  06.04.
+    16:00  Abia Warriors FC           v Enyimba FC                 2-1 (2-1)
+    16:00  Dakkada FC                 v Kwara United FC            2-0 (1-0)
+    16:00  Kano Pillars FC            v Akwa United FC             0-0 (0-0)
+    16:00  Nasarawa United FC         v Heartland FC               2-0 (1-0)
+    16:00  Rangers International FC   v Katsina United FC          1-0 (0-0)
+    16:00  Remo Stars FC              v MFM FC                     1-0 (1-0)
+    16:00  Shooting Stars SC          v Gombe United FC            0-0 (0-0)
+  07.04.
+    16:00  Plateau United FC          v Niger Tornadoes FC         1-0 (0-0)
+    16:00  Rivers United FC           v Lobi Stars FC              1-0 (1-0)
+    16:00  Wikki Tourists FC          v Sunshine Stars FC          1-0 (1-0)
+
+
+
+» Matchday 22
+  10.04.
+    16:00  Enyimba FC                 v Rangers International FC   2-1 (1-1)
+    16:00  Lobi Stars FC              v Kano Pillars FC            0-0 (0-0)
+    16:00  MFM FC                     v Dakkada FC                 2-0 (1-0)
+    16:00  Niger Tornadoes FC         v Wikki Tourists FC          1-0 (0-0)
+    16:00  Sunshine Stars FC          v Abia Warriors FC           1-0 (1-0)
+  11.04.
+    16:00  Akwa United FC             v Shooting Stars SC          2-1 (1-0)
+    16:00  Gombe United FC            v Nasarawa United FC         3-1 (2-0)
+    16:00  Kwara United FC            v Plateau United FC          1-1 (1-1)
+  12.04.
+    16:00  Heartland FC               v Remo Stars FC              0-0 (0-0)
+  13.04.
+    16:00  Katsina United FC          v Rivers United FC           0-1 (0-0)
+
+
+
+» Matchday 23
+  16.04.
+    16:00  Abia Warriors FC           v Niger Tornadoes FC         1-1 (1-0)
+    16:00  Dakkada FC                 v Heartland FC               2-1 (1-0)
+    16:00  Gombe United FC            v Akwa United FC             1-1 (1-1)
+    16:00  Nasarawa United FC         v Remo Stars FC              1-1 (0-0)
+    16:00  Rangers International FC   v Sunshine Stars FC          0-0 (0-0)
+    16:00  Shooting Stars SC          v Lobi Stars FC              3-0 (2-0)
+    16:00  Wikki Tourists FC          v Kwara United FC            1-1 (1-0)
+  17.04.
+    16:00  Plateau United FC          v MFM FC                     2-0 (2-0)
+  18.04.
+    16:00  Rivers United FC           v Enyimba FC                 2-0 (2-0)
+  26.05.
+    08:30  Kano Pillars FC            v Katsina United FC          1-0 (0-0)
+
+
+
+» Matchday 24
+  20.04.
+    16:00  Katsina United FC          v Shooting Stars SC          3-1 (1-0)
+    16:00  Kwara United FC            v Abia Warriors FC           1-1 (1-0)
+    16:00  Lobi Stars FC              v Gombe United FC            2-1 (1-0)
+    16:00  Niger Tornadoes FC         v Rangers International FC   2-1 (1-0)
+    16:00  Remo Stars FC              v Dakkada FC                 4-1 (1-1)
+  21.04.
+    16:00  Akwa United FC             v Nasarawa United FC         6-1 (4-0)
+    16:00  Enyimba FC                 v Kano Pillars FC            4-0 (1-0)
+    16:00  Heartland FC               v Plateau United FC          1-0 (1-0)
+    16:00  MFM FC                     v Wikki Tourists FC          0-2 (0-1)
+    16:00  Sunshine Stars FC          v Rivers United FC           1-0 (1-0)
+
+
+
+» Matchday 25
+  04.05.
+    16:00  Abia Warriors FC           v MFM FC                     2-1 (2-1)
+  24.04.
+    16:00  Akwa United FC             v Lobi Stars FC              1-0 (1-0)
+    16:00  Gombe United FC            v Katsina United FC          1-0 (1-0)
+    16:00  Rangers International FC   v Kwara United FC            3-0 (3-0)
+  25.04.
+    16:00  Plateau United FC          v Remo Stars FC              1-0 (0-0)
+    16:00  Rivers United FC           v Niger Tornadoes FC         3-0 (2-0)
+    16:00  Shooting Stars SC          v Enyimba FC                 2-0 (2-0)
+    16:00  Wikki Tourists FC          v Heartland FC               0-0 (0-0)
+  26.04.
+    16:00  Nasarawa United FC         v Dakkada FC                 1-0 (1-0)
+  27.04.
+    16:00  Kano Pillars FC            v Sunshine Stars FC          1-0 (1-0)
+
+
+
+» Matchday 26
+  01.05.
+    16:00  Heartland FC               v Abia Warriors FC           2-1 (2-1)
+    16:00  Katsina United FC          v Akwa United FC             1-0 (0-0)
+    16:00  Kwara United FC            v Rivers United FC           2-1 (0-1)
+    16:00  Lobi Stars FC              v Nasarawa United FC         2-1 (0-0)
+    16:00  MFM FC                     v Rangers International FC   0-0 (0-0)
+    16:00  Remo Stars FC              v Wikki Tourists FC          1-0 (1-0)
+    16:00  Sunshine Stars FC          v Shooting Stars SC          0-0 (0-0)
+  30.04.
+    16:00  Dakkada FC                 v Plateau United FC          1-0 (0-0)
+    16:00  Enyimba FC                 v Gombe United FC            3-0 (3-0)
+    16:00  Niger Tornadoes FC         v Kano Pillars FC            2-1 (0-1)
+
+
+
+» Matchday 27
+  07.05.
+    16:00  Abia Warriors FC           v Remo Stars FC              2-0 (0-0)
+    16:00  Rangers International FC   v Heartland FC               3-1 (2-1)
+  08.05.
+    16:00  Akwa United FC             v Enyimba FC                 1-1 (1-0)
+    16:00  Gombe United FC            v Sunshine Stars FC          1-0 (1-0)
+    16:00  Kano Pillars FC            v Kwara United FC            2-1 (0-1)
+    16:00  Lobi Stars FC              v Katsina United FC          2-1 (0-1)
+    16:00  Nasarawa United FC         v Plateau United FC          2-1 (1-1)
+    16:00  Rivers United FC           v MFM FC                     5-0 (2-0)
+    16:00  Shooting Stars SC          v Niger Tornadoes FC         1-0 (1-0)
+    16:00  Wikki Tourists FC          v Dakkada FC                 2-0 (1-0)
+
+
+
+» Matchday 28
+  08.06.
+    16:00  Dakkada FC                 v Abia Warriors FC           2-1 (1-1)
+  14.05.
+    16:00  Enyimba FC                 v Lobi Stars FC              2-1 (0-0)
+    16:00  Heartland FC               v Rivers United FC           2-0 (0-0)
+    16:00  Niger Tornadoes FC         v Gombe United FC            1-0 (1-0)
+  15.05.
+    08:15  MFM FC                     v Kano Pillars FC            2-1 (1-1)
+    16:00  Katsina United FC          v Nasarawa United FC         1-0 (1-0)
+    16:00  Kwara United FC            v Shooting Stars SC          3-1 (1-0)
+    16:00  Plateau United FC          v Wikki Tourists FC          3-1 (1-0)
+    16:00  Remo Stars FC              v Rangers International FC   1-0 (1-0)
+    16:00  Sunshine Stars FC          v Akwa United FC             0-0 (0-0)
+
+
+
+» Matchday 29
+  21.05.
+    16:00  Abia Warriors FC           v Plateau United FC          2-0 (1-0)
+    16:00  Rangers International FC   v Dakkada FC                 1-0 (0-0)
+  22.05.
+    16:00  Akwa United FC             v Niger Tornadoes FC         1-0 (0-0)
+    16:00  Gombe United FC            v Kwara United FC            4-2 (1-1)
+    16:00  Kano Pillars FC            v Heartland FC               3-1 (2-0)
+    16:00  Katsina United FC          v Enyimba FC                 1-0 (0-0)
+    16:00  Lobi Stars FC              v Sunshine Stars FC          0-0 (0-0)
+    16:00  Nasarawa United FC         v Wikki Tourists FC          1-0 (1-0)
+    16:00  Rivers United FC           v Remo Stars FC              1-0 (0-0)
+    16:00  Shooting Stars SC          v MFM FC                     1-1 (1-0)
+
+
+
+» Matchday 30
+  22.06.
+    15:00  Niger Tornadoes FC         v Lobi Stars FC              0-1 (0-0)
+  28.05.
+    11:00  MFM FC                     v Gombe United FC            3-1 (1-1)
+    16:00  Dakkada FC                 v Rivers United FC           2-3 (1-1)
+    16:00  Enyimba FC                 v Nasarawa United FC         3-2 (1-0)
+    16:00  Heartland FC               v Shooting Stars SC          3-1 (1-1)
+    16:00  Kwara United FC            v Akwa United FC             1-0 (1-0)
+    16:00  Plateau United FC          v Rangers International FC   4-0 (2-0)
+    16:00  Remo Stars FC              v Kano Pillars FC            1-3 (1-2)
+    16:00  Sunshine Stars FC          v Katsina United FC          2-0 (0-0)
+    16:00  Wikki Tourists FC          v Abia Warriors FC           1-0 (1-0)
+
+
+
+» Matchday 31
+  01.06.
+    16:00  Akwa United FC             v MFM FC                     0-0 (0-0)
+    16:00  Enyimba FC                 v Sunshine Stars FC          2-0 (1-0)
+    16:00  Gombe United FC            v Heartland FC               3-2 (1-0)
+    16:00  Katsina United FC          v Niger Tornadoes FC         2-0 (0-0)
+    16:00  Lobi Stars FC              v Kwara United FC            3-1 (1-1)
+    16:00  Nasarawa United FC         v Abia Warriors FC           2-1 (1-0)
+    16:00  Rangers International FC   v Wikki Tourists FC          2-1 (1-1)
+    16:00  Rivers United FC           v Plateau United FC          2-0 (1-0)
+    16:00  Shooting Stars SC          v Remo Stars FC              1-1 (1-1)
+  23.06.
+    16:00  Kano Pillars FC            v Dakkada FC                 1-0 (1-0)
+
+
+
+» Matchday 32
+  05.06.
+    14:00  Abia Warriors FC           v Rangers International FC   2-0 (1-0)
+    14:00  Heartland FC               v Akwa United FC             1-0 (0-0)
+    16:00  Dakkada FC                 v Shooting Stars SC          2-0 (1-0)
+    16:00  Kwara United FC            v Katsina United FC          2-0 (1-0)
+    16:00  MFM FC                     v Lobi Stars FC              0-0 (0-0)
+    16:00  Niger Tornadoes FC         v Enyimba FC                 2-1 (2-1)
+    16:00  Plateau United FC          v Kano Pillars FC            1-0 (1-0)
+    16:00  Remo Stars FC              v Gombe United FC            1-0 (1-0)
+    16:00  Sunshine Stars FC          v Nasarawa United FC         2-1 (2-0)
+    16:00  Wikki Tourists FC          v Rivers United FC           1-0 (1-0)
+
+
+
+» Matchday 33
+  12.06.
+    08:00  Enyimba FC                 v Kwara United FC            3-0 (2-0)
+    16:00  Akwa United FC             v Remo Stars FC              1-0 (0-0)
+    16:00  Gombe United FC            v Dakkada FC                 2-2 (1-2)
+    16:00  Kano Pillars FC            v Wikki Tourists FC          1-1 (1-1)
+    16:00  Katsina United FC          v MFM FC                     2-1 (1-0)
+    16:00  Lobi Stars FC              v Heartland FC               2-1 (0-0)
+    16:00  Nasarawa United FC         v Rangers International FC   1-0 (0-0)
+    16:00  Rivers United FC           v Abia Warriors FC           2-1 (0-1)
+    16:00  Shooting Stars SC          v Plateau United FC          2-1 (1-0)
+    16:00  Sunshine Stars FC          v Niger Tornadoes FC         2-1 (1-1)
+
+
+
+» Matchday 34
+  18.06.
+    16:00  Abia Warriors FC           v Kano Pillars FC            3-2 (2-1)
+    16:00  Heartland FC               v Katsina United FC          1-0 (1-0)
+    16:00  Niger Tornadoes FC         v Nasarawa United FC         1-0 (0-0)
+    16:00  Rangers International FC   v Rivers United FC           0-0 (0-0)
+  19.06.
+    16:00  Dakkada FC                 v Akwa United FC             3-1 (1-1)
+    16:00  Kwara United FC            v Sunshine Stars FC          1-0 (1-0)
+    16:00  MFM FC                     v Enyimba FC                 2-1 (0-0)
+    16:00  Plateau United FC          v Gombe United FC            1-1 (0-0)
+    16:00  Remo Stars FC              v Lobi Stars FC              3-1 (1-0)
+    16:00  Wikki Tourists FC          v Shooting Stars SC          1-1 (0-0)
+
+
+
+» Matchday 35
+  25.06.
+    16:00  Akwa United FC             v Plateau United FC          2-1 (1-0)
+    16:00  Niger Tornadoes FC         v Kwara United FC            4-0 (2-0)
+  26.06.
+    16:00  Enyimba FC                 v Heartland FC               0-0 (0-0)
+    16:00  Gombe United FC            v Wikki Tourists FC          2-1 (1-1)
+    16:00  Kano Pillars FC            v Rangers International FC   1-0 (0-0)
+    16:00  Katsina United FC          v Remo Stars FC              3-2 (2-0)
+    16:00  Lobi Stars FC              v Dakkada FC                 1-0 (1-0)
+    16:00  Nasarawa United FC         v Rivers United FC           2-1 (1-0)
+    16:00  Shooting Stars SC          v Abia Warriors FC           2-2 (2-1)
+    16:00  Sunshine Stars FC          v MFM FC                     2-1 (1-0)
+
+
+
+» Matchday 36
+  02.07.
+    16:00  Abia Warriors FC           v Gombe United FC            3-2 (2-1)
+    16:00  Dakkada FC                 v Katsina United FC          2-0 (1-0)
+    16:00  Heartland FC               v Sunshine Stars FC          1-0 (1-0)
+    16:00  Rangers International FC   v Shooting Stars SC          2-2 (0-0)
+  03.07.
+    16:00  Kwara United FC            v Nasarawa United FC         3-0 (1-0)
+    16:00  MFM FC                     v Niger Tornadoes FC         1-2 (0-1)
+    16:00  Plateau United FC          v Lobi Stars FC              2-1 (1-1)
+    16:00  Remo Stars FC              v Enyimba FC                 1-0 (0-0)
+    16:00  Rivers United FC           v Kano Pillars FC            1-0 (0-0)
+    16:00  Wikki Tourists FC          v Akwa United FC             2-0 (2-0)
+
+
+
+» Matchday 37
+  10.07.
+    16:00  Akwa United FC             v Abia Warriors FC           2-2 (2-1)
+    16:00  Enyimba FC                 v Dakkada FC                 0-2 (0-0)
+    16:00  Gombe United FC            v Rangers International FC   1-0 (0-0)
+    16:00  Katsina United FC          v Plateau United FC          2-0 (0-0)
+    16:00  Kwara United FC            v MFM FC                     3-0 (2-0)
+    16:00  Lobi Stars FC              v Wikki Tourists FC          3-2 (1-2)
+    16:00  Nasarawa United FC         v Kano Pillars FC            1-0 (0-0)
+    16:00  Niger Tornadoes FC         v Heartland FC               2-1 (0-0)
+    16:00  Shooting Stars SC          v Rivers United FC           3-2 (3-1)
+    16:00  Sunshine Stars FC          v Remo Stars FC              0-1 (0-0)
+
+
+
+» Matchday 38
+  17.07.
+    16:00  Abia Warriors FC           v Lobi Stars FC              3-0 (2-0)
+    16:00  Dakkada FC                 v Sunshine Stars FC          3-0 (2-0)
+    16:00  Heartland FC               v Kwara United FC            1-0 (1-0)
+    16:00  Kano Pillars FC            v Shooting Stars SC          2-1 (1-1)
+    16:00  MFM FC                     v Nasarawa United FC         0-1 (0-1)
+    16:00  Plateau United FC          v Enyimba FC                 1-0 (0-0)
+    16:00  Rangers International FC   v Akwa United FC             2-0 (1-0)
+    16:00  Remo Stars FC              v Niger Tornadoes FC         3-0 (1-0)
+    16:00  Rivers United FC           v Gombe United FC            1-0 (1-0)
+    16:00  Wikki Tourists FC          v Katsina United FC          2-0 (1-0)
+

--- a/africa/nigeria/2022-23_ng1.txt
+++ b/africa/nigeria/2022-23_ng1.txt
@@ -1,0 +1,355 @@
+= Nigeria Professional Football League 2022/2023
+
+# Teams      20
+# Matches    195
+# Stages     NPFL (180)  NPFL - Championship Group (15)
+
+
+
+======================================================================
+  NPFL
+======================================================================
+
+
+
+» Matchday 1
+  08.01.
+    16:00  Akwa United FC             v Bendel FC                  0-2 (0-2)
+  14.01.
+    16:00  Nasarawa United FC         v Enyimba FC                 1-2 (0-2)
+  15.01.
+    15:00  Rangers International FC   v Abia Warriors FC           0-2 (0-1)
+    16:00  Bayelsa United FC          v Dakkada FC                 1-1 (1-0)
+    16:00  Doma United FC             v Sunshine Stars FC          1-1 (1-0)
+    16:00  Kwara United FC            v Gombe United FC            0-0 (0-0)
+    16:00  Plateau United FC          v Shooting Stars SC          3-3 (1-2)
+    16:00  Remo Stars FC              v El-Kanemi Warriors FC      2-0 (1-0)
+    16:00  Rivers United FC           v Lobi Stars FC              2-1 (1-0)
+    16:00  Wikki Tourists FC          v Niger Tornadoes FC         0-2 (0-0)
+
+
+
+» Matchday 2
+  18.01.
+    16:00  Abia Warriors FC           v Bayelsa United FC          3-1 (1-0)
+    16:00  Dakkada FC                 v Wikki Tourists FC          2-1 (1-1)
+    16:00  Enyimba FC                 v Akwa United FC             0-0 (0-0)
+    16:00  Lobi Stars FC              v Rangers International FC   1-0 (0-0)
+  19.01.
+    16:00  Bendel FC                  v Plateau United FC          2-1 (0-0)
+    16:00  El-Kanemi Warriors FC      v Nasarawa United FC         2-1 (1-0)
+    16:00  Gombe United FC            v Remo Stars FC              0-1 (0-0)
+    16:00  Niger Tornadoes FC         v Doma United FC             1-0 (1-0)
+    16:00  Shooting Stars SC          v Kwara United FC            0-0 (0-0)
+    16:00  Sunshine Stars FC          v Rivers United FC           1-1 (0-1)
+
+
+
+» Matchday 3
+  22.01.
+    14:00  Nasarawa United FC         v Akwa United FC             0-3 (0-1)
+    15:00  Abia Warriors FC           v Lobi Stars FC              0-1 (0-0)
+    15:00  Rangers International FC   v Sunshine Stars FC          1-1 (1-1)
+    16:00  Bayelsa United FC          v Wikki Tourists FC          2-1 (1-0)
+    16:00  Doma United FC             v Dakkada FC                 1-0 (0-0)
+    16:00  El-Kanemi Warriors FC      v Gombe United FC            0-0 (0-0)
+    16:00  Kwara United FC            v Bendel FC                  0-1 (0-1)
+    16:00  Plateau United FC          v Enyimba FC                 2-1 (1-1)
+  24.01.
+    16:00  Rivers United FC           v Niger Tornadoes FC         2-1 (2-1)
+  25.01.
+    16:00  Remo Stars FC              v Shooting Stars SC          2-0 (0-0)
+
+
+
+» Matchday 4
+  28.01.
+    16:00  Bendel FC                  v Remo Stars FC              3-0 (2-0)
+    16:00  Dakkada FC                 v Rivers United FC           1-2 (1-2)
+  29.01.
+    15:00  Akwa United FC             v Plateau United FC          1-0 (0-0)
+    15:00  Enyimba FC                 v Kwara United FC            3-0 (2-0)
+    16:00  Gombe United FC            v Nasarawa United FC         1-1 (0-1)
+    16:00  Lobi Stars FC              v Bayelsa United FC          3-0 (0-0)
+    16:00  Niger Tornadoes FC         v Rangers International FC   0-0 (0-0)
+    16:00  Shooting Stars SC          v El-Kanemi Warriors FC      1-0 (0-0)
+    16:00  Sunshine Stars FC          v Abia Warriors FC           1-0 (1-0)
+    16:00  Wikki Tourists FC          v Doma United FC             0-0 (0-0)
+
+
+
+» Matchday 5
+  01.02.
+    16:00  Abia Warriors FC           v Niger Tornadoes FC         1-0 (1-0)
+    16:00  Bayelsa United FC          v Doma United FC             1-1 (0-1)
+    16:00  El-Kanemi Warriors FC      v Bendel FC                  0-1 (0-1)
+    16:00  Gombe United FC            v Shooting Stars SC          2-1 (0-0)
+    16:00  Kwara United FC            v Akwa United FC             2-1 (1-0)
+    16:00  Lobi Stars FC              v Sunshine Stars FC          1-0 (0-0)
+    16:00  Nasarawa United FC         v Plateau United FC          1-2 (1-1)
+    16:00  Rangers International FC   v Dakkada FC                 1-0 (1-0)
+    16:00  Remo Stars FC              v Enyimba FC                 1-0 (1-0)
+    16:00  Rivers United FC           v Wikki Tourists FC          2-0 (1-0)
+
+
+
+» Matchday 6
+  04.02.
+    16:00  Bendel FC                  v Gombe United FC            0-0 (0-0)
+    16:00  Dakkada FC                 v Abia Warriors FC           2-4 (0-1)
+  05.02.
+    15:00  Enyimba FC                 v El-Kanemi Warriors FC      2-0 (2-0)
+    16:00  Akwa United FC             v Remo Stars FC              3-1 (2-1)
+    16:00  Doma United FC             v Rivers United FC           2-1 (1-1)
+    16:00  Niger Tornadoes FC         v Lobi Stars FC              0-0 (0-0)
+    16:00  Plateau United FC          v Kwara United FC            1-0 (1-0)
+    16:00  Shooting Stars SC          v Nasarawa United FC         2-0 (2-0)
+    16:00  Sunshine Stars FC          v Bayelsa United FC          1-0 (1-0)
+    16:00  Wikki Tourists FC          v Rangers International FC   1-0 (1-0)
+
+
+
+» Matchday 7
+  11.02.
+    16:00  Gombe United FC            v Enyimba FC                 1-2 (1-1)
+    16:00  Nasarawa United FC         v Kwara United FC            2-0 (1-0)
+  12.02.
+    15:00  Abia Warriors FC           v Wikki Tourists FC          1-1 (1-0)
+    15:00  Rangers International FC   v Doma United FC             1-0 (1-0)
+    15:45  El-Kanemi Warriors FC      v Akwa United FC             1-1 (0-1)
+    16:00  Lobi Stars FC              v Dakkada FC                 2-1 (1-0)
+    16:00  Remo Stars FC              v Plateau United FC          1-1 (1-0)
+    16:00  Shooting Stars SC          v Bendel FC                  2-2 (1-2)
+    16:00  Sunshine Stars FC          v Niger Tornadoes FC         2-0 (2-0)
+  22.02.
+    16:00  Bayelsa United FC          v Rivers United FC           2-2 (0-1)
+
+
+
+» Matchday 8
+  15.02.
+    16:00  Bendel FC                  v Nasarawa United FC         1-0 (0-0)
+    16:00  Dakkada FC                 v Sunshine Stars FC          2-1 (0-0)
+    16:00  Doma United FC             v Abia Warriors FC           1-0 (0-0)
+    16:00  Enyimba FC                 v Shooting Stars SC          2-0 (2-0)
+    16:00  Kwara United FC            v Remo Stars FC              0-0 (0-0)
+    16:00  Niger Tornadoes FC         v Bayelsa United FC          1-1 (1-1)
+    16:00  Plateau United FC          v El-Kanemi Warriors FC      5-0 (3-0)
+    16:00  Wikki Tourists FC          v Lobi Stars FC              2-1 (2-1)
+  16.02.
+    16:00  Akwa United FC             v Gombe United FC            1-0 (1-0)
+  22.03.
+    16:00  Rivers United FC           v Rangers International FC   1-0 (0-0)
+
+
+
+» Matchday 9
+  04.03.
+    16:00  Abia Warriors FC           v Rivers United FC           0-0 (0-0)
+  19.02.
+    16:00  Bayelsa United FC          v Rangers International FC   1-1 (1-1)
+    16:00  Bendel FC                  v Enyimba FC                 1-0 (1-0)
+    16:00  Lobi Stars FC              v Doma United FC             2-0 (2-0)
+    16:00  Niger Tornadoes FC         v Dakkada FC                 1-0 (1-0)
+    16:00  Shooting Stars SC          v Akwa United FC             2-2 (2-2)
+    16:00  Sunshine Stars FC          v Wikki Tourists FC          1-0 (0-0)
+  20.02.
+    16:00  Gombe United FC            v Plateau United FC          3-2 (2-1)
+    16:00  Nasarawa United FC         v Remo Stars FC              2-0 (1-0)
+  22.02.
+    16:00  El-Kanemi Warriors FC      v Kwara United FC            1-2 (1-0)
+
+
+
+» Matchday 10
+  25.03.
+    16:00  Dakkada FC                 v Niger Tornadoes FC         1-2 (0-2)
+  26.03.
+    15:00  Rangers International FC   v Bayelsa United FC          2-1 (0-1)
+    16:00  Akwa United FC             v Shooting Stars SC          2-0 (0-0)
+    16:00  Doma United FC             v Lobi Stars FC              2-0 (0-0)
+    16:00  Enyimba FC                 v Bendel FC                  1-1 (1-0)
+    16:00  Kwara United FC            v El-Kanemi Warriors FC      2-0 (0-0)
+    16:00  Plateau United FC          v Gombe United FC            2-0 (1-0)
+    16:00  Remo Stars FC              v Nasarawa United FC         1-0 (1-0)
+    16:00  Rivers United FC           v Abia Warriors FC           1-1 (0-0)
+    16:00  Wikki Tourists FC          v Sunshine Stars FC          1-1 (0-0)
+
+
+
+» Matchday 11
+  12.04.
+    16:00  Lobi Stars FC              v Rivers United FC           3-2 (0-0)
+  29.03.
+    16:00  Abia Warriors FC           v Rangers International FC   2-1 (1-1)
+    16:00  Bendel FC                  v Akwa United FC             1-1 (1-1)
+    16:00  Dakkada FC                 v Bayelsa United FC          1-1 (1-1)
+    16:00  El-Kanemi Warriors FC      v Remo Stars FC              1-2 (0-0)
+    16:00  Enyimba FC                 v Nasarawa United FC         1-1 (1-0)
+    16:00  Gombe United FC            v Kwara United FC            1-0 (1-0)
+    16:00  Niger Tornadoes FC         v Wikki Tourists FC          2-0 (1-0)
+    16:00  Shooting Stars SC          v Plateau United FC          3-2 (1-1)
+    16:00  Sunshine Stars FC          v Doma United FC             1-1 (1-1)
+
+
+
+» Matchday 12
+  01.04.
+    16:00  Nasarawa United FC         v El-Kanemi Warriors FC      1-2 (1-1)
+  02.04.
+    15:00  Rangers International FC   v Lobi Stars FC              1-1 (0-0)
+    16:00  Akwa United FC             v Enyimba FC                 1-0 (0-0)
+    16:00  Bayelsa United FC          v Abia Warriors FC           5-1 (5-1)
+    16:00  Doma United FC             v Niger Tornadoes FC         2-1 (1-0)
+    16:00  Kwara United FC            v Shooting Stars SC          0-1 (0-0)
+    16:00  Plateau United FC          v Bendel FC                  1-1 (1-0)
+    16:00  Wikki Tourists FC          v Dakkada FC                 3-1 (1-1)
+  03.04.
+    08:00  Remo Stars FC              v Gombe United FC            0-0 (0-0)
+  15.05.
+    16:00  Rivers United FC           v Sunshine Stars FC          1-0 (1-0)
+
+
+
+» Matchday 13
+  08.04.
+    16:00  Bendel FC                  v Kwara United FC            1-1 (0-0)
+    16:00  Dakkada FC                 v Doma United FC             1-0 (0-0)
+  09.04.
+    15:00  Enyimba FC                 v Plateau United FC          2-1 (1-0)
+    16:00  Akwa United FC             v Nasarawa United FC         2-2 (1-1)
+    16:00  Gombe United FC            v El-Kanemi Warriors FC      1-0 (1-0)
+    16:00  Lobi Stars FC              v Abia Warriors FC           2-0 (2-0)
+    16:00  Niger Tornadoes FC         v Rivers United FC           0-0 (0-0)
+    16:00  Shooting Stars SC          v Remo Stars FC              1-1 (1-0)
+    16:00  Sunshine Stars FC          v Rangers International FC   1-1 (1-1)
+    16:00  Wikki Tourists FC          v Bayelsa United FC          1-2 (1-2)
+
+
+
+» Matchday 14
+  15.04.
+    14:00  Nasarawa United FC         v Gombe United FC            1-1 (0-0)
+  16.04.
+    15:00  Abia Warriors FC           v Sunshine Stars FC          2-1 (0-0)
+    16:00  Bayelsa United FC          v Lobi Stars FC              3-0 (2-0)
+    16:00  Doma United FC             v Wikki Tourists FC          2-0 (1-0)
+    16:00  El-Kanemi Warriors FC      v Shooting Stars SC          0-0 (0-0)
+    16:00  Kwara United FC            v Enyimba FC                 1-2 (1-1)
+    16:00  Plateau United FC          v Akwa United FC             1-0 (1-0)
+    16:00  Rangers International FC   v Niger Tornadoes FC         2-2 (2-0)
+    16:00  Remo Stars FC              v Bendel FC                  1-1 (1-1)
+  17.04.
+    08:00  Rivers United FC           v Dakkada FC                 1-0 (1-0)
+
+
+
+» Matchday 15
+  11.05.
+    16:00  Wikki Tourists FC          v Rivers United FC           1-1 (0-0)
+  22.04.
+    16:00  Bendel FC                  v El-Kanemi Warriors FC      2-1 (0-0)
+  23.04.
+    15:00  Enyimba FC                 v Remo Stars FC              1-1 (0-1)
+    16:00  Doma United FC             v Bayelsa United FC          2-1 (0-0)
+    16:00  Niger Tornadoes FC         v Abia Warriors FC           3-0 (0-0)
+    16:00  Plateau United FC          v Nasarawa United FC         1-0 (1-0)
+    16:00  Shooting Stars SC          v Gombe United FC            3-0 (1-0)
+    16:00  Sunshine Stars FC          v Lobi Stars FC              1-0 (1-0)
+  24.04.
+    14:00  Dakkada FC                 v Rangers International FC   1-1 (1-1)
+    16:00  Akwa United FC             v Kwara United FC            3-1 (3-0)
+
+
+
+» Matchday 16
+  18.05.
+    16:00  Rivers United FC           v Doma United FC             2-0 (2-0)
+  29.04.
+    16:00  Nasarawa United FC         v Shooting Stars SC          1-0 (1-0)
+  30.04.
+    16:00  Abia Warriors FC           v Dakkada FC                 3-0 (1-0)
+    16:00  Bayelsa United FC          v Sunshine Stars FC          2-1 (0-0)
+    16:00  El-Kanemi Warriors FC      v Enyimba FC                 0-1 (0-0)
+    16:00  Gombe United FC            v Bendel FC                  0-0 (0-0)
+    16:00  Kwara United FC            v Plateau United FC          1-1 (1-0)
+    16:00  Lobi Stars FC              v Niger Tornadoes FC         1-0 (0-0)
+    16:00  Rangers International FC   v Wikki Tourists FC          3-0 (1-0)
+    16:00  Remo Stars FC              v Akwa United FC             1-0 (1-0)
+
+
+
+» Matchday 17
+  06.05.
+    16:00  Dakkada FC                 v Lobi Stars FC              1-1 (0-0)
+  07.05.
+    15:00  Enyimba FC                 v Gombe United FC            5-0 (2-0)
+    16:00  Akwa United FC             v El-Kanemi Warriors FC      2-0 (1-0)
+    16:00  Bendel FC                  v Shooting Stars SC          1-1 (0-0)
+    16:00  Doma United FC             v Rangers International FC   0-0 (0-0)
+    16:00  Kwara United FC            v Nasarawa United FC         1-0 (0-0)
+    16:00  Niger Tornadoes FC         v Sunshine Stars FC          0-2 (0-1)
+    16:00  Plateau United FC          v Remo Stars FC              1-2 (0-0)
+    16:00  Rivers United FC           v Bayelsa United FC          2-1 (1-0)
+    16:00  Wikki Tourists FC          v Abia Warriors FC           4-0 (3-0)
+
+
+
+» Matchday 18
+  21.05.
+    14:00  Nasarawa United FC         v Bendel FC                  1-1 (0-1)
+    16:00  Abia Warriors FC           v Doma United FC             2-0 (1-0)
+    16:00  Bayelsa United FC          v Niger Tornadoes FC         2-0 (2-0)
+    16:00  El-Kanemi Warriors FC      v Plateau United FC          2-2 (1-1)
+    16:00  Gombe United FC            v Akwa United FC             0-1 (0-1)
+    16:00  Lobi Stars FC              v Wikki Tourists FC          0-2 (0-1)
+    16:00  Rangers International FC   v Rivers United FC           1-1 (1-0)
+    16:00  Remo Stars FC              v Kwara United FC            4-0 (4-0)
+    16:00  Shooting Stars SC          v Enyimba FC                 0-0 (0-0)
+    16:00  Sunshine Stars FC          v Dakkada FC                 3-0 (2-0)
+
+
+======================================================================
+  NPFL - CHAMPIONSHIP GROUP
+======================================================================
+
+
+
+» Matchday 1
+  03.06.
+    14:00  Enyimba FC                 v Remo Stars FC              2-2 (0-0)
+    16:30  Sunshine Stars FC          v Rivers United FC           0-1 (0-0)
+    19:00  Bendel FC                  v Lobi Stars FC              0-0 (0-0)
+
+
+
+» Matchday 2
+  05.06.
+    14:00  Lobi Stars FC              v Enyimba FC                 0-1 (0-1)
+    16:30  Rivers United FC           v Remo Stars FC              2-2 (1-0)
+    19:00  Bendel FC                  v Sunshine Stars FC          1-1 (1-0)
+
+
+
+» Matchday 3
+  07.06.
+    14:00  Bendel FC                  v Enyimba FC                 1-1 (1-1)
+    16:30  Remo Stars FC              v Sunshine Stars FC          1-1 (1-0)
+    19:00  Lobi Stars FC              v Rivers United FC           0-0 (0-0)
+
+
+
+» Matchday 4
+  09.06.
+    14:00  Rivers United FC           v Bendel FC                  2-1 (1-0)
+    16:30  Lobi Stars FC              v Remo Stars FC              0-2 (0-2)
+    19:00  Sunshine Stars FC          v Enyimba FC                 0-3 (0-2)
+
+
+
+» Matchday 5
+  11.06.
+    14:00  Sunshine Stars FC          v Lobi Stars FC              3-1 (2-0)
+    16:30  Remo Stars FC              v Bendel FC                  1-0 (1-0)
+    19:00  Enyimba FC                 v Rivers United FC           1-1 (1-0)
+

--- a/africa/nigeria/2023-24_ng1.txt
+++ b/africa/nigeria/2023-24_ng1.txt
@@ -1,0 +1,639 @@
+= Nigeria Professional League 2023/2024
+
+# Date       Fri Jan/06 2023 - Thu Dec/28 2023 (356d)
+# Teams      20
+# Matches    380
+
+
+
+» Matchday 1
+  02.10.
+    16:00  Sporting Lagos FC          v Gombe United FC            2-0 (1-0)
+  12.10.
+    16:00  Rivers United FC           v Remo Stars FC              2-0 (1-0)
+  22.11.
+    16:00  Enyimba FC                 v Bendel FC                  2-1 (0-0)
+  30.09.
+    16:00  Abia Warriors FC           v Niger Tornadoes FC         1-0 (0-0)
+    16:00  Bayelsa United FC          v Akwa United FC             5-3 (2-2)
+    16:00  Heartland FC               v Lobi Stars FC              2-2 (0-2)
+    16:00  Katsina United FC          v Kwara United FC            1-0 (0-0)
+    16:00  Rangers International FC   v Doma United FC             2-1 (2-0)
+    16:00  Shooting Stars SC          v Plateau United FC          2-1 (1-0)
+    16:00  Sunshine Stars FC          v Kano Pillars FC            1-0 (1-0)
+
+
+
+» Matchday 2
+  07.10.
+    16:00  Bendel FC                  v Shooting Stars SC          2-0 (1-0)
+    16:00  Doma United FC             v Bayelsa United FC          2-0 (1-0)
+    16:00  Kano Pillars FC            v Katsina United FC          1-0 (1-0)
+  08.10.
+    15:00  Gombe United FC            v Enyimba FC                 2-0 (1-0)
+    16:00  Akwa United FC             v Sporting Lagos FC          0-0 (0-0)
+    16:00  Kwara United FC            v Abia Warriors FC           1-0 (1-0)
+    16:00  Lobi Stars FC              v Sunshine Stars FC          3-2 (0-0)
+    16:00  Niger Tornadoes FC         v Rivers United FC           1-0 (1-0)
+    16:00  Plateau United FC          v Heartland FC               1-0 (1-0)
+    16:00  Remo Stars FC              v Rangers International FC   2-1 (1-1)
+
+
+
+» Matchday 3
+  14.10.
+    16:00  Bendel FC                  v Plateau United FC          1-0 (1-0)
+    16:00  Katsina United FC          v Lobi Stars FC              0-0 (0-0)
+    16:00  Sunshine Stars FC          v Heartland FC               1-1 (1-0)
+  15.10.
+    16:00  Abia Warriors FC           v Kano Pillars FC            1-0 (1-0)
+    16:00  Bayelsa United FC          v Remo Stars FC              1-2 (0-1)
+    16:00  Enyimba FC                 v Akwa United FC             3-2 (2-1)
+    16:00  Rangers International FC   v Niger Tornadoes FC         2-1 (2-0)
+    16:00  Rivers United FC           v Kwara United FC            0-0 (0-0)
+    16:00  Shooting Stars SC          v Gombe United FC            2-1 (0-1)
+    16:00  Sporting Lagos FC          v Doma United FC             0-0 (0-0)
+
+
+
+» Matchday 4
+  15.11.
+    15:00  Doma United FC             v Enyimba FC                 1-0 (1-0)
+  21.10.
+    16:00  Niger Tornadoes FC         v Bayelsa United FC          1-0 (0-0)
+  22.10.
+    15:00  Gombe United FC            v Bendel FC                  1-0 (0-0)
+    16:00  Akwa United FC             v Shooting Stars SC          0-0 (0-0)
+    16:00  Heartland FC               v Katsina United FC          1-1 (1-0)
+    16:00  Kano Pillars FC            v Rivers United FC           1-0 (0-0)
+    16:00  Kwara United FC            v Rangers International FC   1-1 (0-1)
+    16:00  Lobi Stars FC              v Abia Warriors FC           2-0 (2-0)
+    16:00  Plateau United FC          v Sunshine Stars FC          1-0 (1-0)
+    16:00  Remo Stars FC              v Sporting Lagos FC          2-1 (1-1)
+
+
+
+» Matchday 5
+  28.10.
+    15:00  Gombe United FC            v Plateau United FC          1-0 (0-0)
+    16:00  Bendel FC                  v Akwa United FC             0-0 (0-0)
+    16:00  Rangers International FC   v Kano Pillars FC            4-1 (1-1)
+  29.10.
+    16:00  Abia Warriors FC           v Heartland FC               1-0 (1-0)
+    16:00  Bayelsa United FC          v Kwara United FC            2-1 (2-1)
+    16:00  Katsina United FC          v Sunshine Stars FC          3-2 (1-2)
+    16:00  Rivers United FC           v Lobi Stars FC              1-0 (1-0)
+    16:00  Shooting Stars SC          v Doma United FC             3-1 (1-1)
+    18:00  Sporting Lagos FC          v Niger Tornadoes FC         2-1 (2-0)
+  29.11.
+    16:00  Enyimba FC                 v Remo Stars FC              0-1 (0-1)
+
+
+
+» Matchday 6
+  01.11.
+    16:00  Akwa United FC             v Gombe United FC            1-0 (1-0)
+    16:00  Heartland FC               v Rivers United FC           1-1 (1-1)
+    16:00  Kano Pillars FC            v Bayelsa United FC          3-0 (1-0)
+    16:00  Kwara United FC            v Sporting Lagos FC          2-1 (1-1)
+    16:00  Niger Tornadoes FC         v Enyimba FC                 0-0 (0-0)
+    16:00  Plateau United FC          v Katsina United FC          1-0 (1-0)
+    16:00  Remo Stars FC              v Shooting Stars SC          3-0 (2-0)
+    16:00  Sunshine Stars FC          v Abia Warriors FC           2-1 (1-1)
+  02.11.
+    16:00  Lobi Stars FC              v Rangers International FC   2-1 (1-0)
+  08.11.
+    15:00  Doma United FC             v Bendel FC                  0-0 (0-0)
+
+
+
+» Matchday 7
+  05.11.
+    15:00  Gombe United FC            v Doma United FC             0-3 (0-0)
+    16:00  Abia Warriors FC           v Katsina United FC          2-1 (2-0)
+    16:00  Akwa United FC             v Plateau United FC          0-0 (0-0)
+    16:00  Bendel FC                  v Remo Stars FC              1-0 (1-0)
+    16:00  Enyimba FC                 v Kwara United FC            1-0 (1-0)
+    16:00  Rangers International FC   v Heartland FC               2-0 (1-0)
+    16:00  Rivers United FC           v Sunshine Stars FC          1-1 (0-0)
+    16:00  Shooting Stars SC          v Niger Tornadoes FC         4-1 (1-1)
+  06.11.
+    16:00  Bayelsa United FC          v Lobi Stars FC              1-2 (1-1)
+    16:00  Sporting Lagos FC          v Kano Pillars FC            3-0 (3-0)
+
+
+
+» Matchday 8
+  11.11.
+    15:00  Doma United FC             v Akwa United FC             1-0 (1-0)
+  12.11.
+    16:00  Kano Pillars FC            v Enyimba FC                 1-0 (0-0)
+    16:00  Katsina United FC          v Rivers United FC           1-0 (0-0)
+    16:00  Kwara United FC            v Shooting Stars SC          1-1 (0-1)
+    16:00  Lobi Stars FC              v Sporting Lagos FC          1-0 (1-0)
+    16:00  Niger Tornadoes FC         v Bendel FC                  0-0 (0-0)
+    16:00  Plateau United FC          v Abia Warriors FC           3-1 (3-1)
+    16:00  Remo Stars FC              v Gombe United FC            4-0 (2-0)
+    16:00  Sunshine Stars FC          v Rangers International FC   2-2 (1-1)
+  15.11.
+    16:00  Heartland FC               v Bayelsa United FC          2-2 (1-0)
+
+
+
+» Matchday 9
+  18.11.
+    15:00  Doma United FC             v Plateau United FC          1-0 (1-0)
+    16:00  Bendel FC                  v Kwara United FC            2-2 (1-2)
+  19.11.
+    15:00  Gombe United FC            v Niger Tornadoes FC         1-0 (1-0)
+    16:00  Akwa United FC             v Remo Stars FC              3-2 (2-1)
+    16:00  Bayelsa United FC          v Sunshine Stars FC          1-1 (0-0)
+    16:00  Enyimba FC                 v Lobi Stars FC              1-0 (0-0)
+    16:00  Rangers International FC   v Katsina United FC          0-0 (0-0)
+    16:00  Rivers United FC           v Abia Warriors FC           2-1 (1-0)
+    16:00  Shooting Stars SC          v Kano Pillars FC            1-0 (0-0)
+    16:00  Sporting Lagos FC          v Heartland FC               1-1 (0-0)
+
+
+
+» Matchday 10
+  10.01.
+    16:00  Plateau United FC          v Rivers United FC           3-2 (1-1)
+  25.11.
+    16:00  Heartland FC               v Enyimba FC                 0-1 (0-0)
+    16:00  Remo Stars FC              v Doma United FC             0-0 (0-0)
+  26.11.
+    16:00  Abia Warriors FC           v Rangers International FC   1-0 (1-0)
+    16:00  Kano Pillars FC            v Bendel FC                  0-0 (0-0)
+    16:00  Katsina United FC          v Bayelsa United FC          1-1 (0-1)
+    16:00  Kwara United FC            v Gombe United FC            2-0 (1-0)
+    16:00  Lobi Stars FC              v Shooting Stars SC          2-1 (1-0)
+    16:00  Niger Tornadoes FC         v Akwa United FC             1-0 (0-0)
+    16:00  Sunshine Stars FC          v Sporting Lagos FC          1-0 (1-0)
+
+
+
+» Matchday 11
+  02.12.
+    15:00  Doma United FC             v Niger Tornadoes FC         1-0 (1-0)
+    16:00  Akwa United FC             v Kwara United FC            1-1 (1-1)
+    16:00  Bendel FC                  v Lobi Stars FC              1-0 (0-0)
+    16:00  Enyimba FC                 v Sunshine Stars FC          1-0 (1-0)
+  03.12.
+    15:00  Gombe United FC            v Kano Pillars FC            2-5 (2-4)
+    16:00  Bayelsa United FC          v Abia Warriors FC           2-2 (0-0)
+    16:00  Remo Stars FC              v Plateau United FC          1-0 (0-0)
+    16:00  Shooting Stars SC          v Heartland FC               0-0 (0-0)
+    16:00  Sporting Lagos FC          v Katsina United FC          1-0 (1-0)
+  24.01.
+    16:00  Rangers International FC   v Rivers United FC           1-0 (0-0)
+
+
+
+» Matchday 12
+  06.12.
+    15:45  Kano Pillars FC            v Akwa United FC             1-0 (1-0)
+    16:00  Abia Warriors FC           v Sporting Lagos FC          1-1 (0-1)
+    16:00  Heartland FC               v Bendel FC                  1-0 (0-0)
+    16:00  Kwara United FC            v Doma United FC             0-0 (0-0)
+    16:00  Lobi Stars FC              v Gombe United FC            1-0 (1-0)
+    16:00  Niger Tornadoes FC         v Remo Stars FC              0-0 (0-0)
+    16:00  Plateau United FC          v Rangers International FC   2-1 (1-1)
+    16:00  Sunshine Stars FC          v Shooting Stars SC          1-0 (0-0)
+  14.12.
+    16:00  Rivers United FC           v Bayelsa United FC          2-0 (1-0)
+  17.01.
+    16:00  Katsina United FC          v Enyimba FC                 2-1 (1-1)
+
+
+
+» Matchday 13
+  09.12.
+    15:00  Doma United FC             v Kano Pillars FC            1-0 (1-0)
+  10.12.
+    15:00  Gombe United FC            v Heartland FC               2-0 (1-0)
+    16:00  Akwa United FC             v Lobi Stars FC              1-0 (1-0)
+    16:00  Bayelsa United FC          v Rangers International FC   2-0 (1-0)
+    16:00  Bendel FC                  v Sunshine Stars FC          1-0 (1-0)
+    16:00  Enyimba FC                 v Abia Warriors FC           2-1 (1-0)
+    16:00  Niger Tornadoes FC         v Plateau United FC          2-3 (0-1)
+    16:00  Remo Stars FC              v Kwara United FC            2-0 (1-0)
+    16:00  Shooting Stars SC          v Katsina United FC          1-1 (1-1)
+  14.02.
+    16:00  Sporting Lagos FC          v Rivers United FC           1-0 (0-0)
+
+
+
+» Matchday 14
+  16.12.
+    16:00  Katsina United FC          v Bendel FC                  1-0 (0-0)
+  17.12.
+    16:00  Abia Warriors FC           v Shooting Stars SC          3-2 (1-1)
+    16:00  Heartland FC               v Akwa United FC             1-0 (1-0)
+    16:00  Kano Pillars FC            v Remo Stars FC              2-1 (0-0)
+    16:00  Kwara United FC            v Niger Tornadoes FC         0-0 (0-0)
+    16:00  Lobi Stars FC              v Doma United FC             2-1 (1-0)
+    16:00  Plateau United FC          v Bayelsa United FC          5-1 (2-1)
+    16:00  Rangers International FC   v Sporting Lagos FC          2-0 (1-0)
+    16:00  Sunshine Stars FC          v Gombe United FC            1-1 (1-0)
+  30.01.
+    16:00  Rivers United FC           v Enyimba FC                 2-0 (1-0)
+
+
+
+» Matchday 15
+  10.02.
+    16:00  Shooting Stars SC          v Rivers United FC           1-0 (1-0)
+  20.12.
+    15:00  Doma United FC             v Heartland FC               1-0 (1-0)
+    16:00  Enyimba FC                 v Rangers International FC   1-1 (1-0)
+  21.12.
+    15:00  Gombe United FC            v Katsina United FC          1-0 (0-0)
+    16:00  Akwa United FC             v Sunshine Stars FC          0-0 (0-0)
+    16:00  Bendel FC                  v Abia Warriors FC           1-0 (1-0)
+    16:00  Kwara United FC            v Plateau United FC          2-1 (0-1)
+    16:00  Niger Tornadoes FC         v Kano Pillars FC            1-0 (0-0)
+    16:00  Remo Stars FC              v Lobi Stars FC              2-0 (0-0)
+    16:00  Sporting Lagos FC          v Bayelsa United FC          1-1 (0-1)
+
+
+
+» Matchday 16
+  27.12.
+    16:00  Sunshine Stars FC          v Doma United FC             2-0 (1-0)
+  28.12.
+    15:30  Katsina United FC          v Akwa United FC             1-0 (1-0)
+    16:00  Abia Warriors FC           v Gombe United FC            3-1 (2-0)
+    16:00  Bayelsa United FC          v Enyimba FC                 1-2 (0-0)
+    16:00  Heartland FC               v Remo Stars FC              3-1 (0-0)
+    16:00  Kano Pillars FC            v Kwara United FC            2-1 (1-1)
+    16:00  Lobi Stars FC              v Niger Tornadoes FC         1-0 (0-0)
+    16:00  Plateau United FC          v Sporting Lagos FC          1-0 (0-0)
+    16:00  Rangers International FC   v Shooting Stars SC          2-0 (1-0)
+    16:00  Rivers United FC           v Bendel FC                  1-1 (1-1)
+
+
+
+» Matchday 17
+  06.01.
+    15:00  Doma United FC             v Katsina United FC          2-0 (2-0)
+    16:00  Bendel FC                  v Rangers International FC   2-0 (1-0)
+  07.01.
+    15:00  Gombe United FC            v Rivers United FC           1-1 (1-1)
+    16:00  Akwa United FC             v Abia Warriors FC           3-1 (2-1)
+    16:00  Enyimba FC                 v Sporting Lagos FC          2-0 (1-0)
+    16:00  Kano Pillars FC            v Plateau United FC          2-1 (0-1)
+    16:00  Kwara United FC            v Lobi Stars FC              0-2 (0-2)
+    16:00  Niger Tornadoes FC         v Heartland FC               3-2 (2-2)
+    16:00  Remo Stars FC              v Sunshine Stars FC          2-0 (0-0)
+    16:00  Shooting Stars SC          v Bayelsa United FC          1-0 (1-0)
+
+
+
+» Matchday 18
+  13.01.
+    16:00  Abia Warriors FC           v Doma United FC             3-0 (1-0)
+    16:00  Plateau United FC          v Enyimba FC                 1-0 (1-0)
+    16:00  Rangers International FC   v Gombe United FC            4-1 (2-1)
+    16:00  Sunshine Stars FC          v Niger Tornadoes FC         0-0 (0-0)
+  15.01.
+    16:00  Bayelsa United FC          v Bendel FC                  2-0 (1-0)
+    16:00  Katsina United FC          v Remo Stars FC              2-0 (1-0)
+    16:00  Lobi Stars FC              v Kano Pillars FC            1-1 (1-1)
+    16:00  Sporting Lagos FC          v Shooting Stars SC          2-2 (2-1)
+  16.01.
+    16:00  Rivers United FC           v Akwa United FC             2-1 (1-1)
+  25.01.
+    16:00  Heartland FC               v Kwara United FC            1-1 (0-0)
+
+
+
+» Matchday 19
+  20.01.
+    15:00  Doma United FC             v Rivers United FC           1-1 (0-1)
+    16:00  Bendel FC                  v Sporting Lagos FC          3-1 (2-0)
+    16:00  Kwara United FC            v Sunshine Stars FC          1-0 (1-0)
+  21.01.
+    15:00  Gombe United FC            v Bayelsa United FC          1-1 (1-1)
+    16:00  Akwa United FC             v Rangers International FC   1-0 (0-0)
+    16:00  Kano Pillars FC            v Heartland FC               2-1 (0-0)
+    16:00  Lobi Stars FC              v Plateau United FC          1-0 (1-0)
+    16:00  Niger Tornadoes FC         v Katsina United FC          0-0 (0-0)
+    16:00  Remo Stars FC              v Abia Warriors FC           2-1 (1-0)
+    16:00  Shooting Stars SC          v Enyimba FC                 1-2 (0-0)
+
+
+
+» Matchday 20
+  17.02.
+    14:00  Heartland FC               v Kano Pillars FC            1-1 (0-1)
+    16:00  Enyimba FC                 v Shooting Stars SC          1-0 (1-0)
+  18.02.
+    15:00  Katsina United FC          v Niger Tornadoes FC         1-0 (0-0)
+    16:00  Abia Warriors FC           v Remo Stars FC              0-0 (0-0)
+    16:00  Bayelsa United FC          v Gombe United FC            2-0 (1-0)
+    16:00  Plateau United FC          v Lobi Stars FC              2-1 (1-0)
+    16:00  Rangers International FC   v Akwa United FC             1-0 (0-0)
+    16:00  Rivers United FC           v Doma United FC             3-2 (1-1)
+    16:00  Sporting Lagos FC          v Bendel FC                  1-0 (0-0)
+    16:00  Sunshine Stars FC          v Kwara United FC            1-1 (1-0)
+
+
+
+» Matchday 21
+  06.05.
+    16:00  Remo Stars FC              v Rivers United FC           2-1 (0-1)
+  24.02.
+    15:00  Doma United FC             v Rangers International FC   0-1 (0-1)
+    16:00  Kwara United FC            v Katsina United FC          1-1 (1-0)
+    17:30  Bendel FC                  v Enyimba FC                 0-0 (0-0)
+  25.02.
+    15:00  Gombe United FC            v Sporting Lagos FC          2-0 (1-0)
+    15:00  Plateau United FC          v Shooting Stars SC          0-0 (0-0)
+    15:45  Kano Pillars FC            v Sunshine Stars FC          5-1 (2-0)
+    16:00  Akwa United FC             v Bayelsa United FC          0-1 (0-0)
+    16:00  Lobi Stars FC              v Heartland FC               1-0 (0-0)
+    16:00  Niger Tornadoes FC         v Abia Warriors FC           1-0 (0-0)
+
+
+
+» Matchday 22
+  19.05.
+    16:00  Rivers United FC           v Niger Tornadoes FC         3-2 (2-0)
+  28.02.
+    15:00  Sunshine Stars FC          v Lobi Stars FC              2-0 (2-0)
+    16:00  Bayelsa United FC          v Doma United FC             2-0 (1-0)
+    16:00  Heartland FC               v Plateau United FC          1-5 (0-2)
+    16:00  Katsina United FC          v Kano Pillars FC            3-2 (1-0)
+    16:00  Rangers International FC   v Remo Stars FC              1-0 (0-0)
+    16:00  Sporting Lagos FC          v Akwa United FC             2-1 (0-0)
+  29.02.
+    14:00  Enyimba FC                 v Gombe United FC            4-0 (1-0)
+    16:00  Abia Warriors FC           v Kwara United FC            1-0 (0-0)
+    16:00  Shooting Stars SC          v Bendel FC                  1-0 (0-0)
+
+
+
+» Matchday 23
+  02.03.
+    17:30  Remo Stars FC              v Bayelsa United FC          1-0 (0-0)
+  03.03.
+    16:00  Heartland FC               v Sunshine Stars FC          1-1 (1-1)
+    16:00  Lobi Stars FC              v Katsina United FC          2-0 (0-0)
+    16:00  Niger Tornadoes FC         v Rangers International FC   0-2 (0-2)
+    16:00  Plateau United FC          v Bendel FC                  2-0 (0-0)
+  04.03.
+    15:00  Doma United FC             v Sporting Lagos FC          0-0 (0-0)
+    16:00  Akwa United FC             v Enyimba FC                 3-1 (1-0)
+    16:00  Kano Pillars FC            v Abia Warriors FC           0-1 (0-0)
+  05.03.
+    15:00  Gombe United FC            v Shooting Stars SC          1-1 (1-0)
+  09.05.
+    16:00  Kwara United FC            v Rivers United FC           0-0 (0-0)
+
+
+
+» Matchday 24
+  08.03.
+    17:30  Bendel FC                  v Gombe United FC            2-0 (2-0)
+  09.03.
+    15:00  Katsina United FC          v Heartland FC               1-1 (0-0)
+    16:00  Bayelsa United FC          v Niger Tornadoes FC         0-1 (0-0)
+    16:00  Rivers United FC           v Kano Pillars FC            1-1 (0-1)
+    16:00  Sunshine Stars FC          v Plateau United FC          3-1 (2-0)
+  10.03.
+    16:00  Abia Warriors FC           v Lobi Stars FC              1-1 (0-0)
+    16:00  Enyimba FC                 v Doma United FC             0-0 (0-0)
+    16:00  Rangers International FC   v Kwara United FC            0-0 (0-0)
+    16:00  Shooting Stars SC          v Akwa United FC             3-0 (2-0)
+    16:00  Sporting Lagos FC          v Remo Stars FC              4-1 (2-1)
+
+
+
+» Matchday 25
+  13.03.
+    14:00  Plateau United FC          v Gombe United FC            4-0 (0-0)
+    16:00  Akwa United FC             v Bendel FC                  3-1 (2-1)
+    16:00  Doma United FC             v Shooting Stars SC          0-1 (0-1)
+    16:00  Heartland FC               v Abia Warriors FC           2-0 (2-0)
+    16:00  Kano Pillars FC            v Rangers International FC   1-1 (1-0)
+    16:00  Kwara United FC            v Bayelsa United FC          1-0 (1-0)
+    16:00  Lobi Stars FC              v Rivers United FC           3-2 (2-1)
+    16:00  Niger Tornadoes FC         v Sporting Lagos FC          1-0 (1-0)
+    16:00  Remo Stars FC              v Enyimba FC                 1-0 (0-0)
+    16:00  Sunshine Stars FC          v Katsina United FC          1-0 (1-0)
+
+
+
+» Matchday 26
+  17.03.
+    15:00  Rivers United FC           v Heartland FC               1-0 (1-0)
+    16:00  Abia Warriors FC           v Sunshine Stars FC          0-0 (0-0)
+    16:00  Bayelsa United FC          v Kano Pillars FC            2-1 (0-0)
+    16:00  Bendel FC                  v Doma United FC             4-0 (2-0)
+    16:00  Enyimba FC                 v Niger Tornadoes FC         3-1 (0-0)
+    16:00  Gombe United FC            v Akwa United FC             1-1 (0-0)
+    16:00  Katsina United FC          v Plateau United FC          2-1 (1-1)
+    16:00  Rangers International FC   v Lobi Stars FC              2-1 (1-0)
+    16:00  Sporting Lagos FC          v Kwara United FC            2-0 (2-0)
+    17:30  Shooting Stars SC          v Remo Stars FC              2-0 (1-0)
+
+
+
+» Matchday 27
+  12.05.
+    16:00  Sunshine Stars FC          v Rivers United FC           1-0 (0-0)
+  23.03.
+    16:00  Doma United FC             v Gombe United FC            1-1 (0-1)
+    16:00  Kano Pillars FC            v Sporting Lagos FC          1-0 (0-0)
+  24.03.
+    16:00  Heartland FC               v Rangers International FC   1-2 (0-1)
+    16:00  Katsina United FC          v Abia Warriors FC           2-1 (0-1)
+    16:00  Kwara United FC            v Enyimba FC                 2-1 (1-1)
+    16:00  Lobi Stars FC              v Bayelsa United FC          1-1 (0-0)
+    16:00  Plateau United FC          v Akwa United FC             1-2 (0-1)
+    17:30  Remo Stars FC              v Bendel FC                  2-0 (0-0)
+  25.03.
+    16:00  Niger Tornadoes FC         v Shooting Stars SC          2-1 (0-1)
+
+
+
+» Matchday 28
+  02.04.
+    16:00  Gombe United FC            v Remo Stars FC              0-0 (0-0)
+  03.04.
+    15:00  Akwa United FC             v Doma United FC             0-1 (0-1)
+    16:00  Abia Warriors FC           v Plateau United FC          1-0 (0-0)
+    16:00  Bayelsa United FC          v Heartland FC               1-0 (0-0)
+    16:00  Enyimba FC                 v Kano Pillars FC            5-0 (3-0)
+    16:00  Rangers International FC   v Sunshine Stars FC          2-0 (1-0)
+    16:00  Sporting Lagos FC          v Lobi Stars FC              1-1 (1-0)
+    17:30  Bendel FC                  v Niger Tornadoes FC         1-3 (0-3)
+    17:30  Shooting Stars SC          v Kwara United FC            2-0 (0-0)
+  25.04.
+    16:00  Rivers United FC           v Katsina United FC          2-0 (1-0)
+
+
+
+» Matchday 29
+  06.04.
+    15:00  Plateau United FC          v Doma United FC             4-0 (2-0)
+    17:30  Remo Stars FC              v Akwa United FC             2-1 (2-0)
+  07.04.
+    16:00  Heartland FC               v Sporting Lagos FC          3-1 (1-0)
+    16:00  Katsina United FC          v Rangers International FC   4-3 (3-2)
+    16:00  Kwara United FC            v Bendel FC                  1-1 (0-1)
+    16:00  Lobi Stars FC              v Enyimba FC                 1-0 (0-0)
+    16:00  Niger Tornadoes FC         v Gombe United FC            5-0 (2-0)
+    16:00  Sunshine Stars FC          v Bayelsa United FC          1-1 (0-1)
+  08.04.
+    16:00  Kano Pillars FC            v Shooting Stars SC          1-2 (1-0)
+  15.05.
+    16:00  Abia Warriors FC           v Rivers United FC           2-0 (0-0)
+
+
+
+» Matchday 30
+  16.04.
+    16:00  Akwa United FC             v Niger Tornadoes FC         4-1 (2-0)
+    16:00  Bayelsa United FC          v Katsina United FC          1-1 (1-1)
+    16:00  Bendel FC                  v Kano Pillars FC            2-1 (0-1)
+    16:00  Enyimba FC                 v Heartland FC               1-0 (1-0)
+    16:00  Gombe United FC            v Kwara United FC            1-2 (0-1)
+    16:00  Rangers International FC   v Abia Warriors FC           3-2 (1-1)
+    16:00  Rivers United FC           v Plateau United FC          3-1 (2-0)
+    16:00  Sporting Lagos FC          v Sunshine Stars FC          1-0 (1-0)
+    17:30  Shooting Stars SC          v Lobi Stars FC              2-0 (1-0)
+  17.04.
+    16:00  Doma United FC             v Remo Stars FC              1-1 (1-0)
+
+
+
+» Matchday 31
+  19.04.
+    16:00  Heartland FC               v Shooting Stars SC          1-0 (1-0)
+  20.04.
+    16:00  Abia Warriors FC           v Bayelsa United FC          1-0 (0-0)
+  21.04.
+    16:00  Kano Pillars FC            v Gombe United FC            4-0 (3-0)
+    16:00  Katsina United FC          v Sporting Lagos FC          2-0 (1-0)
+    16:00  Kwara United FC            v Akwa United FC             1-0 (0-0)
+    16:00  Lobi Stars FC              v Bendel FC                  0-0 (0-0)
+    16:00  Niger Tornadoes FC         v Doma United FC             2-0 (2-0)
+    16:00  Plateau United FC          v Remo Stars FC              1-0 (0-0)
+    16:00  Rivers United FC           v Rangers International FC   2-0 (1-0)
+    16:00  Sunshine Stars FC          v Enyimba FC                 1-1 (0-0)
+
+
+
+» Matchday 32
+  26.04.
+    16:00  Remo Stars FC              v Niger Tornadoes FC         3-0 (2-0)
+  27.04.
+    16:00  Bendel FC                  v Heartland FC               1-0 (0-0)
+    16:00  Doma United FC             v Kwara United FC            0-0 (0-0)
+  28.04.
+    16:00  Akwa United FC             v Kano Pillars FC            3-0 (1-0)
+    16:00  Enyimba FC                 v Katsina United FC          1-0 (0-0)
+    16:00  Gombe United FC            v Lobi Stars FC              3-2 (1-1)
+    16:00  Rangers International FC   v Plateau United FC          2-0 (1-0)
+    16:00  Sporting Lagos FC          v Abia Warriors FC           4-2 (2-0)
+    17:30  Shooting Stars SC          v Sunshine Stars FC          2-0 (0-0)
+  30.04.
+    08:00  Bayelsa United FC          v Rivers United FC           2-1 (2-1)
+
+
+
+» Matchday 33
+  26.05.
+    14:00  Plateau United FC          v Niger Tornadoes FC         0-0 (0-0)
+    16:00  Abia Warriors FC           v Enyimba FC                 0-1 (0-0)
+    16:00  Heartland FC               v Gombe United FC            3-0 (1-0)
+    16:00  Kano Pillars FC            v Doma United FC             3-1 (2-0)
+    16:00  Katsina United FC          v Shooting Stars SC          2-2 (1-1)
+    16:00  Kwara United FC            v Remo Stars FC              3-2 (2-0)
+    16:00  Lobi Stars FC              v Akwa United FC             1-2 (0-1)
+    16:00  Rangers International FC   v Bayelsa United FC          3-0 (1-0)
+    16:00  Rivers United FC           v Sporting Lagos FC          4-1 (1-1)
+    16:00  Sunshine Stars FC          v Bendel FC                  0-0 (0-0)
+
+
+
+» Matchday 34
+  01.06.
+    16:00  Doma United FC             v Lobi Stars FC              1-0 (1-0)
+    16:00  Remo Stars FC              v Kano Pillars FC            2-1 (1-0)
+    17:45  Bendel FC                  v Katsina United FC          2-0 (0-0)
+  02.06.
+    15:00  Enyimba FC                 v Rivers United FC           4-1 (1-1)
+    16:00  Bayelsa United FC          v Plateau United FC          3-2 (2-0)
+    16:00  Gombe United FC            v Sunshine Stars FC          0-2 (0-2)
+    16:00  Niger Tornadoes FC         v Kwara United FC            1-1 (0-0)
+    16:00  Sporting Lagos FC          v Rangers International FC   0-0 (0-0)
+    17:30  Shooting Stars SC          v Abia Warriors FC           4-0 (0-0)
+  03.06.
+    16:00  Akwa United FC             v Heartland FC               2-0 (0-0)
+
+
+
+» Matchday 35
+  08.06.
+    16:00  Kano Pillars FC            v Niger Tornadoes FC         1-1 (0-0)
+    16:00  Katsina United FC          v Gombe United FC            4-0 (3-0)
+    16:00  Plateau United FC          v Kwara United FC            2-0 (1-0)
+  09.06.
+    15:00  Abia Warriors FC           v Bendel FC                  0-0 (0-0)
+    15:00  Lobi Stars FC              v Remo Stars FC              3-2 (2-1)
+    16:00  Bayelsa United FC          v Sporting Lagos FC          2-2 (0-0)
+    16:00  Heartland FC               v Doma United FC             3-1 (1-0)
+    16:00  Rivers United FC           v Shooting Stars SC          1-0 (0-0)
+    16:00  Sunshine Stars FC          v Akwa United FC             2-0 (0-0)
+    17:00  Rangers International FC   v Enyimba FC                 3-0 (0-0)
+
+
+
+» Matchday 36
+  12.06.
+    15:30  Gombe United FC            v Abia Warriors FC           1-3 (1-1)
+    16:00  Akwa United FC             v Katsina United FC          3-1 (3-1)
+    16:00  Bendel FC                  v Rivers United FC           2-1 (1-0)
+    16:00  Enyimba FC                 v Bayelsa United FC          1-1 (1-1)
+    16:00  Kwara United FC            v Kano Pillars FC            2-0 (1-0)
+    16:00  Niger Tornadoes FC         v Lobi Stars FC              3-2 (2-1)
+    16:00  Remo Stars FC              v Heartland FC               4-1 (2-0)
+    16:00  Sporting Lagos FC          v Plateau United FC          1-2 (0-2)
+    17:30  Shooting Stars SC          v Rangers International FC   1-0 (1-0)
+  19.06.
+    16:00  Doma United FC             v Sunshine Stars FC          0-1 (0-1)
+
+
+
+» Matchday 37
+  15.06.
+    16:00  Heartland FC               v Niger Tornadoes FC         1-0 (1-0)
+    16:00  Katsina United FC          v Doma United FC             2-0 (1-0)
+    16:00  Lobi Stars FC              v Kwara United FC            4-3 (2-2)
+    16:00  Plateau United FC          v Kano Pillars FC            1-1 (0-0)
+    16:00  Rivers United FC           v Gombe United FC            6-0 (2-0)
+  16.06.
+    16:00  Abia Warriors FC           v Akwa United FC             2-0 (1-0)
+    16:00  Bayelsa United FC          v Shooting Stars SC          2-1 (0-1)
+    16:00  Rangers International FC   v Bendel FC                  2-0 (1-0)
+    16:00  Sporting Lagos FC          v Enyimba FC                 2-1 (1-0)
+    16:00  Sunshine Stars FC          v Remo Stars FC              2-1 (0-0)
+
+
+
+» Matchday 38
+  23.06.
+    15:00  Gombe United FC            v Rangers International FC   1-2 (1-2)
+    16:00  Akwa United FC             v Rivers United FC           3-1 (2-1)
+    16:00  Bendel FC                  v Bayelsa United FC          0-2 (0-2)
+    16:00  Doma United FC             v Abia Warriors FC           1-1 (0-1)
+    16:00  Enyimba FC                 v Plateau United FC          2-0 (0-0)
+    16:00  Kano Pillars FC            v Lobi Stars FC              3-2 (2-0)
+    16:00  Kwara United FC            v Heartland FC               4-0 (2-0)
+    16:00  Niger Tornadoes FC         v Sunshine Stars FC          2-1 (1-0)
+    16:00  Remo Stars FC              v Katsina United FC          2-1 (2-0)
+    16:00  Shooting Stars SC          v Sporting Lagos FC          1-0 (1-0)
+

--- a/africa/nigeria/2024-25_ng1.txt
+++ b/africa/nigeria/2024-25_ng1.txt
@@ -1,0 +1,637 @@
+= Nigeria Professional League 2024/2025
+
+# Date       Mon Jan/08 2024 - Tue Dec/31 2024 (358d)
+# Teams      20
+# Matches    380
+
+
+
+» Matchday 1
+  08.09.
+    16:00  Abia Warriors FC           v Remo Stars FC              0-2 (0-0)
+    16:00  Bendel FC                  v Rivers United FC           0-0 (0-0)
+    16:00  Heartland FC               v Enyimba FC                 1-3 (0-0)
+    16:00  Kano Pillars FC            v Ikorodu City FC            3-0 (0-0)
+    16:00  Kwara United FC            v Niger Tornadoes FC         1-2 (0-1)
+    16:00  Nasarawa United FC         v Shooting Stars SC          1-1 (0-0)
+    16:00  Plateau United FC          v Katsina United FC          1-0 (1-0)
+    16:00  Sunshine Stars FC          v Bayelsa United FC          3-0 (1-0)
+  09.09.
+    16:00  Lobi Stars FC              v Akwa United FC             0-0 (0-0)
+  31.08.
+    16:00  Rangers International FC   v El-Kanemi Warriors FC      0-0 (0-0)
+
+
+
+» Matchday 2
+  14.09.
+    15:00  Rivers United FC           v Heartland FC               3-1 (1-1)
+    17:30  Remo Stars FC              v Sunshine Stars FC          1-0 (1-0)
+  15.09.
+    15:00  Akwa United FC             v Abia Warriors FC           1-1 (0-1)
+    16:00  Bayelsa United FC          v Kano Pillars FC            1-1 (0-1)
+    16:00  Katsina United FC          v Bendel FC                  2-1 (1-1)
+    16:00  Niger Tornadoes FC         v Nasarawa United FC         0-0 (0-0)
+    17:30  Shooting Stars SC          v Plateau United FC          1-1 (1-1)
+  23.10.
+    15:00  El-Kanemi Warriors FC      v Kwara United FC            1-1 (0-0)
+  25.09.
+    16:00  Enyimba FC                 v Lobi Stars FC              2-1 (2-1)
+    16:00  Ikorodu City FC            v Rangers International FC   0-1 (0-1)
+
+
+
+» Matchday 3
+  02.10.
+    16:00  Bendel FC                  v Shooting Stars SC          1-0 (0-0)
+    16:00  Enyimba FC                 v Akwa United FC             1-0 (0-0)
+  03.10.
+    16:00  Rangers International FC   v Bayelsa United FC          1-0 (0-0)
+  21.09.
+    14:00  Lobi Stars FC              v Rivers United FC           0-1 (0-0)
+    16:00  Nasarawa United FC         v El-Kanemi Warriors FC      3-4 (2-3)
+  22.09.
+    15:00  Plateau United FC          v Niger Tornadoes FC         1-2 (0-1)
+    16:00  Heartland FC               v Katsina United FC          0-0 (0-0)
+    16:00  Kano Pillars FC            v Remo Stars FC              0-2 (0-1)
+    16:00  Sunshine Stars FC          v Abia Warriors FC           0-0 (0-0)
+    17:30  Kwara United FC            v Ikorodu City FC            0-0 (0-0)
+
+
+
+» Matchday 4
+  28.09.
+    15:00  Ikorodu City FC            v Nasarawa United FC         1-2 (1-1)
+    17:30  Akwa United FC             v Sunshine Stars FC          1-2 (0-1)
+  29.09.
+    15:00  El-Kanemi Warriors FC      v Plateau United FC          2-2 (0-1)
+    15:00  Niger Tornadoes FC         v Bendel FC                  1-1 (0-0)
+    15:00  Rivers United FC           v Enyimba FC                 2-0 (1-0)
+    16:00  Abia Warriors FC           v Kano Pillars FC            2-0 (2-0)
+    16:00  Bayelsa United FC          v Kwara United FC            1-1 (0-0)
+    16:00  Katsina United FC          v Lobi Stars FC              3-0 (1-0)
+    17:30  Remo Stars FC              v Rangers International FC   2-1 (0-0)
+    17:30  Shooting Stars SC          v Heartland FC               1-0 (1-0)
+
+
+
+» Matchday 5
+  05.10.
+    15:00  Lobi Stars FC              v Shooting Stars SC          1-0 (1-0)
+    16:00  Bendel FC                  v El-Kanemi Warriors FC      1-1 (1-1)
+  06.10.
+    14:00  Nasarawa United FC         v Bayelsa United FC          0-0 (0-0)
+    16:00  Heartland FC               v Niger Tornadoes FC         2-0 (1-0)
+    16:00  Kano Pillars FC            v Sunshine Stars FC          2-0 (1-0)
+    16:00  Kwara United FC            v Remo Stars FC              1-0 (0-0)
+    16:00  Plateau United FC          v Ikorodu City FC            1-0 (0-0)
+    16:00  Rangers International FC   v Abia Warriors FC           1-0 (0-0)
+    16:00  Rivers United FC           v Akwa United FC             2-1 (1-0)
+  07.10.
+    08:00  Enyimba FC                 v Katsina United FC          3-0 (3-0)
+
+
+
+» Matchday 6
+  12.10.
+    16:00  Ikorodu City FC            v Bendel FC                  3-0 (0-0)
+    16:00  Sunshine Stars FC          v Rangers International FC   1-0 (1-0)
+  13.10.
+    08:00  Abia Warriors FC           v Kwara United FC            1-0 (0-0)
+    15:00  Bayelsa United FC          v Plateau United FC          1-0 (1-0)
+    15:00  El-Kanemi Warriors FC      v Heartland FC               0-0 (0-0)
+    16:00  Akwa United FC             v Kano Pillars FC            2-0 (1-0)
+    16:00  Katsina United FC          v Rivers United FC           0-0 (0-0)
+    16:00  Niger Tornadoes FC         v Lobi Stars FC              1-1 (0-0)
+    16:00  Remo Stars FC              v Nasarawa United FC         3-0 (0-0)
+    17:30  Shooting Stars SC          v Enyimba FC                 0-0 (0-0)
+
+
+
+» Matchday 7
+  16.10.
+    14:00  Lobi Stars FC              v El-Kanemi Warriors FC      2-2 (1-0)
+    15:00  Rangers International FC   v Kano Pillars FC            3-4 (0-4)
+    16:00  Enyimba FC                 v Niger Tornadoes FC         1-1 (0-1)
+    16:00  Kwara United FC            v Sunshine Stars FC          3-0 (2-0)
+    16:00  Nasarawa United FC         v Abia Warriors FC           3-0 (0-0)
+  17.10.
+    15:00  Bendel FC                  v Bayelsa United FC          3-0 (1-0)
+    16:00  Heartland FC               v Ikorodu City FC            1-1 (0-1)
+    16:00  Katsina United FC          v Akwa United FC             1-0 (1-0)
+    16:00  Plateau United FC          v Remo Stars FC              3-1 (1-0)
+    16:00  Rivers United FC           v Shooting Stars SC          2-0 (0-0)
+
+
+
+» Matchday 8
+  20.10.
+    15:00  Bayelsa United FC          v Heartland FC               1-0 (0-0)
+    15:00  El-Kanemi Warriors FC      v Enyimba FC                 1-0 (1-0)
+    16:00  Abia Warriors FC           v Plateau United FC          3-1 (2-1)
+    16:00  Kano Pillars FC            v Kwara United FC            1-1 (0-0)
+    16:00  Sunshine Stars FC          v Nasarawa United FC         1-0 (1-0)
+    17:30  Remo Stars FC              v Bendel FC                  1-0 (1-0)
+  21.10.
+    15:00  Ikorodu City FC            v Lobi Stars FC              4-2 (2-2)
+    16:00  Niger Tornadoes FC         v Rivers United FC           0-1 (0-0)
+    17:30  Akwa United FC             v Rangers International FC   0-0 (0-0)
+    17:30  Shooting Stars SC          v Katsina United FC          1-0 (0-0)
+
+
+
+» Matchday 9
+  26.10.
+    15:00  Katsina United FC          v Niger Tornadoes FC         1-1 (0-1)
+    16:00  Bendel FC                  v Abia Warriors FC           0-1 (0-1)
+  27.10.
+    16:00  Enyimba FC                 v Ikorodu City FC            2-1 (1-0)
+    16:00  Heartland FC               v Remo Stars FC              1-0 (0-0)
+    16:00  Nasarawa United FC         v Kano Pillars FC            1-0 (1-0)
+    16:00  Plateau United FC          v Sunshine Stars FC          3-0 (1-0)
+    16:00  Rivers United FC           v El-Kanemi Warriors FC      1-1 (1-1)
+    16:00  Shooting Stars SC          v Akwa United FC             2-1 (1-0)
+  28.10.
+    16:00  Kwara United FC            v Rangers International FC   1-1 (1-1)
+    16:00  Lobi Stars FC              v Bayelsa United FC          2-1 (1-1)
+
+
+
+» Matchday 10
+  03.11.
+    15:00  El-Kanemi Warriors FC      v Katsina United FC          1-0 (0-0)
+    16:00  Abia Warriors FC           v Heartland FC               0-2 (0-1)
+    16:00  Akwa United FC             v Kwara United FC            2-1 (1-1)
+    16:00  Bayelsa United FC          v Enyimba FC                 1-1 (1-1)
+    16:00  Ikorodu City FC            v Rivers United FC           2-0 (0-0)
+    16:00  Kano Pillars FC            v Plateau United FC          2-1 (0-0)
+    16:00  Niger Tornadoes FC         v Shooting Stars SC          2-0 (1-0)
+    16:00  Rangers International FC   v Nasarawa United FC         2-0 (0-0)
+    16:00  Remo Stars FC              v Lobi Stars FC              1-0 (0-0)
+    16:00  Sunshine Stars FC          v Bendel FC                  1-2 (1-1)
+
+
+
+» Matchday 11
+  09.11.
+    16:00  Bendel FC                  v Kano Pillars FC            0-1 (0-0)
+    16:00  Lobi Stars FC              v Abia Warriors FC           3-1 (0-0)
+  10.11.
+    15:00  Katsina United FC          v Ikorodu City FC            1-2 (1-1)
+    16:00  Enyimba FC                 v Remo Stars FC              0-0 (0-0)
+    16:00  Heartland FC               v Sunshine Stars FC          1-0 (1-0)
+    16:00  Nasarawa United FC         v Kwara United FC            0-1 (0-1)
+    16:00  Niger Tornadoes FC         v Akwa United FC             1-0 (0-0)
+    16:00  Plateau United FC          v Rangers International FC   0-0 (0-0)
+    16:00  Rivers United FC           v Bayelsa United FC          0-1 (0-1)
+    17:30  Shooting Stars SC          v El-Kanemi Warriors FC      3-0 (2-0)
+
+
+
+» Matchday 12
+  16.11.
+    16:00  Akwa United FC             v Nasarawa United FC         1-0 (1-0)
+  17.11.
+    15:00  El-Kanemi Warriors FC      v Niger Tornadoes FC         1-0 (0-0)
+    15:45  Kano Pillars FC            v Heartland FC               2-2 (0-0)
+    16:00  Abia Warriors FC           v Enyimba FC                 1-1 (1-1)
+    16:00  Bayelsa United FC          v Katsina United FC          1-1 (0-0)
+    16:00  Ikorodu City FC            v Shooting Stars SC          2-1 (0-1)
+    16:00  Kwara United FC            v Plateau United FC          2-0 (0-0)
+    16:00  Rangers International FC   v Bendel FC                  3-2 (2-0)
+    16:00  Remo Stars FC              v Rivers United FC           0-0 (0-0)
+    16:00  Sunshine Stars FC          v Lobi Stars FC              1-0 (0-0)
+
+
+
+» Matchday 13
+  11.12.
+    16:00  Enyimba FC                 v Sunshine Stars FC          0-0 (0-0)
+  23.11.
+    15:00  El-Kanemi Warriors FC      v Akwa United FC             1-0 (1-0)
+    16:00  Bendel FC                  v Kwara United FC            3-1 (2-1)
+    16:00  Heartland FC               v Rangers International FC   0-0 (0-0)
+    16:00  Lobi Stars FC              v Kano Pillars FC            2-2 (2-0)
+    16:00  Niger Tornadoes FC         v Ikorodu City FC            0-0 (0-0)
+  24.11.
+    15:00  Plateau United FC          v Nasarawa United FC         2-0 (0-0)
+    16:00  Katsina United FC          v Remo Stars FC              2-0 (0-0)
+    16:00  Rivers United FC           v Abia Warriors FC           1-0 (0-0)
+    17:30  Shooting Stars SC          v Bayelsa United FC          1-0 (1-0)
+
+
+
+» Matchday 14
+  23.01.
+    15:30  Kano Pillars FC            v Enyimba FC                 2-0 (1-0)
+  27.11.
+    16:00  Abia Warriors FC           v Katsina United FC          2-0 (1-0)
+    16:00  Akwa United FC             v Plateau United FC          1-0 (0-0)
+    16:00  Bayelsa United FC          v Niger Tornadoes FC         4-1 (2-0)
+    16:00  Ikorodu City FC            v El-Kanemi Warriors FC      2-0 (0-0)
+    16:00  Kwara United FC            v Heartland FC               1-0 (1-0)
+    16:00  Nasarawa United FC         v Bendel FC                  2-1 (1-1)
+    16:00  Rangers International FC   v Lobi Stars FC              3-0 (3-0)
+    16:00  Remo Stars FC              v Shooting Stars SC          2-0 (1-0)
+    16:00  Sunshine Stars FC          v Rivers United FC           1-1 (0-1)
+
+
+
+» Matchday 15
+  01.12.
+    15:00  El-Kanemi Warriors FC      v Bayelsa United FC          0-0 (0-0)
+    16:00  Heartland FC               v Nasarawa United FC         3-2 (1-1)
+    16:00  Ikorodu City FC            v Akwa United FC             4-1 (2-1)
+    16:00  Katsina United FC          v Sunshine Stars FC          1-0 (1-0)
+    16:00  Niger Tornadoes FC         v Remo Stars FC              2-1 (2-0)
+    16:00  Rivers United FC           v Kano Pillars FC            1-0 (1-0)
+    17:30  Shooting Stars SC          v Abia Warriors FC           2-0 (2-0)
+  03.12.
+    16:00  Enyimba FC                 v Rangers International FC   0-0 (0-0)
+  30.11.
+    16:00  Bendel FC                  v Plateau United FC          2-1 (1-1)
+    16:00  Lobi Stars FC              v Kwara United FC            1-0 (1-0)
+
+
+
+» Matchday 16
+  07.12.
+    15:00  Nasarawa United FC         v Lobi Stars FC              1-0 (1-0)
+    17:30  Sunshine Stars FC          v Shooting Stars SC          0-1 (0-1)
+  08.12.
+    15:00  Plateau United FC          v Heartland FC               3-2 (1-0)
+    15:30  Kano Pillars FC            v Katsina United FC          1-0 (1-0)
+    16:00  Abia Warriors FC           v Niger Tornadoes FC         2-1 (1-0)
+    16:00  Bayelsa United FC          v Ikorodu City FC            1-0 (0-0)
+    16:00  Rangers International FC   v Rivers United FC           1-0 (1-0)
+    17:30  Remo Stars FC              v El-Kanemi Warriors FC      2-0 (2-0)
+  09.12.
+    16:00  Akwa United FC             v Bendel FC                  1-1 (1-1)
+  27.01.
+    16:00  Kwara United FC            v Enyimba FC                 2-0 (2-0)
+
+
+
+» Matchday 17
+  08.01.
+    16:00  Enyimba FC                 v Nasarawa United FC         2-1 (1-0)
+  14.12.
+    15:00  Lobi Stars FC              v Plateau United FC          1-0 (1-0)
+    17:30  Shooting Stars SC          v Kano Pillars FC            2-0 (1-0)
+  15.12.
+    15:00  El-Kanemi Warriors FC      v Abia Warriors FC           3-0 (2-0)
+    15:00  Katsina United FC          v Rangers International FC   0-0 (0-0)
+    15:00  Niger Tornadoes FC         v Sunshine Stars FC          4-1 (4-0)
+    16:00  Bayelsa United FC          v Akwa United FC             2-1 (1-1)
+    16:00  Heartland FC               v Bendel FC                  1-1 (1-0)
+    16:00  Rivers United FC           v Kwara United FC            2-1 (0-1)
+    17:30  Ikorodu City FC            v Remo Stars FC              1-1 (0-1)
+
+
+
+» Matchday 18
+  21.12.
+    15:00  Kano Pillars FC            v Niger Tornadoes FC         2-1 (1-0)
+    16:00  Sunshine Stars FC          v El-Kanemi Warriors FC      1-0 (0-0)
+    17:30  Bendel FC                  v Lobi Stars FC              1-0 (0-0)
+  22.12.
+    16:00  Abia Warriors FC           v Ikorodu City FC            2-0 (2-0)
+    16:00  Nasarawa United FC         v Rivers United FC           1-1 (1-0)
+    16:00  Rangers International FC   v Shooting Stars SC          0-1 (0-1)
+    16:00  Remo Stars FC              v Bayelsa United FC          2-0 (0-0)
+    17:30  Kwara United FC            v Katsina United FC          1-0 (0-0)
+  23.12.
+    16:00  Akwa United FC             v Heartland FC               2-0 (1-0)
+  26.12.
+    16:00  Plateau United FC          v Enyimba FC                 0-0 (0-0)
+
+
+
+» Matchday 19
+  28.12.
+    17:30  Bayelsa United FC          v Abia Warriors FC           0-1 (0-1)
+  29.12.
+    15:00  El-Kanemi Warriors FC      v Kano Pillars FC            1-0 (1-0)
+    15:00  Niger Tornadoes FC         v Rangers International FC   0-1 (0-1)
+    16:00  Ikorodu City FC            v Sunshine Stars FC          2-1 (1-1)
+    16:00  Katsina United FC          v Nasarawa United FC         1-0 (0-0)
+    16:00  Lobi Stars FC              v Heartland FC               0-0 (0-0)
+    17:30  Remo Stars FC              v Akwa United FC             2-1 (1-1)
+    17:30  Shooting Stars SC          v Kwara United FC            1-0 (1-0)
+  30.12.
+    16:00  Rivers United FC           v Plateau United FC          1-1 (0-0)
+  31.12.
+    16:00  Enyimba FC                 v Bendel FC                  0-0 (0-0)
+
+
+
+» Matchday 20
+  12.02.
+    15:00  Kano Pillars FC            v El-Kanemi Warriors FC      2-1 (0-0)
+    16:00  Bendel FC                  v Enyimba FC                 1-0 (0-0)
+    16:00  Kwara United FC            v Shooting Stars SC          2-0 (1-0)
+  25.01.
+    14:00  Nasarawa United FC         v Katsina United FC          1-0 (1-0)
+    15:00  Rangers International FC   v Niger Tornadoes FC         1-2 (1-1)
+    16:00  Sunshine Stars FC          v Ikorodu City FC            4-3 (3-1)
+    16:15  Abia Warriors FC           v Bayelsa United FC          1-0 (1-0)
+  26.01.
+    16:00  Akwa United FC             v Remo Stars FC              1-2 (1-0)
+    16:00  Heartland FC               v Lobi Stars FC              1-0 (0-0)
+    16:15  Plateau United FC          v Rivers United FC           2-1 (1-0)
+
+
+
+» Matchday 21
+  29.01.
+    15:00  Bayelsa United FC          v Sunshine Stars FC          4-1 (1-1)
+    15:00  El-Kanemi Warriors FC      v Rangers International FC   2-1 (1-0)
+    16:00  Akwa United FC             v Lobi Stars FC              1-1 (0-1)
+    16:00  Ikorodu City FC            v Kano Pillars FC            4-1 (2-1)
+    16:00  Remo Stars FC              v Abia Warriors FC           3-2 (2-2)
+    17:30  Shooting Stars SC          v Nasarawa United FC         2-0 (1-0)
+  30.01.
+    15:00  Enyimba FC                 v Heartland FC               1-1 (0-1)
+    16:00  Katsina United FC          v Plateau United FC          1-0 (0-0)
+    16:00  Niger Tornadoes FC         v Kwara United FC            2-1 (1-0)
+    16:00  Rivers United FC           v Bendel FC                  2-2 (1-1)
+
+
+
+» Matchday 22
+  01.02.
+    17:30  Sunshine Stars FC          v Remo Stars FC              1-2 (0-2)
+  02.02.
+    15:00  Kano Pillars FC            v Bayelsa United FC          0-0 (0-0)
+    15:00  Plateau United FC          v Shooting Stars SC          1-1 (0-0)
+    16:00  Abia Warriors FC           v Akwa United FC             2-0 (1-0)
+    16:00  Heartland FC               v Rivers United FC           2-0 (0-0)
+    16:00  Nasarawa United FC         v Niger Tornadoes FC         2-0 (1-0)
+  03.02.
+    15:00  Lobi Stars FC              v Enyimba FC                 0-1 (0-1)
+    16:00  Bendel FC                  v Katsina United FC          1-0 (1-0)
+    16:00  Rangers International FC   v Ikorodu City FC            2-0 (1-0)
+    17:30  Kwara United FC            v El-Kanemi Warriors FC      2-0 (1-0)
+
+
+
+» Matchday 23
+  07.02.
+    15:00  Katsina United FC          v Heartland FC               1-0 (0-0)
+  08.02.
+    15:00  El-Kanemi Warriors FC      v Nasarawa United FC         1-0 (1-0)
+    16:00  Remo Stars FC              v Kano Pillars FC            2-1 (2-1)
+    17:30  Shooting Stars SC          v Bendel FC                  1-0 (0-0)
+  09.02.
+    15:00  Niger Tornadoes FC         v Plateau United FC          1-1 (0-0)
+    16:00  Abia Warriors FC           v Sunshine Stars FC          3-0 (2-0)
+    16:00  Akwa United FC             v Enyimba FC                 2-1 (1-1)
+    16:00  Bayelsa United FC          v Rangers International FC   0-0 (0-0)
+    16:00  Rivers United FC           v Lobi Stars FC              1-0 (0-0)
+    17:30  Ikorodu City FC            v Kwara United FC            2-1 (1-1)
+
+
+
+» Matchday 24
+  15.02.
+    15:00  Enyimba FC                 v Rivers United FC           1-0 (1-0)
+    16:00  Kano Pillars FC            v Abia Warriors FC           1-0 (1-0)
+    16:00  Kwara United FC            v Bayelsa United FC          1-0 (0-0)
+    16:00  Lobi Stars FC              v Katsina United FC          1-1 (0-0)
+    16:00  Nasarawa United FC         v Ikorodu City FC            0-0 (0-0)
+    16:00  Plateau United FC          v El-Kanemi Warriors FC      2-0 (1-0)
+    17:30  Sunshine Stars FC          v Akwa United FC             1-0 (1-0)
+  16.02.
+    15:00  Rangers International FC   v Remo Stars FC              2-1 (1-0)
+    16:00  Heartland FC               v Shooting Stars SC          2-1 (1-0)
+    17:30  Bendel FC                  v Niger Tornadoes FC         3-0 (1-0)
+
+
+
+» Matchday 25
+  19.02.
+    15:00  El-Kanemi Warriors FC      v Bendel FC                  0-0 (0-0)
+    16:00  Abia Warriors FC           v Rangers International FC   1-0 (1-0)
+    16:00  Akwa United FC             v Rivers United FC           1-1 (0-1)
+    16:00  Bayelsa United FC          v Nasarawa United FC         2-2 (1-2)
+    16:00  Niger Tornadoes FC         v Heartland FC               2-1 (0-1)
+    16:00  Sunshine Stars FC          v Kano Pillars FC            1-1 (0-0)
+    17:30  Ikorodu City FC            v Plateau United FC          2-1 (0-1)
+    17:30  Shooting Stars SC          v Lobi Stars FC              2-2 (1-2)
+  20.02.
+    16:00  Katsina United FC          v Enyimba FC                 2-1 (1-0)
+    17:30  Remo Stars FC              v Kwara United FC            2-0 (0-0)
+
+
+
+» Matchday 26
+  26.02.
+    15:00  Enyimba FC                 v Shooting Stars SC          1-1 (1-1)
+    16:00  Heartland FC               v El-Kanemi Warriors FC      0-0 (0-0)
+    16:00  Kano Pillars FC            v Akwa United FC             1-0 (0-0)
+    16:00  Kwara United FC            v Abia Warriors FC           0-0 (0-0)
+    16:00  Lobi Stars FC              v Niger Tornadoes FC         0-2 (0-1)
+    16:00  Nasarawa United FC         v Remo Stars FC              1-0 (1-0)
+    16:00  Plateau United FC          v Bayelsa United FC          1-0 (0-0)
+    16:00  Rangers International FC   v Sunshine Stars FC          3-0 (3-0)
+  27.02.
+    17:30  Bendel FC                  v Ikorodu City FC            2-1 (0-0)
+  28.02.
+    09:00  Rivers United FC           v Katsina United FC          1-0 (1-0)
+
+
+
+» Matchday 27
+  01.03.
+    16:00  Sunshine Stars FC          v Kwara United FC            4-2 (3-2)
+  02.03.
+    15:00  Abia Warriors FC           v Nasarawa United FC         1-1 (1-1)
+    16:00  Bayelsa United FC          v Bendel FC                  2-1 (1-1)
+    16:00  Kano Pillars FC            v Rangers International FC   2-1 (1-1)
+    16:00  Niger Tornadoes FC         v Enyimba FC                 0-1 (0-0)
+    17:30  Ikorodu City FC            v Heartland FC               2-0 (1-0)
+    17:30  Remo Stars FC              v Plateau United FC          1-0 (0-0)
+  03.03.
+    15:00  Akwa United FC             v Katsina United FC          1-0 (1-0)
+    15:00  El-Kanemi Warriors FC      v Lobi Stars FC              1-0 (0-0)
+    17:30  Shooting Stars SC          v Rivers United FC           0-0 (0-0)
+
+
+
+» Matchday 28
+  07.03.
+    15:00  Katsina United FC          v Shooting Stars SC          1-0 (0-0)
+  08.03.
+    15:00  Rivers United FC           v Niger Tornadoes FC         1-0 (0-0)
+    16:00  Bendel FC                  v Remo Stars FC              2-1 (1-0)
+    16:00  Lobi Stars FC              v Ikorodu City FC            0-1 (0-0)
+  09.03.
+    15:00  Plateau United FC          v Abia Warriors FC           1-0 (0-0)
+    16:00  Enyimba FC                 v El-Kanemi Warriors FC      1-0 (1-0)
+    16:00  Kwara United FC            v Kano Pillars FC            2-0 (1-0)
+    16:00  Nasarawa United FC         v Sunshine Stars FC          1-1 (1-1)
+    16:00  Rangers International FC   v Akwa United FC             1-1 (0-1)
+    17:30  Heartland FC               v Bayelsa United FC          1-1 (0-0)
+
+
+
+» Matchday 29
+  14.03.
+    16:00  Niger Tornadoes FC         v Katsina United FC          1-0 (0-0)
+  15.03.
+    16:00  Rangers International FC   v Kwara United FC            3-0 (2-0)
+  16.03.
+    15:00  El-Kanemi Warriors FC      v Rivers United FC           1-2 (0-0)
+    15:00  Kano Pillars FC            v Nasarawa United FC         1-1 (1-0)
+    16:00  Abia Warriors FC           v Bendel FC                  1-0 (1-0)
+    16:00  Akwa United FC             v Shooting Stars SC          2-0 (0-0)
+    16:00  Bayelsa United FC          v Lobi Stars FC              1-0 (0-0)
+    17:30  Ikorodu City FC            v Enyimba FC                 2-2 (1-0)
+    17:30  Remo Stars FC              v Heartland FC               2-0 (1-0)
+  17.03.
+    16:00  Sunshine Stars FC          v Plateau United FC          2-2 (1-2)
+
+
+
+» Matchday 30
+  09.04.
+    16:00  Lobi Stars FC              v Remo Stars FC              2-2 (2-0)
+  21.03.
+    16:00  Nasarawa United FC         v Rangers International FC   1-0 (0-0)
+  22.03.
+    15:00  Plateau United FC          v Kano Pillars FC            2-1 (0-1)
+    17:30  Bendel FC                  v Sunshine Stars FC          1-0 (1-0)
+  23.03.
+    16:00  Enyimba FC                 v Bayelsa United FC          1-1 (1-1)
+    16:00  Heartland FC               v Abia Warriors FC           0-1 (0-0)
+    16:00  Katsina United FC          v El-Kanemi Warriors FC      3-0 (1-0)
+    16:00  Kwara United FC            v Akwa United FC             0-2 (0-1)
+    16:00  Rivers United FC           v Ikorodu City FC            1-0 (0-0)
+    17:30  Shooting Stars SC          v Niger Tornadoes FC         3-1 (2-0)
+
+
+
+» Matchday 31
+  10.04.
+    17:30  Ikorodu City FC            v Katsina United FC          6-0 (2-0)
+  26.03.
+    16:00  Abia Warriors FC           v Lobi Stars FC              2-0 (1-0)
+    16:00  Bayelsa United FC          v Rivers United FC           1-0 (1-0)
+    16:00  Kano Pillars FC            v Bendel FC                  0-0 (0-0)
+    16:00  Kwara United FC            v Nasarawa United FC         1-0 (0-0)
+    16:00  Sunshine Stars FC          v Heartland FC               0-0 (0-0)
+  27.03.
+    15:00  El-Kanemi Warriors FC      v Shooting Stars SC          2-2 (0-2)
+    16:00  Akwa United FC             v Niger Tornadoes FC         2-0 (1-0)
+    16:00  Rangers International FC   v Plateau United FC          0-1 (0-0)
+    16:00  Remo Stars FC              v Enyimba FC                 2-0 (1-0)
+
+
+
+» Matchday 32
+  05.04.
+    15:15  Heartland FC               v Kano Pillars FC            2-0 (1-0)
+    17:30  Bendel FC                  v Rangers International FC   0-0 (0-0)
+  06.04.
+    16:00  Enyimba FC                 v Abia Warriors FC           2-1 (1-1)
+    16:00  Katsina United FC          v Bayelsa United FC          1-1 (0-1)
+    16:00  Lobi Stars FC              v Sunshine Stars FC          1-1 (0-1)
+    16:00  Nasarawa United FC         v Akwa United FC             2-0 (1-0)
+    16:00  Niger Tornadoes FC         v El-Kanemi Warriors FC      2-0 (1-0)
+    16:00  Plateau United FC          v Kwara United FC            0-0 (0-0)
+    16:00  Rivers United FC           v Remo Stars FC              1-0 (0-0)
+    17:30  Shooting Stars SC          v Ikorodu City FC            0-0 (0-0)
+
+
+
+» Matchday 33
+  11.04.
+    16:00  Bayelsa United FC          v Shooting Stars SC          3-0 (2-0)
+  13.04.
+    15:00  Rangers International FC   v Heartland FC               0-2 (0-1)
+    16:00  Abia Warriors FC           v Rivers United FC           2-0 (1-0)
+    16:00  Akwa United FC             v El-Kanemi Warriors FC      1-1 (1-0)
+    16:00  Kano Pillars FC            v Lobi Stars FC              2-0 (0-0)
+    16:00  Nasarawa United FC         v Plateau United FC          3-2 (1-0)
+    16:00  Remo Stars FC              v Katsina United FC          0-0 (0-0)
+    16:00  Sunshine Stars FC          v Enyimba FC                 2-1 (2-1)
+    17:30  Ikorodu City FC            v Niger Tornadoes FC         3-0 (0-0)
+    17:30  Kwara United FC            v Bendel FC                  0-1 (0-1)
+
+
+
+» Matchday 34
+  19.04.
+    15:00  Katsina United FC          v Abia Warriors FC           5-1 (2-1)
+    16:00  Enyimba FC                 v Kano Pillars FC            2-1 (1-0)
+    16:00  Lobi Stars FC              v Rangers International FC   2-4 (1-2)
+  20.04.
+    15:00  El-Kanemi Warriors FC      v Ikorodu City FC            1-1 (1-1)
+    15:00  Niger Tornadoes FC         v Bayelsa United FC          1-1 (1-0)
+    16:00  Heartland FC               v Kwara United FC            0-0 (0-0)
+    16:00  Plateau United FC          v Akwa United FC             1-0 (1-0)
+    16:00  Rivers United FC           v Sunshine Stars FC          1-0 (0-0)
+    16:00  Shooting Stars SC          v Remo Stars FC              0-1 (0-1)
+    17:30  Bendel FC                  v Nasarawa United FC         1-1 (0-1)
+
+
+
+» Matchday 35
+  25.04.
+    16:00  Kano Pillars FC            v Rivers United FC           2-0 (0-0)
+  27.04.
+    15:00  Nasarawa United FC         v Heartland FC               1-0 (1-0)
+    16:00  Abia Warriors FC           v Shooting Stars SC          3-1 (2-0)
+    16:00  Akwa United FC             v Ikorodu City FC            2-1 (1-1)
+    16:00  Bayelsa United FC          v El-Kanemi Warriors FC      2-1 (1-1)
+    16:00  Kwara United FC            v Lobi Stars FC              4-0 (2-0)
+    16:00  Plateau United FC          v Bendel FC                  2-1 (1-0)
+    16:00  Rangers International FC   v Enyimba FC                 1-2 (0-2)
+    16:00  Sunshine Stars FC          v Katsina United FC          2-0 (0-0)
+    17:30  Remo Stars FC              v Niger Tornadoes FC         1-0 (0-0)
+
+
+
+» Matchday 36
+  07.05.
+    15:00  El-Kanemi Warriors FC      v Remo Stars FC              2-0 (0-0)
+    15:00  Lobi Stars FC              v Nasarawa United FC         1-2 (1-0)
+    16:00  Bendel FC                  v Akwa United FC             1-0 (0-0)
+    16:00  Enyimba FC                 v Kwara United FC            2-0 (2-0)
+    16:00  Heartland FC               v Plateau United FC          2-0 (1-0)
+    16:00  Katsina United FC          v Kano Pillars FC            1-0 (1-0)
+    16:00  Niger Tornadoes FC         v Abia Warriors FC           1-1 (0-0)
+    16:00  Rivers United FC           v Rangers International FC   1-0 (1-0)
+    16:00  Shooting Stars SC          v Sunshine Stars FC          1-0 (0-0)
+    17:30  Ikorodu City FC            v Bayelsa United FC          3-2 (2-2)
+
+
+
+» Matchday 37
+  11.05.
+    15:00  Abia Warriors FC           v El-Kanemi Warriors FC      2-1 (0-1)
+    15:00  Akwa United FC             v Bayelsa United FC          2-0 (1-0)
+    15:00  Bendel FC                  v Heartland FC               1-0 (0-0)
+    15:00  Kano Pillars FC            v Shooting Stars SC          3-1 (0-0)
+    15:00  Kwara United FC            v Rivers United FC           3-1 (1-0)
+    15:00  Nasarawa United FC         v Enyimba FC                 3-2 (2-1)
+    15:00  Plateau United FC          v Lobi Stars FC              2-1 (2-1)
+    15:00  Rangers International FC   v Katsina United FC          4-0 (2-0)
+    15:00  Remo Stars FC              v Ikorodu City FC            4-1 (2-1)
+    15:00  Sunshine Stars FC          v Niger Tornadoes FC         1-2 (1-1)
+
+
+
+» Matchday 38
+  25.05.
+    16:00  Bayelsa United FC          v Remo Stars FC              3-0 (1-0)
+    16:00  El-Kanemi Warriors FC      v Sunshine Stars FC          1-0 (1-0)
+    16:00  Enyimba FC                 v Plateau United FC          0-1 (0-1)
+    16:00  Heartland FC               v Akwa United FC             2-1 (1-0)
+    16:00  Ikorodu City FC            v Abia Warriors FC           3-2 (1-1)
+    16:00  Katsina United FC          v Kwara United FC            1-0 (1-0)
+    16:00  Lobi Stars FC              v Bendel FC                  2-1 (1-1)
+    16:00  Niger Tornadoes FC         v Kano Pillars FC            3-2 (1-1)
+    16:00  Rivers United FC           v Nasarawa United FC         2-1 (1-1)
+    16:00  Shooting Stars SC          v Rangers International FC   5-1 (1-1)
+


### PR DESCRIPTION
## Summary

Adds Nigeria Professional Football League (NPFL) seasons from 2021/22 to 2024/25 to the Open Football dataset.

## Details

- **Country:** Nigeria  
- **Competition:** Nigeria Professional Football League  
- **Seasons:** 2021/22 – 2024/25 
- **Tier:** 1 (`ng1`)  
- **Matches:** Full league seasons (excluding 2019/20)  
- **Source:** Soccerway  

## Notes

- The 2019/20 NPFL season remains excluded due to COVID-19 disruption and league cancellation (as documented in earlier PRs).
- Team names follow the established NPFL canonical naming used in prior seasons.
- This PR completes the historical NPFL data up to the most recently finished season (2024/25).