### PR TITLE
Add Nigeria National League seasons 2022-2025

### DIFF
--- a/africa/nigeria/2022-23_ng2.txt
+++ b/africa/nigeria/2022-23_ng2.txt
@@ -1,0 +1,340 @@
+= Nigeria National League 2022/2023
+
+# Teams      44
+# Matches    215
+# Stages     NNL (202)  NNL - Promotion Group (12)  NNL - Play Offs (1)
+
+
+
+======================================================================
+  NNL
+======================================================================
+
+
+
+» Matchday 1
+  04.03.
+    16:00  One Rocket FC            v Warri Wolves FC          2-1
+  05.04.
+    15:00  Adamawa United FC        v Yobe Desert Stars FC     0-1
+  21.03.
+    14:00  Madiba FC                v Ekiti United FC          3-0
+    16:00  Ikorodu United FC        v Ebedei FC                3-1
+  22.03.
+    13:00  Joy Cometh FC            v Ijebu FC                 1-2
+    14:00  Kogi FC                  v Hypebuzz FC              1-1
+    16:00  Abia Comets FC           v Heartland FC             0-1
+    16:00  Crown FC                 v Gateway Utd.             0-1
+    16:00  Go Round FC              v Vandrezzer FC            1-3
+    16:00  Green Beret FC           v FWC Champions FC         2-2
+    16:00  Ibom Youths FC           v Cynosure FC              3-2
+    16:00  Kebbi FC                 v Malumfashi FC            3-1
+    16:00  Rovers FC                v Henserd FC               2-1
+    16:00  Smart City FC            v Sporting Lagos FC        1-2
+    17:00  Katsina United FC        v City FC Abuja            3-0
+    17:00  Mighty Jets FC           v EFCC FC                  1-0
+    17:00  Nigeria Airforce FC      v Jigawa Golden Stars FC   1-1
+    17:00  Police Machine FC        v DMD FC                   0-0
+    17:00  Sokoto FC                v Kano Pillars FC          0-1
+  23.03.
+    08:00  Giant Brillars FC        v Edel FC                  1-0
+    17:00  ABS FC                   v Mailantarki Care FC      1-0
+
+
+
+» Matchday 2
+  24.03.
+    16:00  Police Machine FC        v Adamawa United FC        0-0
+  25.03.
+    16:00  Abeokuta FC              v Ikorodu United FC        2-0
+    16:00  DMD FC                   v Yobe Desert Stars FC     1-0
+    16:00  Edel FC                  v Cynosure FC              1-1
+    16:00  Kogi FC                  v Mighty Jets FC           1-0
+  26.03.
+    15:00  Ebedei FC                v Madiba FC                0-0
+    15:00  EFCC FC                  v ABS FC                   2-0
+    15:00  FWC Champions FC         v Nigeria Airforce FC      0-0
+    15:00  Giant Brillars FC        v Abia Comets FC           1-1
+    15:00  Heartland FC             v Ibom Youths FC           1-0
+    15:00  Henserd FC               v Warri Wolves FC          1-2
+    15:00  Ijebu FC                 v Gateway Utd.             1-0
+    15:00  Kano Pillars FC          v Kebbi FC                 3-0
+    15:00  Katsina United FC        v Green Beret FC           2-1
+    15:00  Rovers FC                v Go Round FC              1-0
+    15:00  Sporting Lagos FC        v Crown FC                 1-2
+    15:00  Vandrezzer FC            v One Rocket FC            0-0
+    15:00  Zamfara United FC        v Sokoto FC                2-2
+  27.03.
+    15:00  City FC Abuja            v Jigawa Golden Stars FC   1-0
+    15:00  Hypebuzz FC              v Mailantarki Care FC      0-0
+    15:00  Joy Cometh FC            v Smart City FC            0-1
+
+
+
+» Matchday 3
+  01.04.
+    15:00  Go Round FC              v Henserd FC               1-1
+    15:00  Green Beret FC           v City FC Abuja            2-1
+    15:00  Madiba FC                v Abeokuta FC              1-1
+    15:00  Nigeria Airforce FC      v Katsina United FC        0-0
+    16:00  Abia Comets FC           v Edel FC                  2-0
+    16:00  Crown FC                 v Joy Cometh FC            1-0
+    16:00  Cynosure FC              v Heartland FC             0-0
+    16:00  Ibom Youths FC           v Giant Brillars FC        0-0
+    16:00  Jigawa Golden Stars FC   v FWC Champions FC         2-0
+    16:00  Kebbi FC                 v Zamfara United FC        3-0
+    16:00  One Rocket FC            v Rovers FC                0-0
+  02.04.
+    15:00  Ekiti United FC          v Ebedei FC                3-0
+    15:00  Mailantarki Care FC      v EFCC FC                  1-0
+    16:00  ABS FC                   v Kogi FC                  2-0
+    16:00  Gateway Utd.             v Sporting Lagos FC        1-1
+    16:00  Smart City FC            v Ijebu FC                 3-2
+    16:00  Warri Wolves FC          v Vandrezzer FC            1-1
+  03.04.
+    15:00  Mighty Jets FC           v Hypebuzz FC              1-0
+  08.04.
+    16:00  Adamawa United FC        v DMD FC                   1-0
+    16:00  Yobe Desert Stars FC     v Police Machine FC        1-0
+  31.03.
+    16:00  Malumfashi FC            v Kano Pillars FC          1-0
+
+
+
+» Matchday 4
+  07.04.
+    16:00  Hypebuzz FC              v EFCC FC                  2-0
+    16:00  Ikorodu United FC        v Madiba FC                1-3
+    16:00  Zamfara United FC        v Malumfashi FC            0-0
+  08.04.
+    16:00  Abeokuta FC              v Ekiti United FC          1-1
+    16:00  Abia Comets FC           v Ibom Youths FC           0-0
+    16:00  Edel FC                  v Heartland FC             1-1
+    16:00  Giant Brillars FC        v Cynosure FC              2-1
+    16:00  Go Round FC              v One Rocket FC            2-1
+    16:00  Green Beret FC           v Nigeria Airforce FC      0-1
+    16:00  Henserd FC               v Vandrezzer FC            2-0
+    16:00  Ijebu FC                 v Sporting Lagos FC        0-0
+    16:00  Kogi FC                  v Mailantarki Care FC      0-0
+    16:00  Mighty Jets FC           v ABS FC                   1-0
+    16:00  Rovers FC                v Warri Wolves FC          2-0
+    16:00  Sokoto FC                v Kebbi FC                 2-2
+  09.04.
+    16:00  City FC Abuja            v FWC Champions FC         1-1
+    16:00  Katsina United FC        v Jigawa Golden Stars FC   2-1
+    16:00  Smart City FC            v Crown FC                 0-0
+  10.04.
+    16:00  Joy Cometh FC            v Gateway Utd.             2-0
+  29.04.
+    16:00  Police Machine FC        v Yobe Desert Stars FC     1-0
+  30.04.
+    16:00  DMD FC                   v Adamawa United FC        1-0
+
+
+
+» Matchday 5
+  07.05.
+    16:00  Adamawa United FC        v Police Machine FC        2-1
+    16:00  Yobe Desert Stars FC     v DMD FC                   0-0
+  14.04.
+    16:00  EFCC FC                  v Kogi FC                  1-1
+  15.04.
+    16:00  Crown FC                 v Ijebu FC                 1-1
+    16:00  Cynosure FC              v Abia Comets FC           1-0
+    16:00  Ebedei FC                v Abeokuta FC              0-2
+    16:00  Ibom Youths FC           v Edel FC                  0-1
+    16:00  Jigawa Golden Stars FC   v Green Beret FC           2-0
+    16:00  Nigeria Airforce FC      v City FC Abuja            2-0
+    16:00  One Rocket FC            v Henserd FC               3-1
+  16.04.
+    15:00  Sporting Lagos FC        v Joy Cometh FC            3-1
+    16:00  ABS FC                   v Hypebuzz FC              2-1
+    16:00  Ekiti United FC          v Ikorodu United FC        2-1
+    16:00  FWC Champions FC         v Katsina United FC        1-2
+    16:00  Heartland FC             v Giant Brillars FC        3-2
+    16:00  Mailantarki Care FC      v Mighty Jets FC           0-1
+    16:00  Vandrezzer FC            v Rovers FC                1-1
+    16:00  Warri Wolves FC          v Go Round FC              1-0
+  19.04.
+    16:00  Kano Pillars FC          v Zamfara United FC        3-0
+    16:00  Malumfashi FC            v Sokoto FC                3-0
+  20.04.
+    16:00  Gateway Utd.             v Smart City FC            1-0
+
+
+
+» Matchday 6
+  10.06.
+    16:00  DMD FC                   v Police Machine FC        1-0
+    16:00  Yobe Desert Stars FC     v Adamawa United FC        2-0
+  28.04.
+    13:00  Joy Cometh FC            v Sporting Lagos FC        2-2
+  29.04.
+    15:00  Abeokuta FC              v Ebedei FC                3-1
+    16:00  Edel FC                  v Ibom Youths FC           2-1
+    16:00  Giant Brillars FC        v Heartland FC             0-0
+    16:00  Henserd FC               v One Rocket FC            2-3
+    16:00  Ijebu FC                 v Crown FC                 2-2
+    16:00  Ikorodu United FC        v Ekiti United FC          1-0
+    16:00  Kogi FC                  v EFCC FC                  0-1
+    16:00  Mighty Jets FC           v Mailantarki Care FC      2-1
+    16:00  Rovers FC                v Vandrezzer FC            1-0
+  30.04.
+    13:00  Abia Comets FC           v Cynosure FC              1-0
+    16:00  City FC Abuja            v Nigeria Airforce FC      1-0
+    16:00  Go Round FC              v Warri Wolves FC          0-0
+    16:00  Green Beret FC           v Jigawa Golden Stars FC   1-2
+    16:00  Hypebuzz FC              v ABS FC                   2-0
+    16:00  Katsina United FC        v FWC Champions FC         1-0
+    16:00  Smart City FC            v Gateway Utd.             2-1
+    16:00  Sokoto FC                v Malumfashi FC            2-0
+    16:00  Zamfara United FC        v Kano Pillars FC          0-2
+
+
+
+» Matchday 7
+  05.05.
+    16:00  Malumfashi FC            v Zamfara United FC        4-0
+  06.05.
+    16:00  Crown FC                 v Smart City FC            1-0
+    16:00  Cynosure FC              v Giant Brillars FC        1-0
+    16:00  Ibom Youths FC           v Abia Comets FC           0-0
+    16:00  Jigawa Golden Stars FC   v Katsina United FC        0-0
+    16:00  Kebbi FC                 v Sokoto FC                2-0
+    16:00  Madiba FC                v Ikorodu United FC        1-0
+    16:00  Nigeria Airforce FC      v Green Beret FC           1-1
+    16:00  One Rocket FC            v Go Round FC              2-0
+    16:00  Warri Wolves FC          v Rovers FC                0-0
+  07.05.
+    14:00  Heartland FC             v Edel FC                  1-0
+    14:00  Mailantarki Care FC      v Kogi FC                  3-1
+    15:30  Sporting Lagos FC        v Ijebu FC                 2-1
+    16:00  ABS FC                   v Mighty Jets FC           1-0
+    16:00  EFCC FC                  v Hypebuzz FC              3-1
+    16:00  Ekiti United FC          v Abeokuta FC              2-1
+    16:00  Gateway Utd.             v Joy Cometh FC            0-0
+    16:00  Vandrezzer FC            v Henserd FC               2-0
+  08.05.
+    16:00  FWC Champions FC         v City FC Abuja            0-1
+
+
+
+» Matchday 8
+  12.05.
+    16:00  EFCC FC                  v Mailantarki Care FC      1-0
+    16:00  Zamfara United FC        v Kebbi FC                 0-1
+  13.05.
+    16:00  Abeokuta FC              v Madiba FC                3-1
+    16:00  Edel FC                  v Abia Comets FC           2-1
+    16:00  Giant Brillars FC        v Ibom Youths FC           3-1
+    16:00  Henserd FC               v Go Round FC              1-0
+    16:00  Hypebuzz FC              v Mighty Jets FC           2-0
+    16:00  Ijebu FC                 v Smart City FC            2-1
+    16:00  Kogi FC                  v ABS FC                   1-0
+    16:00  Rovers FC                v One Rocket FC            1-2
+  14.05.
+    14:00  Heartland FC             v Cynosure FC              1-0
+    15:30  Sporting Lagos FC        v Gateway Utd.             1-0
+    16:00  City FC Abuja            v Green Beret FC           1-0
+    16:00  Ebedei FC                v Ekiti United FC          1-2
+    16:00  FWC Champions FC         v Jigawa Golden Stars FC   2-0
+    16:00  Kano Pillars FC          v Malumfashi FC            3-1
+    16:00  Katsina United FC        v Nigeria Airforce FC      3-1
+    16:00  Vandrezzer FC            v Warri Wolves FC          0-1
+  15.05.
+    16:00  Joy Cometh FC            v Crown FC                 2-1
+
+
+
+» Matchday 9
+  04.06.
+    16:00  Madiba FC                v Ebedei FC                6-0
+  20.05.
+    16:00  Abia Comets FC           v Giant Brillars FC        1-0
+    16:00  Crown FC                 v Sporting Lagos FC        1-0
+    16:00  Cynosure FC              v Edel FC                  4-0
+    16:00  Green Beret FC           v Katsina United FC        1-1
+    16:00  Ibom Youths FC           v Heartland FC             1-2
+    16:00  Jigawa Golden Stars FC   v City FC Abuja            2-0
+    16:00  Kebbi FC                 v Kano Pillars FC          1-1
+    16:00  Mighty Jets FC           v Kogi FC                  1-0
+    16:00  Nigeria Airforce FC      v FWC Champions FC         0-1
+    16:00  Sokoto FC                v Zamfara United FC        2-0
+  21.05.
+    16:00  ABS FC                   v EFCC FC                  1-2
+    16:00  Gateway Utd.             v Ijebu FC                 0-1
+    16:00  Go Round FC              v Rovers FC                0-0
+    16:00  Mailantarki Care FC      v Hypebuzz FC              1-0
+    16:00  One Rocket FC            v Vandrezzer FC            3-1
+    16:00  Warri Wolves FC          v Henserd FC               2-1
+  22.05.
+    16:00  Ikorodu United FC        v Abeokuta FC              1-3
+  23.05.
+    16:00  Smart City FC            v Joy Cometh FC            2-0
+
+
+
+» Matchday 10
+  10.06.
+    14:00  EFCC FC                  v Mighty Jets FC           2-0
+    14:00  Hypebuzz FC              v Kogi FC                  4-0
+    14:00  Mailantarki Care FC      v ABS FC                   2-0
+    16:00  City FC Abuja            v Katsina United FC        1-0
+    16:00  Cynosure FC              v Ibom Youths FC           4-0
+    16:00  Ebedei FC                v Ikorodu United FC        2-1
+    16:00  Edel FC                  v Giant Brillars FC        0-1
+    16:00  Ekiti United FC          v Madiba FC                2-1
+    16:00  FWC Champions FC         v Green Beret FC           1-1
+    16:00  Heartland FC             v Abia Comets FC           0-0
+    16:00  Henserd FC               v Rovers FC                3-0
+    16:00  Jigawa Golden Stars FC   v Nigeria Airforce FC      1-1
+    16:00  Kano Pillars FC          v Sokoto FC                1-0
+    16:00  Malumfashi FC            v Kebbi FC                 2-0
+    16:00  Vandrezzer FC            v Go Round FC              2-0
+    16:00  Warri Wolves FC          v One Rocket FC            2-1
+  14.06.
+    16:00  Gateway Utd.             v Crown FC                 1-0
+    16:00  Ijebu FC                 v Joy Cometh FC            3-1
+    16:00  Sporting Lagos FC        v Smart City FC            4-0
+
+
+======================================================================
+  NNL - PROMOTION GROUP
+======================================================================
+
+
+
+» Matchday 1
+  02.07.
+    09:00  Kano Pillars FC          v EFCC FC                  1-0
+    11:00  DMD FC                   v Katsina United FC        1-2
+    14:00  Sporting Lagos FC        v One Rocket FC            1-0
+    16:00  Abeokuta FC              v Heartland FC             0-0
+
+
+
+» Matchday 2
+  03.07.
+    09:00  EFCC FC                  v Katsina United FC        2-1
+    11:00  Kano Pillars FC          v DMD FC                   2-0
+    14:00  One Rocket FC            v Heartland FC             0-1
+    16:00  Sporting Lagos FC        v Abeokuta FC              2-0
+
+
+
+» Matchday 3
+  05.07.
+    13:00  DMD FC                   v EFCC FC                  2-0
+    13:00  Katsina United FC        v Kano Pillars FC          1-0
+    15:00  Abeokuta FC              v One Rocket FC            4-0
+    15:00  Heartland FC             v Sporting Lagos FC        2-1
+
+
+======================================================================
+  NNL - PLAY OFFS
+======================================================================
+
+» Final
+  07.07.
+    16:00  Kano Pillars FC          v Heartland FC             0-2
+

--- a/africa/nigeria/2023-24_ng2.txt
+++ b/africa/nigeria/2023-24_ng2.txt
@@ -1,0 +1,609 @@
+= Nigeria National League 2023/2024
+
+# Teams      40
+# Matches    378
+# Stages     NNL (365)  NNL - Promotion Group (12)  NNL - Play Offs (1)
+
+
+
+======================================================================
+  NNL
+======================================================================
+
+
+
+» Matchday 1
+  06.12.
+    15:00  Malumfashi FC            v Adamawa United FC        1-2
+    15:00  Osun FC                  v Gateway Utd.             1-1
+  11.11.
+    16:00  Nasarawa United FC       v Zamfara United FC        1-0
+  17.11.
+    17:00  Kebbi FC                 v Sporting Supreme FC      1-2
+  18.11.
+    16:00  Crown FC                 v One Rocket FC            2-1
+    16:00  Dakkada FC               v 1472 FC                  2-2
+    16:00  Giant Brillars FC        v Ikorodu City FC          1-0
+    16:00  Ijebu FC                 v Inter Lagos FC           2-1
+    16:00  Jigawa Golden Stars FC   v Mailantarki Care FC      1-0
+    16:00  Sokoto FC                v City FC Abuja            1-0
+    16:00  Solution FC              v Tradesafe FC             1-0
+    16:00  Wikki Tourists FC        v EFCC FC                  5-0
+    16:00  Yobe Desert Stars FC     v Mighty Jets FC           2-2
+  19.11.
+    15:00  Vandrezzer FC            v Coal City FC             1-0
+    16:00  Beyond Limits FC         v Madiba FC                1-1
+    16:00  Ekiti United FC          v Abia Comets FC           3-0
+    16:00  Rovers FC                v Stormers FC              1-0
+  20.11.
+    16:00  Nigeria Airforce FC      v ABS FC                   1-0
+    16:00  Smart City FC            v Edel FC                  1-1
+
+
+
+» Matchday 2
+  19.12.
+    15:00  Gateway Utd.             v Ijebu FC                 2-1
+    16:00  Malumfashi FC            v Kebbi FC                 1-0
+  24.11.
+    16:00  EFCC FC                  v Nasarawa United FC       0-0
+    16:00  Sporting Supreme FC      v Jigawa Golden Stars FC   3-1
+  25.11.
+    13:00  Inter Lagos FC           v Crown FC                 1-2
+    16:00  Abia Comets FC           v Beyond Limits FC         2-0
+    16:00  Coal City FC             v Ekiti United FC          2-1
+    16:00  Edel FC                  v Madiba FC                0-1
+    16:00  El-Kanemi Warriors FC    v Yobe Desert Stars FC     2-0
+    16:00  Mighty Jets FC           v Wikki Tourists FC        0-0
+    16:00  Sokoto FC                v Adamawa United FC        2-0
+    16:00  Tradesafe FC             v Osun FC                  0-1
+  26.11.
+    14:00  1472 FC                  v Rovers FC                2-1
+    16:00  City FC Abuja            v Mailantarki Care FC      2-1
+    16:00  One Rocket FC            v Giant Brillars FC        1-0
+    16:00  Smart City FC            v Dakkada FC               1-0
+    16:00  Stormers FC              v Vandrezzer FC            2-0
+    16:00  Warri Wolves FC          v Solution FC              2-0
+    16:00  Zamfara United FC        v Nigeria Airforce FC      2-1
+
+
+
+» Matchday 3
+  01.12.
+    15:00  Adamawa United FC        v City FC Abuja            1-0
+    15:00  Kebbi FC                 v Sokoto FC                2-1
+    15:00  Madiba FC                v Abia Comets FC           3-0
+    15:00  Nigeria Airforce FC      v EFCC FC                  0-1
+  02.12.
+    15:00  ABS FC                   v Zamfara United FC        1-0
+    15:00  Beyond Limits FC         v Coal City FC             2-1
+    15:00  Crown FC                 v Gateway Utd.             2-0
+    15:00  Dakkada FC               v Edel FC                  4-0
+    15:00  Giant Brillars FC        v Inter Lagos FC           3-0
+    15:00  Ijebu FC                 v Tradesafe FC             1-1
+    15:00  Ikorodu City FC          v One Rocket FC            2-0
+    15:00  Jigawa Golden Stars FC   v Malumfashi FC            1-0
+    15:00  Mailantarki Care FC      v Sporting Supreme FC      1-1
+    15:00  Nasarawa United FC       v Mighty Jets FC           2-0
+    15:00  Osun FC                  v Warri Wolves FC          2-0
+  03.12.
+    15:00  Ekiti United FC          v Stormers FC              3-2
+    15:00  Rovers FC                v Smart City FC            1-0
+    15:00  Vandrezzer FC            v 1472 FC                  0-0
+    15:00  Wikki Tourists FC        v El-Kanemi Warriors FC    1-1
+
+
+
+» Matchday 4
+  08.12.
+    14:00  1472 FC                  v Ekiti United FC          4-1
+    15:00  Adamawa United FC        v Kebbi FC                 0-2
+    15:00  EFCC FC                  v ABS FC                   0-1
+  09.12.
+    13:00  Inter Lagos FC           v Ikorodu City FC          1-1
+    15:00  El-Kanemi Warriors FC    v Nasarawa United FC       1-0
+    15:00  Gateway Utd.             v Giant Brillars FC        1-0
+    15:00  Mighty Jets FC           v Nigeria Airforce FC      2-0
+    15:00  Sokoto FC                v Jigawa Golden Stars FC   2-1
+    15:00  Stormers FC              v Beyond Limits FC         0-5
+    15:00  Yobe Desert Stars FC     v Wikki Tourists FC        1-1
+    16:00  Coal City FC             v Madiba FC                1-2
+    16:00  Dakkada FC               v Rovers FC                1-1
+    16:00  Smart City FC            v Vandrezzer FC            2-0
+    16:00  Solution FC              v Osun FC                  1-0
+  10.12.
+    15:00  Edel FC                  v Abia Comets FC           3-0
+    16:00  City FC Abuja            v Sporting Supreme FC      0-1
+    16:00  Malumfashi FC            v Mailantarki Care FC      1-3
+    16:00  Warri Wolves FC          v Ijebu FC                 2-0
+  11.12.
+    16:00  Tradesafe FC             v Crown FC                 2-1
+
+
+
+» Matchday 5
+  15.12.
+    15:00  Kebbi FC                 v City FC Abuja            0-0
+    15:00  Madiba FC                v Stormers FC              2-0
+  16.12.
+    15:00  Abia Comets FC           v Coal City FC             0-1
+    15:00  ABS FC                   v Mighty Jets FC           0-0
+    15:00  Crown FC                 v Warri Wolves FC          1-1
+    15:00  Giant Brillars FC        v Tradesafe FC             0-1
+    15:00  Ijebu FC                 v Solution FC              1-0
+    15:00  Jigawa Golden Stars FC   v Adamawa United FC        0-1
+    15:00  Mailantarki Care FC      v Sokoto FC                1-0
+    15:00  Nasarawa United FC       v Yobe Desert Stars FC     2-1
+    15:00  Sporting Supreme FC      v Malumfashi FC            2-1
+    15:00  Vandrezzer FC            v Dakkada FC               0-0
+    15:00  Zamfara United FC        v EFCC FC                  2-0
+    16:00  Ikorodu City FC          v Gateway Utd.             4-0
+  17.12.
+    15:00  Nigeria Airforce FC      v El-Kanemi Warriors FC    1-1
+    15:00  One Rocket FC            v Inter Lagos FC           0-1
+    15:00  Rovers FC                v Edel FC                  1-0
+    16:00  Beyond Limits FC         v 1472 FC                  2-0
+    16:00  Ekiti United FC          v Smart City FC            2-0
+
+
+
+» Matchday 6
+  22.12.
+    13:00  1472 FC                  v Madiba FC                2-3
+    15:00  Adamawa United FC        v Mailantarki Care FC      0-0
+    15:00  City FC Abuja            v Malumfashi FC            1-0
+    15:00  Dakkada FC               v Ekiti United FC          2-1
+    15:00  Edel FC                  v Coal City FC             0-1
+    15:00  Gateway Utd.             v One Rocket FC            0-1
+    15:00  Mighty Jets FC           v Zamfara United FC        2-0
+    15:00  Osun FC                  v Ijebu FC                 1-0
+    15:00  Sokoto FC                v Sporting Supreme FC      2-1
+    15:00  Stormers FC              v Abia Comets FC           2-3
+    15:00  Warri Wolves FC          v Giant Brillars FC        1-2
+    15:00  Wikki Tourists FC        v Nasarawa United FC       2-1
+    15:00  Yobe Desert Stars FC     v Nigeria Airforce FC      3-0
+    16:00  Rovers FC                v Vandrezzer FC            1-0
+    16:00  Smart City FC            v Beyond Limits FC         3-1
+  23.12.
+    15:00  El-Kanemi Warriors FC    v ABS FC                   1-0
+    15:00  Kebbi FC                 v Jigawa Golden Stars FC   0-0
+    15:00  Solution FC              v Crown FC                 1-0
+    15:00  Tradesafe FC             v Ikorodu City FC          0-0
+
+
+
+» Matchday 7
+  05.01.
+    15:00  EFCC FC                  v Mighty Jets FC           0-0
+    15:00  Madiba FC                v Smart City FC            3-2
+    15:00  Sporting Supreme FC      v Adamawa United FC        0-0
+  06.01.
+    13:00  Inter Lagos FC           v Gateway Utd.             1-0
+    15:00  ABS FC                   v Yobe Desert Stars FC     0-0
+    15:00  Beyond Limits FC         v Dakkada FC               3-0
+    15:00  Coal City FC             v Stormers FC              0-0
+    15:00  Ikorodu City FC          v Warri Wolves FC          2-1
+    15:00  Jigawa Golden Stars FC   v City FC Abuja            1-0
+    15:00  Mailantarki Care FC      v Kebbi FC                 1-1
+    15:00  Nigeria Airforce FC      v Wikki Tourists FC        0-1
+    15:00  One Rocket FC            v Tradesafe FC             2-0
+    15:00  Zamfara United FC        v El-Kanemi Warriors FC    1-0
+    16:00  Abia Comets FC           v 1472 FC                  1-0
+    16:00  Crown FC                 v Osun FC                  2-0
+    16:00  Malumfashi FC            v Sokoto FC                0-3
+  07.01.
+    15:00  Ekiti United FC          v Rovers FC                2-1
+    15:00  Giant Brillars FC        v Solution FC              1-1
+    15:00  Vandrezzer FC            v Edel FC                  1-2
+
+
+
+» Matchday 8
+  01.03.
+    15:00  Adamawa United FC        v Sporting Supreme FC      0-2
+    15:00  Kebbi FC                 v Mailantarki Care FC      4-1
+  02.03.
+    15:00  Sokoto FC                v Malumfashi FC            3-0
+  03.03.
+    15:00  City FC Abuja            v Jigawa Golden Stars FC   3-1
+  12.01.
+    13:00  1472 FC                  v Coal City FC             3-1
+  13.01.
+    13:00  Tradesafe FC             v Inter Lagos FC           2-4
+    15:00  Dakkada FC               v Madiba FC                1-0
+    15:00  Edel FC                  v Stormers FC              1-0
+    15:00  El-Kanemi Warriors FC    v EFCC FC                  1-0
+    15:00  Yobe Desert Stars FC     v Zamfara United FC        1-0
+    16:00  Ijebu FC                 v Crown FC                 2-1
+    16:00  Nasarawa United FC       v Nigeria Airforce FC      1-0
+    16:00  Osun FC                  v Giant Brillars FC        0-0
+    16:00  Smart City FC            v Abia Comets FC           1-1
+  14.01.
+    15:00  Solution FC              v Ikorodu City FC          2-1
+    15:00  Vandrezzer FC            v Ekiti United FC          2-1
+    15:00  Warri Wolves FC          v One Rocket FC            1-0
+    16:00  Rovers FC                v Beyond Limits FC         2-3
+    16:00  Wikki Tourists FC        v ABS FC                   3-0
+
+
+
+» Matchday 9
+  08.03.
+    15:00  Sporting Supreme FC      v Sokoto FC                0-0
+    15:00  Malumfashi FC            v City FC Abuja            0-3
+  09.03.
+    15:00  Jigawa Golden Stars FC   v Kebbi FC                 1-0
+    15:00  Mailantarki Care FC      v Adamawa United FC        0-0
+  19.01.
+    15:00  EFCC FC                  v Yobe Desert Stars FC     1-1
+    15:00  Madiba FC                v Rovers FC                2-0
+    15:00  Stormers FC              v 1472 FC                  2-0
+  20.01.
+    13:00  Inter Lagos FC           v Warri Wolves FC          4-1
+    15:00  Abia Comets FC           v Dakkada FC               3-1
+    15:00  Beyond Limits FC         v Vandrezzer FC            1-1
+    15:00  Gateway Utd.             v Tradesafe FC             1-0
+    15:00  Giant Brillars FC        v Ijebu FC                 0-0
+    15:00  Mighty Jets FC           v El-Kanemi Warriors FC    2-2
+    15:00  One Rocket FC            v Solution FC              1-0
+    15:00  Zamfara United FC        v Wikki Tourists FC        1-1
+    16:00  Ikorodu City FC          v Osun FC                  1-0
+  21.01.
+    15:00  ABS FC                   v Nasarawa United FC       0-0
+    15:00  Coal City FC             v Smart City FC            2-0
+    15:00  Ekiti United FC          v Edel FC                  0-1
+
+
+
+» Matchday 10
+  02.03.
+    15:00  Nasarawa United FC       v ABS FC                   3-0
+    15:00  Yobe Desert Stars FC     v EFCC FC                  2-0
+  03.03.
+    15:00  Wikki Tourists FC        v Zamfara United FC        4-0
+  13.03.
+    15:00  El-Kanemi Warriors FC    v Mighty Jets FC           2-0
+  16.03.
+    15:00  Adamawa United FC        v Jigawa Golden Stars FC   0-0
+    15:00  Sokoto FC                v Mailantarki Care FC      2-1
+  17.03.
+    15:00  City FC Abuja            v Kebbi FC                 1-1
+  27.01.
+    15:00  Crown FC                 v Giant Brillars FC        3-1
+    15:00  Dakkada FC               v Coal City FC             2-1
+    15:00  Edel FC                  v 1472 FC                  2-1
+    15:00  Ijebu FC                 v Ikorodu City FC          1-1
+    15:00  Osun FC                  v One Rocket FC            2-0
+    15:00  Smart City FC            v Stormers FC              3-0
+  28.01.
+    15:00  Ekiti United FC          v Beyond Limits FC         1-1
+    15:00  Rovers FC                v Abia Comets FC           1-1
+    15:00  Solution FC              v Inter Lagos FC           0-1
+    15:00  Vandrezzer FC            v Madiba FC                1-0
+    15:00  Warri Wolves FC          v Gateway Utd.             1-1
+
+
+
+» Matchday 11
+  02.02.
+    14:05  Madiba FC                v Ekiti United FC          2-0
+  03.02.
+    13:00  Inter Lagos FC           v Osun FC                  0-0
+    15:00  Abia Comets FC           v Vandrezzer FC            2-2
+    15:00  Coal City FC             v Rovers FC                1-0
+    15:00  Gateway Utd.             v Solution FC              1-0
+    15:05  Stormers FC              v Dakkada FC               1-2
+    16:00  Ikorodu City FC          v Crown FC                 3-1
+  04.02.
+    15:00  Beyond Limits FC         v Edel FC                  0-0
+    15:00  One Rocket FC            v Ijebu FC                 2-0
+  05.02.
+    13:00  1472 FC                  v Smart City FC            1-1
+    16:00  Tradesafe FC             v Warri Wolves FC          1-0
+  08.03.
+    15:00  EFCC FC                  v El-Kanemi Warriors FC    1-2
+  09.03.
+    15:00  ABS FC                   v Wikki Tourists FC        1-1
+    15:00  Zamfara United FC        v Yobe Desert Stars FC     0-2
+  10.03.
+    15:00  Nigeria Airforce FC      v Nasarawa United FC       0-1
+  22.03.
+    15:00  Kebbi FC                 v Adamawa United FC        1-1
+    15:00  Sporting Supreme FC      v City FC Abuja            4-0
+  23.03.
+    15:00  Jigawa Golden Stars FC   v Sokoto FC                0-2
+
+
+
+» Matchday 12
+  02.03.
+    15:00  Crown FC                 v Ikorodu City FC          0-0
+    15:00  Dakkada FC               v Stormers FC              2-0
+    15:00  Ijebu FC                 v One Rocket FC            1-0
+    15:00  Osun FC                  v Inter Lagos FC           1-0
+    15:00  Smart City FC            v 1472 FC                  2-1
+    15:00  Solution FC              v Gateway Utd.             1-1
+  02.04.
+    14:00  Sokoto FC                v Kebbi FC                 1-0
+  03.03.
+    15:00  Edel FC                  v Beyond Limits FC         1-0
+    15:00  Ekiti United FC          v Madiba FC                0-2
+    15:00  Rovers FC                v Coal City FC             1-0
+    15:00  Vandrezzer FC            v Abia Comets FC           1-2
+    15:00  Warri Wolves FC          v Tradesafe FC             3-1
+  03.04.
+    14:00  City FC Abuja            v Adamawa United FC        1-1
+    15:00  Sporting Supreme FC      v Mailantarki Care FC      1-1
+  17.03.
+    15:00  El-Kanemi Warriors FC    v Zamfara United FC        2-1
+    15:00  Mighty Jets FC           v EFCC FC                  1-1
+    15:00  Wikki Tourists FC        v Nigeria Airforce FC      1-0
+    15:00  Yobe Desert Stars FC     v ABS FC                   2-1
+
+
+
+» Matchday 13
+  06.04.
+    14:00  Adamawa United FC        v Sokoto FC                2-1
+    14:00  Jigawa Golden Stars FC   v Sporting Supreme FC      2-1
+    14:00  Mailantarki Care FC      v City FC Abuja            2-1
+  08.03.
+    15:00  Stormers FC              v Smart City FC            2-1
+    15:00  Madiba FC                v Vandrezzer FC            3-0
+  09.03.
+    15:00  Abia Comets FC           v Rovers FC                1-1
+    15:00  Coal City FC             v Dakkada FC               3-0
+    15:00  Gateway Utd.             v Warri Wolves FC          4-0
+    15:00  Ikorodu City FC          v Ijebu FC                 0-0
+    15:00  Inter Lagos FC           v Solution FC              3-0
+    15:00  One Rocket FC            v Osun FC                  1-1
+  10.03.
+    15:00  Beyond Limits FC         v Ekiti United FC          2-0
+    15:00  Giant Brillars FC        v Crown FC                 1-1
+  11.03.
+    15:00  1472 FC                  v Edel FC                  1-1
+  23.03.
+    15:00  ABS FC                   v El-Kanemi Warriors FC    0-0
+    15:00  Nasarawa United FC       v Wikki Tourists FC        2-0
+    15:00  Zamfara United FC        v Mighty Jets FC           3-0
+  24.03.
+    15:00  Nigeria Airforce FC      v Yobe Desert Stars FC     3-1
+
+
+
+» Matchday 14
+  03.04.
+    15:00  El-Kanemi Warriors FC    v Nigeria Airforce FC      1-0
+    15:00  Mighty Jets FC           v ABS FC                   2-0
+    15:00  Yobe Desert Stars FC     v Nasarawa United FC       1-0
+    16:00  EFCC FC                  v Zamfara United FC        2-1
+  13.04.
+    14:00  Mailantarki Care FC      v Jigawa Golden Stars FC   2-1
+    14:00  Sporting Supreme FC      v Kebbi FC                 2-1
+    15:00  City FC Abuja            v Sokoto FC                2-2
+  15.03.
+    15:00  1472 FC                  v Stormers FC              4-3
+  16.03.
+    15:00  Dakkada FC               v Abia Comets FC           0-1
+    15:00  Edel FC                  v Ekiti United FC          2-1
+    15:00  Ijebu FC                 v Giant Brillars FC        1-2
+    15:00  Osun FC                  v Ikorodu City FC          1-0
+    15:00  Smart City FC            v Coal City FC             4-1
+    15:00  Tradesafe FC             v Gateway Utd.             0-0
+  17.03.
+    15:00  Rovers FC                v Madiba FC                1-0
+    15:00  Solution FC              v One Rocket FC            1-0
+    15:00  Vandrezzer FC            v Beyond Limits FC         1-3
+    15:00  Warri Wolves FC          v Inter Lagos FC           2-1
+
+
+
+» Matchday 15
+  06.04.
+    14:00  ABS FC                   v EFCC FC                  1-1
+    15:00  Nasarawa United FC       v El-Kanemi Warriors FC    2-1
+  07.04.
+    15:00  Nigeria Airforce FC      v Mighty Jets FC           1-1
+    15:00  Wikki Tourists FC        v Yobe Desert Stars FC     3-0
+  22.03.
+    15:00  Madiba FC                v Dakkada FC               2-1
+    15:00  Stormers FC              v Edel FC                  2-0
+  23.03.
+    15:00  Abia Comets FC           v Smart City FC            1-1
+    15:00  Beyond Limits FC         v Rovers FC                2-0
+    15:00  Crown FC                 v Ijebu FC                 3-1
+    15:00  Giant Brillars FC        v Osun FC                  1-1
+    15:00  Ikorodu City FC          v Solution FC              3-1
+  24.03.
+    15:00  Coal City FC             v 1472 FC                  2-0
+    15:00  Ekiti United FC          v Vandrezzer FC            2-0
+    15:00  Inter Lagos FC           v Tradesafe FC             2-0
+    15:00  One Rocket FC            v Warri Wolves FC          0-0
+
+
+
+» Matchday 16
+  02.04.
+    14:00  1472 FC                  v Abia Comets FC           1-1
+    14:00  Smart City FC            v Madiba FC                1-1
+  03.04.
+    13:00  Solution FC              v Giant Brillars FC        1-0
+    15:00  Dakkada FC               v Beyond Limits FC         1-2
+    15:00  Gateway Utd.             v Inter Lagos FC           2-1
+    15:00  Osun FC                  v Crown FC                 1-0
+    15:00  Rovers FC                v Ekiti United FC          2-1
+    15:00  Stormers FC              v Coal City FC             1-0
+    15:00  Warri Wolves FC          v Ikorodu City FC          1-0
+    15:00  Edel FC                  v Vandrezzer FC            3-0
+  04.04.
+    15:00  Tradesafe FC             v One Rocket FC            1-1
+  12.04.
+    14:00  EFCC FC                  v Nigeria Airforce FC      0-1
+  13.04.
+    14:00  Zamfara United FC        v ABS FC                   3-0
+    15:00  El-Kanemi Warriors FC    v Wikki Tourists FC        2-0
+    15:00  Mighty Jets FC           v Nasarawa United FC       1-2
+
+
+
+» Matchday 17
+  05.04.
+    15:00  Madiba FC                v 1472 FC                  1-0
+  06.04.
+    14:00  Abia Comets FC           v Stormers FC              1-0
+    14:00  Coal City FC             v Edel FC                  1-0
+    14:00  Crown FC                 v Solution FC              2-0
+    15:00  Ijebu FC                 v Osun FC                  1-0
+  07.04.
+    14:00  Vandrezzer FC            v Rovers FC                2-0
+    15:00  Beyond Limits FC         v Smart City FC            3-0
+    15:00  Giant Brillars FC        v Warri Wolves FC          0-0
+    15:00  Ikorodu City FC          v Tradesafe FC             2-1
+    15:00  One Rocket FC            v Gateway Utd.             1-0
+  08.04.
+    15:00  Ekiti United FC          v Dakkada FC               0-0
+  20.04.
+    15:00  Nasarawa United FC       v EFCC FC                  2-0
+    15:00  Yobe Desert Stars FC     v El-Kanemi Warriors FC    0-1
+  21.04.
+    15:00  Nigeria Airforce FC      v Zamfara United FC        0-0
+    15:00  Wikki Tourists FC        v Mighty Jets FC           4-1
+
+
+
+» Matchday 18
+  12.04.
+    13:00  Inter Lagos FC           v One Rocket FC            4-3
+    14:00  Tradesafe FC             v Giant Brillars FC        1-2
+  13.04.
+    14:00  Coal City FC             v Abia Comets FC           2-1
+    14:00  Dakkada FC               v Vandrezzer FC            0-0
+    15:00  Edel FC                  v Rovers FC                1-0
+    15:00  Gateway Utd.             v Ikorodu City FC          0-0
+    16:00  1472 FC                  v Beyond Limits FC         2-2
+  14.04.
+    15:00  Solution FC              v Ijebu FC                 1-1
+    15:00  Stormers FC              v Madiba FC                0-0
+    15:00  Warri Wolves FC          v Crown FC                 2-1
+  15.04.
+    15:00  Smart City FC            v Ekiti United FC          5-0
+  27.04.
+    15:00  ABS FC                   v Nigeria Airforce FC      0-2
+    15:00  EFCC FC                  v Wikki Tourists FC        2-4
+    15:00  Mighty Jets FC           v Yobe Desert Stars FC     1-1
+    15:00  Zamfara United FC        v Nasarawa United FC       1-1
+
+
+
+» Matchday 19
+  19.04.
+    15:00  Ekiti United FC          v 1472 FC                  1-0
+    15:00  Madiba FC                v Coal City FC             3-1
+  20.04.
+    15:00  Beyond Limits FC         v Stormers FC              2-2
+    15:00  Crown FC                 v Tradesafe FC             1-0
+    15:00  Giant Brillars FC        v Gateway Utd.             4-1
+    15:00  Ijebu FC                 v Warri Wolves FC          1-0
+    15:00  Ikorodu City FC          v Inter Lagos FC           4-3
+  21.04.
+    15:00  Abia Comets FC           v Edel FC                  1-1
+    15:00  Rovers FC                v Dakkada FC               0-0
+    15:00  Vandrezzer FC            v Smart City FC            0-2
+  22.04.
+    15:00  Osun FC                  v Solution FC              0-0
+
+
+
+» Matchday 20
+  26.04.
+    13:00  1472 FC                  v Vandrezzer FC            2-3
+    15:00  Smart City FC            v Rovers FC                1-0
+  27.04.
+    13:00  Inter Lagos FC           v Giant Brillars FC        2-1
+    15:00  Abia Comets FC           v Madiba FC                1-0
+    15:00  Coal City FC             v Beyond Limits FC         1-0
+    15:00  Edel FC                  v Dakkada FC               2-0
+    16:00  Tradesafe FC             v Ijebu FC                 2-4
+  28.04.
+    15:00  Gateway Utd.             v Crown FC                 1-0
+    15:00  One Rocket FC            v Ikorodu City FC          0-1
+    15:00  Stormers FC              v Ekiti United FC          2-0
+    15:00  Warri Wolves FC          v Osun FC                  3-2
+
+
+
+» Matchday 21
+  03.05.
+    15:00  Ijebu FC                 v Gateway Utd.             5-0
+  04.05.
+    15:00  Beyond Limits FC         v Abia Comets FC           3-0
+    15:00  Dakkada FC               v Smart City FC            1-1
+    15:00  Giant Brillars FC        v One Rocket FC            1-2
+  05.05.
+    15:00  Crown FC                 v Inter Lagos FC           0-2
+    15:00  Madiba FC                v Edel FC                  3-0
+    15:00  Solution FC              v Warri Wolves FC          1-0
+    15:00  Vandrezzer FC            v Stormers FC              2-1
+    15:00  Osun FC                  v Tradesafe FC             3-0
+    15:00  Rovers FC                v 1472 FC                  3-0
+  06.05.
+    15:00  Ekiti United FC          v Coal City FC             1-0
+
+
+
+» Matchday 22
+  11.05.
+    15:00  1472 FC                  v Dakkada FC               1-2
+    15:00  Abia Comets FC           v Ekiti United FC          0-0
+    15:00  Coal City FC             v Vandrezzer FC            2-3
+    15:00  Edel FC                  v Smart City FC            1-0
+    15:00  Madiba FC                v Beyond Limits FC         1-1
+    15:00  Stormers FC              v Rovers FC                3-0
+  12.05.
+    10:00  Tradesafe FC             v Solution FC              0-2
+    15:00  Gateway Utd.             v Osun FC                  2-0
+    15:00  Ikorodu City FC          v Giant Brillars FC        4-0
+    15:00  Inter Lagos FC           v Ijebu FC                 2-0
+    15:00  One Rocket FC            v Crown FC                 0-0
+
+
+======================================================================
+  NNL - PROMOTION GROUP
+======================================================================
+
+
+
+» Matchday 1
+  08.06.
+    08:00  El-Kanemi Warriors FC    v Nasarawa United FC       0-1
+    11:00  Sporting Supreme FC      v Sokoto FC                1-0
+    13:30  Beyond Limits FC         v Madiba FC                2-1
+    16:15  Ikorodu City FC          v Inter Lagos FC           1-1
+
+
+
+» Matchday 2
+  10.06.
+    08:00  Madiba FC                v Inter Lagos FC           2-1
+    11:00  Beyond Limits FC         v Ikorodu City FC          1-1
+    13:30  Nasarawa United FC       v Sokoto FC                2-1
+    16:15  El-Kanemi Warriors FC    v Sporting Supreme FC      2-1
+
+
+
+» Matchday 3
+  12.06.
+    10:00  Sokoto FC                v El-Kanemi Warriors FC    1-4
+    10:00  Sporting Supreme FC      v Nasarawa United FC       1-2
+    12:30  Ikorodu City FC          v Madiba FC                2-0
+    12:30  Inter Lagos FC           v Beyond Limits FC         0-1
+
+
+======================================================================
+  NNL - PLAY OFFS
+======================================================================
+
+» Final
+  13.06.
+    15:00  Nasarawa United FC       v Beyond Limits FC         2-3 (2-2)
+

--- a/africa/nigeria/2024-25_ng2.txt
+++ b/africa/nigeria/2024-25_ng2.txt
@@ -1,0 +1,530 @@
+= Nigeria National League 2024/2025
+
+# Teams      36
+# Matches    311
+# Stages     NNL (298)  NNL - Promotion Group (12)  NNL - Play Offs (1)
+
+
+
+======================================================================
+  NNL
+======================================================================
+
+
+
+» Matchday 1
+  06.12.
+    15:00  Adamawa United FC        v Kada Warriors FC         1-2
+    15:00  Kebbi FC                 v Sporting Supreme FC      1-2
+    15:00  Solution FC              v Rovers FC                1-1
+  07.12.
+    09:00  Beyond Limits FC         v Dakkada FC               1-1
+    15:00  Barau FC                 v Mighty Jets FC           1-1
+    15:00  First Bank FC            v Osun FC                  0-0
+    15:00  Gateway Utd.             v Godswill Akpabio FC      0-0
+    15:00  Ijele FC                 v Inter Lagos FC           2-2
+    15:00  Kun Khalifa FC           v ABS FC                   1-0
+    15:00  Sokoto FC                v Jigawa Golden Stars FC   2-0
+    15:00  Warri Wolves FC          v Crown FC                 2-0
+  08.12.
+    15:00  1472 FC                  v Igbajo FC                1-0
+    15:00  Basira FC                v Yobe Desert Stars FC     1-0
+    15:00  Edel FC                  v Abia Comets FC           1-2
+    15:00  Zamfara United FC        v Wikki Tourists FC        0-2
+  30.11.
+    15:00  Abakaliki FC             v Madiba FC                2-2
+
+
+
+» Matchday 2
+  14.12.
+    15:00  Abia Comets FC           v 1472 FC                  3-0
+    15:00  ABS FC                   v Abakaliki FC             5-2
+    15:00  Crown FC                 v Ijele FC                 2-1
+    15:00  Dakkada FC               v Warri Wolves FC          1-1
+    15:00  Doma United FC           v Kebbi FC                 0-0
+    15:00  Godswill Akpabio FC      v Kun Khalifa FC           0-1
+    15:00  Jigawa Golden Stars FC   v Zamfara United FC        0-0
+    15:00  Osun FC                  v Gateway Utd.             3-0
+    15:00  Rovers FC                v First Bank FC            2-1
+    15:00  Smart City FC            v Edel FC                  2-1
+    15:00  Sporting Supreme FC      v Basira FC                1-1
+    15:00  Wikki Tourists FC        v Barau FC                 2-0
+    15:00  Yobe Desert Stars FC     v Adamawa United FC        2-0
+  15.12.
+    15:00  Gombe United FC          v Sokoto FC                2-0
+    15:00  Igbajo FC                v Beyond Limits FC         0-3
+  16.12.
+    15:00  Sporting Lagos FC        v Solution FC              4-0
+
+
+
+» Matchday 3
+  12.02.
+    10:00  1472 FC                  v Smart City FC            0-3
+    16:00  First Bank FC            v Sporting Lagos FC        1-0
+  19.12.
+    15:00  Ijele FC                 v Dakkada FC               2-1
+  20.12.
+    15:00  Adamawa United FC        v Sporting Supreme FC      2-1
+    15:00  Barau FC                 v Jigawa Golden Stars FC   1-1
+  21.12.
+    15:00  Abakaliki FC             v Godswill Akpabio FC      0-0
+    15:00  Basira FC                v Doma United FC           0-0
+    15:00  Gateway Utd.             v Rovers FC                1-0
+    15:00  Kun Khalifa FC           v Osun FC                  2-1
+    15:00  Mighty Jets FC           v Wikki Tourists FC        0-0
+    15:00  Warri Wolves FC          v Igbajo FC                1-0
+    15:00  Zamfara United FC        v Gombe United FC          1-0
+    18:00  Beyond Limits FC         v Abia Comets FC           1-1
+  22.12.
+    15:00  Kada Warriors FC         v Yobe Desert Stars FC     0-0
+  29.01.
+    10:00  Inter Lagos FC           v Crown FC                 0-0
+    12:00  Madiba FC                v ABS FC                   3-0
+
+
+
+» Matchday 4
+  04.01.
+    15:00  Dakkada FC               v Inter Lagos FC           1-0
+    15:00  Doma United FC           v Adamawa United FC        2-1
+    15:00  Jigawa Golden Stars FC   v Mighty Jets FC           0-1
+    15:00  Osun FC                  v Abakaliki FC             1-0
+    15:00  Rovers FC                v Kun Khalifa FC           1-1
+    15:00  Smart City FC            v Beyond Limits FC         2-0
+    15:00  Sokoto FC                v Zamfara United FC        3-1
+    15:00  Solution FC              v First Bank FC            2-0
+    15:00  Sporting Supreme FC      v Kada Warriors FC         2-0
+  05.01.
+    15:00  Abia Comets FC           v Warri Wolves FC          0-0
+    15:00  Edel FC                  v 1472 FC                  1-0
+    15:00  Godswill Akpabio FC      v Madiba FC                3-1
+    15:00  Gombe United FC          v Barau FC                 2-1
+    15:00  Igbajo FC                v Ijele FC                 0-0
+    15:00  Kebbi FC                 v Basira FC                1-1
+    15:00  Sporting Lagos FC        v Gateway Utd.             2-0
+
+
+
+» Matchday 5
+  10.01.
+    15:00  Adamawa United FC        v Kebbi FC                 1-1
+    15:00  Madiba FC                v Osun FC                  0-1
+  11.01.
+    15:00  Abakaliki FC             v Rovers FC                1-0
+    15:00  ABS FC                   v Godswill Akpabio FC      2-1
+    15:00  Barau FC                 v Sokoto FC                1-0
+    15:00  Beyond Limits FC         v Edel FC                  1-0
+    15:00  Crown FC                 v Dakkada FC               1-0
+    15:00  Gateway Utd.             v Solution FC              2-3
+    15:00  Ijele FC                 v Abia Comets FC           1-2
+    15:00  Kada Warriors FC         v Doma United FC           0-0
+    15:00  Kun Khalifa FC           v Sporting Lagos FC        2-1
+    15:00  Mighty Jets FC           v Gombe United FC          2-0
+    15:00  Warri Wolves FC          v Smart City FC            0-0
+    15:00  Wikki Tourists FC        v Jigawa Golden Stars FC   3-1
+    15:00  Yobe Desert Stars FC     v Sporting Supreme FC      2-0
+  12.01.
+    15:00  Inter Lagos FC           v Igbajo FC                2-0
+
+
+
+» Matchday 6
+  17.01.
+    15:00  1472 FC                  v Beyond Limits FC         0-1
+    15:00  Kebbi FC                 v Kada Warriors FC         4-1
+  18.01.
+    13:00  First Bank FC            v Gateway Utd.             0-2
+    15:00  Basira FC                v Adamawa United FC        2-1
+    15:00  Doma United FC           v Yobe Desert Stars FC     2-2
+    15:00  Osun FC                  v ABS FC                   1-0
+    15:00  Rovers FC                v Madiba FC                1-0
+    15:00  Smart City FC            v Ijele FC                 2-1
+    15:00  Sokoto FC                v Mighty Jets FC           1-0
+    15:00  Solution FC              v Kun Khalifa FC           2-0
+  19.01.
+    15:00  Abia Comets FC           v Inter Lagos FC           0-0
+    15:00  Edel FC                  v Warri Wolves FC          1-2
+    15:00  Gombe United FC          v Wikki Tourists FC        2-1
+    15:00  Igbajo FC                v Crown FC                 0-1
+    15:00  Sporting Lagos FC        v Abakaliki FC             0-0
+    15:00  Zamfara United FC        v Barau FC                 1-1
+
+
+
+» Matchday 7
+  24.01.
+    15:00  Dakkada FC               v Igbajo FC                3-1
+    15:00  Madiba FC                v Sporting Lagos FC        0-2
+  25.01.
+    15:00  Abakaliki FC             v Solution FC              0-0
+    15:00  ABS FC                   v Rovers FC                2-3
+    15:00  Crown FC                 v Abia Comets FC           0-0
+    15:00  Godswill Akpabio FC      v Osun FC                  1-0
+    15:00  Kada Warriors FC         v Basira FC                1-1
+    15:00  Kun Khalifa FC           v First Bank FC            1-0
+    15:00  Mighty Jets FC           v Zamfara United FC        1-0
+    15:00  Sporting Supreme FC      v Doma United FC           1-2
+    15:00  Yobe Desert Stars FC     v Kebbi FC                 3-1
+  26.01.
+    15:00  Ijele FC                 v Edel FC                  1-0
+    15:00  Inter Lagos FC           v Smart City FC            3-1
+    15:00  Jigawa Golden Stars FC   v Gombe United FC          1-0
+    15:00  Warri Wolves FC          v 1472 FC                  1-0
+  27.01.
+    15:00  Wikki Tourists FC        v Sokoto FC                2-0
+
+
+
+» Matchday 8
+  01.02.
+    15:00  Abia Comets FC           v Dakkada FC               2-2
+    15:00  Gateway Utd.             v Kun Khalifa FC           1-3
+    15:00  Rovers FC                v Godswill Akpabio FC      1-0
+    15:00  Solution FC              v Madiba FC                4-1
+  02.02.
+    13:00  First Bank FC            v Abakaliki FC             1-0
+    15:00  Beyond Limits FC         v Warri Wolves FC          0-0
+    15:00  Edel FC                  v Inter Lagos FC           1-2
+    15:00  Sporting Lagos FC        v ABS FC                   1-0
+  05.04.
+    15:00  Sokoto FC                v Wikki Tourists FC        0-0
+  06.04.
+    08:00  Kebbi FC                 v Yobe Desert Stars FC     2-0
+    15:00  Doma United FC           v Sporting Supreme FC      2-0
+    15:00  Gombe United FC          v Jigawa Golden Stars FC   3-0
+    15:00  Zamfara United FC        v Mighty Jets FC           3-1
+  07.04.
+    15:00  Basira FC                v Kada Warriors FC         3-1
+  31.01.
+    13:00  1472 FC                  v Ijele FC                 2-3
+    16:00  Smart City FC            v Crown FC                 0-1
+
+
+
+» Matchday 9
+  07.02.
+    15:00  Godswill Akpabio FC      v Sporting Lagos FC        1-1
+    15:00  Madiba FC                v First Bank FC            2-0
+  08.02.
+    15:00  Abakaliki FC             v Gateway Utd.             1-0
+    15:00  Crown FC                 v Edel FC                  1-0
+    15:00  Dakkada FC               v Smart City FC            1-1
+    15:00  Ijele FC                 v Beyond Limits FC         2-0
+    15:00  Inter Lagos FC           v 1472 FC                  4-1
+    15:00  Osun FC                  v Rovers FC                2-1
+  09.02.
+    15:00  ABS FC                   v Solution FC              1-0
+    15:00  Igbajo FC                v Abia Comets FC           1-0
+  12.04.
+    15:00  Adamawa United FC        v Basira FC                1-0
+    15:00  Barau FC                 v Zamfara United FC        3-0
+    15:00  Kada Warriors FC         v Kebbi FC                 2-0
+    15:00  Mighty Jets FC           v Sokoto FC                1-0
+    15:00  Wikki Tourists FC        v Gombe United FC          2-0
+    15:00  Yobe Desert Stars FC     v Doma United FC           3-1
+
+
+
+» Matchday 10
+  14.02.
+    15:00  First Bank FC            v ABS FC                   2-0
+  15.02.
+    13:00  1472 FC                  v Crown FC                 1-1
+    15:00  Gateway Utd.             v Madiba FC                1-2
+    15:00  Solution FC              v Godswill Akpabio FC      1-0
+    16:00  Smart City FC            v Igbajo FC                1-0
+  16.02.
+    15:00  Edel FC                  v Dakkada FC               1-1
+    15:00  Kun Khalifa FC           v Abakaliki FC             1-0
+    15:00  Warri Wolves FC          v Ijele FC                 2-0
+    16:00  Sporting Lagos FC        v Osun FC                  1-2
+    17:00  Beyond Limits FC         v Inter Lagos FC           1-0
+  18.04.
+    15:00  Sporting Supreme FC      v Yobe Desert Stars FC     1-0
+  19.04.
+    15:00  Doma United FC           v Kada Warriors FC         1-0
+    15:00  Jigawa Golden Stars FC   v Wikki Tourists FC        3-1
+    15:00  Kebbi FC                 v Adamawa United FC        4-1
+    15:00  Sokoto FC                v Barau FC                 1-0
+  20.04.
+    15:00  Gombe United FC          v Mighty Jets FC           2-0
+
+
+
+» Matchday 11
+  01.03.
+    15:00  Abia Comets FC           v Smart City FC            0-0
+    15:00  ABS FC                   v Gateway Utd.             1-0
+    15:00  Crown FC                 v Beyond Limits FC         2-1
+    15:00  Godswill Akpabio FC      v First Bank FC            2-0
+    15:00  Osun FC                  v Solution FC              1-0
+    15:00  Rovers FC                v Sporting Lagos FC        1-0
+  02.03.
+    15:00  Igbajo FC                v Edel FC                  0-0
+  04.03.
+    13:00  Madiba FC                v Kun Khalifa FC           0-1
+    16:00  Inter Lagos FC           v Warri Wolves FC          1-1
+  26.04.
+    15:00  Adamawa United FC        v Doma United FC           3-1
+    15:00  Barau FC                 v Gombe United FC          2-0
+    15:00  Basira FC                v Kebbi FC                 2-1
+    15:00  Kada Warriors FC         v Sporting Supreme FC      3-0
+    15:00  Mighty Jets FC           v Jigawa Golden Stars FC   1-2
+  27.04.
+    15:00  Zamfara United FC        v Sokoto FC                1-0
+  28.02.
+    15:00  Dakkada FC               v 1472 FC                  3-0
+
+
+
+» Matchday 12
+  02.05.
+    15:00  Sporting Supreme FC      v Adamawa United FC        1-0
+  03.05.
+    15:00  Doma United FC           v Basira FC                3-0
+    15:00  Jigawa Golden Stars FC   v Barau FC                 1-2
+    15:00  Yobe Desert Stars FC     v Kada Warriors FC         3-0
+  04.04.
+    15:00  First Bank FC            v Godswill Akpabio FC      2-1
+  04.05.
+    15:00  Gombe United FC          v Zamfara United FC        2-0
+  05.04.
+    13:00  1472 FC                  v Dakkada FC               0-0
+    15:00  Edel FC                  v Igbajo FC                2-1
+    15:00  Gateway Utd.             v ABS FC                   0-0
+    16:00  Smart City FC            v Abia Comets FC           2-0
+  06.04.
+    15:00  Solution FC              v Osun FC                  1-1
+    15:00  Sporting Lagos FC        v Rovers FC                1-0
+    15:00  Warri Wolves FC          v Inter Lagos FC           1-0
+    16:00  Beyond Limits FC         v Crown FC                 3-1
+  07.05.
+    15:00  Wikki Tourists FC        v Mighty Jets FC           3-1
+  08.04.
+    15:00  Kun Khalifa FC           v Madiba FC                3-1
+
+
+
+» Matchday 13
+  10.05.
+    15:00  Adamawa United FC        v Yobe Desert Stars FC     3-0
+    15:00  Basira FC                v Sporting Supreme FC      2-3
+    15:00  Kebbi FC                 v Doma United FC           1-0
+    15:00  Sokoto FC                v Gombe United FC          1-0
+  11.04.
+    15:00  Godswill Akpabio FC      v Solution FC              4-1
+  11.05.
+    15:00  Barau FC                 v Wikki Tourists FC        2-1
+    15:00  Zamfara United FC        v Jigawa Golden Stars FC   2-1
+  12.04.
+    14:00  Inter Lagos FC           v Beyond Limits FC         3-0
+    15:00  Abakaliki FC             v Kun Khalifa FC           0-0
+    15:00  ABS FC                   v First Bank FC            0-1
+    15:00  Crown FC                 v 1472 FC                  4-0
+    15:00  Dakkada FC               v Edel FC                  2-1
+    15:00  Igbajo FC                v Smart City FC            1-1
+    15:00  Ijele FC                 v Warri Wolves FC          0-1
+  13.04.
+    15:00  Osun FC                  v Sporting Lagos FC        0-0
+  14.04.
+    15:00  Madiba FC                v Gateway Utd.             2-0
+
+
+
+» Matchday 14
+  17.05.
+    15:00  Kada Warriors FC         v Adamawa United FC        2-1
+    15:00  Sporting Supreme FC      v Kebbi FC                 1-2
+    15:00  Yobe Desert Stars FC     v Basira FC                1-0
+  18.04.
+    15:00  First Bank FC            v Madiba FC                2-2
+  18.05.
+    15:00  Jigawa Golden Stars FC   v Sokoto FC                1-0
+    15:00  Mighty Jets FC           v Barau FC                 0-0
+    15:00  Wikki Tourists FC        v Zamfara United FC        4-1
+  19.04.
+    15:00  Edel FC                  v Crown FC                 2-0
+    15:00  Gateway Utd.             v Abakaliki FC             2-1
+    15:00  Rovers FC                v Osun FC                  1-0
+    15:00  Smart City FC            v Dakkada FC               3-2
+  20.04.
+    15:00  Abia Comets FC           v Igbajo FC                2-0
+    15:00  Beyond Limits FC         v Ijele FC                 6-1
+    15:00  Solution FC              v ABS FC                   3-0
+    16:00  Sporting Lagos FC        v Godswill Akpabio FC      1-0
+  22.04.
+    13:00  1472 FC                  v Inter Lagos FC           1-4
+
+
+
+» Matchday 15
+  25.04.
+    15:00  Dakkada FC               v Abia Comets FC           1-1
+    15:00  Madiba FC                v Solution FC              1-0
+  26.04.
+    15:00  Abakaliki FC             v First Bank FC            1-0
+    15:00  ABS FC                   v Sporting Lagos FC        1-0
+    15:00  Crown FC                 v Smart City FC            2-0
+    15:00  Godswill Akpabio FC      v Rovers FC                2-2
+    15:00  Inter Lagos FC           v Edel FC                  1-1
+    15:00  Kun Khalifa FC           v Gateway Utd.             2-2
+    15:00  Ijele FC                 v 1472 FC                  3-0
+  27.04.
+    15:00  Warri Wolves FC          v Beyond Limits FC         4-1
+
+
+
+» Matchday 16
+  02.05.
+    15:00  First Bank FC            v Kun Khalifa FC           1-1
+  03.05.
+    15:00  Edel FC                  v Ijele FC                 2-1
+    15:00  Igbajo FC                v Dakkada FC               1-0
+    15:00  Rovers FC                v ABS FC                   2-0
+    16:00  Smart City FC            v Inter Lagos FC           0-0
+  04.05.
+    15:00  Abia Comets FC           v Crown FC                 2-0
+    15:00  Osun FC                  v Godswill Akpabio FC      2-0
+    15:00  Sporting Lagos FC        v Madiba FC                2-1
+  07.05.
+    15:00  Solution FC              v Abakaliki FC             1-0
+
+
+
+» Matchday 17
+  10.05.
+    15:00  Abakaliki FC             v Sporting Lagos FC        2-3
+    15:00  ABS FC                   v Osun FC                  1-0
+    15:00  Crown FC                 v Igbajo FC                1-0
+    15:00  Gateway Utd.             v First Bank FC            3-2
+    15:00  Ijele FC                 v Smart City FC            0-2
+    15:00  Kun Khalifa FC           v Solution FC              1-0
+  11.05.
+    15:00  Warri Wolves FC          v Edel FC                  3-2
+  12.05.
+    15:00  Inter Lagos FC           v Abia Comets FC           1-0
+    15:00  Madiba FC                v Rovers FC                3-2
+
+
+
+» Matchday 18
+  17.05.
+    15:00  Abia Comets FC           v Ijele FC                 4-1
+    15:00  Edel FC                  v Beyond Limits FC         1-0
+    15:00  Igbajo FC                v Inter Lagos FC           1-2
+    15:00  Rovers FC                v Abakaliki FC             2-0
+    15:00  Smart City FC            v Warri Wolves FC          1-1
+    16:00  Dakkada FC               v Crown FC                 1-1
+  18.05.
+    15:00  Godswill Akpabio FC      v ABS FC                   1-1
+    15:00  Osun FC                  v Madiba FC                1-0
+    15:00  Solution FC              v Gateway Utd.             2-2
+    15:00  Sporting Lagos FC        v Kun Khalifa FC           0-0
+
+
+
+» Matchday 19
+  21.05.
+    16:00  Beyond Limits FC         v Smart City FC            2-2
+  23.05.
+    13:00  First Bank FC            v Solution FC              1-0
+    16:00  Madiba FC                v Godswill Akpabio FC      2-1
+  24.05.
+    15:00  Gateway Utd.             v Sporting Lagos FC        2-1
+    15:00  Ijele FC                 v Igbajo FC                2-0
+    15:00  Kun Khalifa FC           v Rovers FC                0-0
+    16:00  Inter Lagos FC           v Dakkada FC               3-0
+  25.05.
+    15:00  Warri Wolves FC          v Abia Comets FC           1-0
+  28.05.
+    15:00  Abakaliki FC             v Osun FC                  2-0
+
+
+
+» Matchday 20
+  01.06.
+    15:00  Godswill Akpabio FC      v Abakaliki FC             1-0
+    15:00  Sporting Lagos FC        v First Bank FC            4-0
+  02.06.
+    15:00  Dakkada FC               v Ijele FC                 1-1
+    15:00  Osun FC                  v Kun Khalifa FC           1-0
+  31.05.
+    15:00  Abia Comets FC           v Beyond Limits FC         1-1
+    15:00  ABS FC                   v Madiba FC                3-1
+    15:00  Crown FC                 v Inter Lagos FC           1-0
+    15:00  Igbajo FC                v Warri Wolves FC          1-3
+    15:00  Rovers FC                v Gateway Utd.             2-1
+
+
+
+» Matchday 21
+  07.06.
+    15:00  Abakaliki FC             v ABS FC                   1-0
+    15:00  Edel FC                  v Smart City FC            2-0
+    15:00  First Bank FC            v Rovers FC                2-0
+    15:00  Gateway Utd.             v Osun FC                  2-1
+    15:00  Ijele FC                 v Crown FC                 1-2
+    15:00  Kun Khalifa FC           v Godswill Akpabio FC      1-1
+  08.06.
+    15:00  Beyond Limits FC         v Igbajo FC                7-0
+    15:00  Solution FC              v Sporting Lagos FC        3-3
+    15:00  Warri Wolves FC          v Dakkada FC               4-2
+
+
+
+» Matchday 22
+  14.06.
+    15:00  ABS FC                   v Kun Khalifa FC           1-0
+    15:00  Godswill Akpabio FC      v Gateway Utd.             3-0
+    15:00  Madiba FC                v Abakaliki FC             1-4
+    15:00  Osun FC                  v First Bank FC            3-1
+    15:00  Rovers FC                v Solution FC              1-3
+  15.06.
+    15:00  Abia Comets FC           v Edel FC                  0-1
+    15:00  Crown FC                 v Warri Wolves FC          1-0
+    15:00  Dakkada FC               v Beyond Limits FC         2-2
+    15:00  Inter Lagos FC           v Ijele FC                 4-0
+
+
+======================================================================
+  NNL - PROMOTION GROUP
+======================================================================
+
+
+
+» Matchday 1
+  05.07.
+    09:00  Barau FC                 v Yobe Desert Stars FC     0-0
+    11:30  Wikki Tourists FC        v Doma United FC           0-0
+    14:00  Crown FC                 v Kun Khalifa FC           0-1
+    16:00  Osun FC                  v Warri Wolves FC          1-0
+
+
+
+» Matchday 2
+  07.07.
+    09:00  Yobe Desert Stars FC     v Doma United FC           2-1
+    11:30  Barau FC                 v Wikki Tourists FC        0-0
+    14:00  Kun Khalifa FC           v Warri Wolves FC          0-3
+    16:00  Crown FC                 v Osun FC                  1-1
+
+
+
+» Matchday 3
+  10.07.
+    10:00  Doma United FC           v Barau FC                 0-2
+    10:00  Wikki Tourists FC        v Yobe Desert Stars FC     4-0
+    13:00  Osun FC                  v Kun Khalifa FC           1-2
+    13:00  Warri Wolves FC          v Crown FC                 2-1
+
+
+======================================================================
+  NNL - PLAY OFFS
+======================================================================
+
+» Final
+  12.07.
+    15:00  Wikki Tourists FC        v Warri Wolves FC          2-3
+


### PR DESCRIPTION
## Summary

Adds Nigeria National League (NNL) seasons from 2022 to 2025 to the Open Football dataset.

## Details

- **Country:** Nigeria  
- **Competition:** Nigeria National League  
- **Seasons:** 2022 – 2025  
- **Tier:** 2 (`ng2`)  
- **Matches:** Full league seasons  
- **Source:** Soccerway  

## Notes

- Team names follow the established NNL canonical naming used in prior seasons.
- The 2025/26 season is ongoing and will be added once all matches are completed and final standings are confirmed.
- This PR continues the incremental expansion of NNL coverage in line with Open Football contribution practices.
