### PR TITLE
Add Ghana Premier League seasons 2016-2025

### DIFF
--- a/africa/ghana/2016-17_gh1.txt
+++ b/africa/ghana/2016-17_gh1.txt
@@ -1,0 +1,372 @@
+= Ghana | Premier League 2016/17
+
+# Date       Sun Feb/12 2017 - Sun Oct/22 2017 (252d)
+# Teams      16
+# Matches    240
+# Source     https://www.rsssf.org/tablesg/gha2017.html
+# Retrieved  2026-08-17
+
+
+» Matchday 1
+  Sun Feb/12 2017
+           Ebusua Dwarfs                  v Bolga All Stars FC             3-1
+           Medeama SC                     v West Africa Football Academy   1-0
+           Tema Youth FC                  v Berekum Chelsea FC             2-1
+           Aduana Stars                   v Obuasi Ashanti Gold SC         1-0
+           Asante Kotoko FC               v Liberty Professionals FC       2-1
+  Mon Feb/13 2017
+           International Allies FC        v Accra Hearts of Oak SC         0-0
+  Wed Mar/1 2017
+           Wa All Stars FC                v Elmina Sharks FC               1-1
+  Thu Mar/2 2017
+           Great Olympics FC              v Bechem United FC               1-3
+
+» Matchday 2
+  Sat Feb/18 2017
+           Obuasi Ashanti Gold SC         v Great Olympics FC              3-1
+  Sun Feb/19 2017
+           Berekum Chelsea FC             v Asante Kotoko FC               0-0
+           Elmina Sharks FC               v Aduana Stars                   0-1
+           West Africa Football Academy   v Ebusua Dwarfs                  2-0
+           Liberty Professionals FC       v International Allies FC        2-0
+           Accra Hearts of Oak SC         v Medeama SC                     0-0
+  Wed Mar/8 2017
+           Bolga All Stars FC             v Wa All Stars FC                1-3
+           Bechem United FC               v Tema Youth FC                  1-0
+
+» Matchday 3
+  Wed Feb/22 2017
+           Medeama SC                     v International Allies FC        1-1
+           Aduana Stars                   v Bolga All Stars FC             4-0
+           Berekum Chelsea FC             v Liberty Professionals FC       2-0
+           Great Olympics FC              v Elmina Sharks FC               2-2
+           Asante Kotoko FC               v Bechem United FC               1-0
+           Ebusua Dwarfs                  v Accra Hearts of Oak SC         1-1
+           Tema Youth FC                  v Obuasi Ashanti Gold SC         1-1
+  Sun Mar/26 2017
+           Wa All Stars FC                v West Africa Football Academy   1-4
+
+» Matchday 4
+  Sat Feb/25 2017
+           West Africa Football Academy   v Aduana Stars                   1-1
+  Sun Feb/26 2017
+           Bechem United FC               v Berekum Chelsea FC             1-1
+           Bolga All Stars FC             v Great Olympics FC              0-3 (awarded)
+           Accra Hearts of Oak SC         v Wa All Stars FC                2-1
+           Elmina Sharks FC               v Tema Youth FC                  1-0
+           International Allies FC        v Ebusua Dwarfs                  2-1
+           Liberty Professionals FC       v Medeama SC                     3-2
+  Mon Feb/27 2017
+           Obuasi Ashanti Gold SC         v Asante Kotoko FC               0-1
+
+» Matchday 5
+  Sun Mar/5 2017
+           Bechem United FC               v Liberty Professionals FC       1-0
+           Berekum Chelsea FC             v Obuasi Ashanti Gold SC         5-1
+           Asante Kotoko FC               v Elmina Sharks FC               1-0
+           Aduana Stars                   v Accra Hearts of Oak SC         2-0
+           Great Olympics FC              v West Africa Football Academy   0-0
+           Wa All Stars FC                v International Allies FC        1-0
+           Tema Youth FC                  v Bolga All Stars FC             2-0
+  Mon Mar/6 2017
+           Ebusua Dwarfs                  v Medeama SC                     1-0
+
+» Matchday 6
+  Sat Mar/11 2017
+           International Allies FC        v Aduana Stars                   1-2
+  Sun Mar/12 2017
+           Medeama SC                     v Wa All Stars FC                0-1
+           Bolga All Stars FC             v Asante Kotoko FC               1-1
+           Obuasi Ashanti Gold SC         v Bechem United FC               2-4
+           Accra Hearts of Oak SC         v Great Olympics FC              2-1
+           Liberty Professionals FC       v Ebusua Dwarfs                  2-1
+           Elmina Sharks FC               v Berekum Chelsea FC             2-1
+           West Africa Football Academy   v Tema Youth FC                  2-1
+
+» Matchday 7
+  Wed Mar/15 2017
+           Tema Youth FC                  v Accra Hearts of Oak SC         2-1
+           Great Olympics FC              v International Allies FC        1-1
+           Berekum Chelsea FC             v Bolga All Stars FC             1-0
+           Bechem United FC               v Elmina Sharks FC               0-0
+           Obuasi Ashanti Gold SC         v Liberty Professionals FC       1-0
+           Asante Kotoko FC               v West Africa Football Academy   1-0
+           Aduana Stars                   v Medeama SC                     0-0
+           Wa All Stars FC                v Ebusua Dwarfs                  1-1
+
+» Matchday 8
+  Sat Mar/18 2017
+           Ebusua Dwarfs                  v Aduana Stars                   2-1
+           Liberty Professionals FC       v Wa All Stars FC                0-0
+           Medeama SC                     v Great Olympics FC              1-1
+           Elmina Sharks FC               v Obuasi Ashanti Gold SC         1-0
+           Bolga All Stars FC             v Bechem United FC               2-1
+           West Africa Football Academy   v Berekum Chelsea FC             2-0
+  Sun Mar/19 2017
+           Accra Hearts of Oak SC         v Asante Kotoko FC               1-0
+  Mon Mar/20 2017
+           International Allies FC        v Tema Youth FC                  1-0
+
+» Matchday 9
+  Sat Apr/1 2017
+           Elmina Sharks FC               v Liberty Professionals FC       1-1
+  Sun Apr/2 2017
+           Asante Kotoko FC               v International Allies FC        0-0
+           Obuasi Ashanti Gold SC         v Bolga All Stars FC             1-1
+           Bechem United FC               v West Africa Football Academy   0-1
+           Berekum Chelsea FC             v Accra Hearts of Oak SC         1-0
+           Great Olympics FC              v Ebusua Dwarfs                  1-0
+           Tema Youth FC                  v Medeama SC                     1-1
+  Thu Apr/13 2017
+           Aduana Stars                   v Wa All Stars FC                0-0
+
+» Matchday 10
+  Wed Apr/5 2017
+           Bolga All Stars FC             v Elmina Sharks FC               1-0
+           Ebusua Dwarfs                  v Tema Youth FC                  1-1
+           Accra Hearts of Oak SC         v Bechem United FC               4-2
+           International Allies FC        v Berekum Chelsea FC             1-1
+           Liberty Professionals FC       v Aduana Stars                   1-1
+           Medeama SC                     v Asante Kotoko FC               2-1
+           West Africa Football Academy   v Obuasi Ashanti Gold SC         3-0
+  Sun Apr/30 2017
+           Wa All Stars FC                v Great Olympics FC              1-0
+
+» Matchday 11
+  Sat Apr/8 2017
+           Obuasi Ashanti Gold SC         v Accra Hearts of Oak SC         0-1
+  Sun Apr/9 2017
+           Bolga All Stars FC             v Liberty Professionals FC       1-1
+           Bechem United FC               v International Allies FC        1-0
+           Berekum Chelsea FC             v Medeama SC                     2-0
+           Elmina Sharks FC               v West Africa Football Academy   1-2
+           Asante Kotoko FC               v Ebusua Dwarfs                  0-0
+  Mon Apr/10 2017
+           Tema Youth FC                  v Wa All Stars FC                1-1
+           Great Olympics FC              v Aduana Stars                   1-2
+
+» Matchday 12
+  Sat Apr/15 2017
+           Medeama SC                     v Bechem United FC               2-0
+  Sun Apr/16 2017
+           Aduana Stars                   v Tema Youth FC                  3-0
+           Accra Hearts of Oak SC         v Elmina Sharks FC               1-1
+           West Africa Football Academy   v Bolga All Stars FC             2-0
+           Wa All Stars FC                v Asante Kotoko FC               1-0
+           Ebusua Dwarfs                  v Berekum Chelsea FC             1-0
+           International Allies FC        v Obuasi Ashanti Gold SC         1-0
+           Liberty Professionals FC       v Great Olympics FC              0-0
+
+» Matchday 13
+  Wed Apr/26 2017
+           Elmina Sharks FC               v International Allies FC        0-0
+           Bechem United FC               v Ebusua Dwarfs                  0-0
+           West Africa Football Academy   v Liberty Professionals FC       2-1
+           Obuasi Ashanti Gold SC         v Medeama SC                     1-1
+           Asante Kotoko FC               v Aduana Stars                   1-1
+           Tema Youth FC                  v Great Olympics FC              2-1
+           Berekum Chelsea FC             v Wa All Stars FC                1-0
+           Bolga All Stars FC             v Accra Hearts of Oak SC         3-3
+
+» Matchday 14
+  Sat May/6 2017
+           Great Olympics FC              v Asante Kotoko FC               2-0
+  Sun May/7 2017
+           Ebusua Dwarfs                  v Obuasi Ashanti Gold SC         4-1
+           Aduana Stars                   v Berekum Chelsea FC             1-0
+           Liberty Professionals FC       v Tema Youth FC                  2-1
+           International Allies FC        v Bolga All Stars FC             3-0
+           Wa All Stars FC                v Bechem United FC               0-1
+  Mon May/8 2017
+           Medeama SC                     v Elmina Sharks FC               3-1
+           Accra Hearts of Oak SC         v West Africa Football Academy   2-1
+
+» Matchday 15
+  Sat May/13 2017
+           West Africa Football Academy   v International Allies FC        2-0
+  Sun May/14 2017
+           Liberty Professionals FC       v Accra Hearts of Oak SC         0-3
+           Berekum Chelsea FC             v Great Olympics FC              0-0
+           Asante Kotoko FC               v Tema Youth FC                  0-0
+           Obuasi Ashanti Gold SC         v Wa All Stars FC                1-0
+           Bechem United FC               v Aduana Stars                   1-1
+           Bolga All Stars FC             v Medeama SC                     1-2
+           Elmina Sharks FC               v Ebusua Dwarfs                  1-0
+
+» Matchday 16
+  Sat May/27 2017
+           Great Olympics FC              v Berekum Chelsea FC             1-0
+           Ebusua Dwarfs                  v Elmina Sharks FC               3-1
+  Sun May/28 2017
+           Tema Youth FC                  v Asante Kotoko FC               0-1
+           International Allies FC        v West Africa Football Academy   1-0
+           Accra Hearts of Oak SC         v Liberty Professionals FC       1-1
+           Medeama SC                     v Bolga All Stars FC             5-1
+           Aduana Stars                   v Bechem United FC               3-0
+           Wa All Stars FC                v Obuasi Ashanti Gold SC         1-1
+
+» Matchday 17
+  Sat Jun/3 2017
+           Berekum Chelsea FC             v Aduana Stars                   3-2
+  Sun Jun/4 2017
+           Obuasi Ashanti Gold SC         v Ebusua Dwarfs                  3-0
+           Asante Kotoko FC               v Great Olympics FC              1-1
+           Bechem United FC               v Wa All Stars FC                2-0
+           Elmina Sharks FC               v Medeama SC                     2-0
+           Bolga All Stars FC             v International Allies FC        1-1
+           West Africa Football Academy   v Accra Hearts of Oak SC         5-0
+           Tema Youth FC                  v Liberty Professionals FC       0-0
+
+» Matchday 18
+  Fri Jun/9 2017
+           Wa All Stars FC                v Berekum Chelsea FC             3-0
+           International Allies FC        v Elmina Sharks FC               2-0
+           Medeama SC                     v Obuasi Ashanti Gold SC         0-1
+           Liberty Professionals FC       v West Africa Football Academy   0-0
+           Accra Hearts of Oak SC         v Bolga All Stars FC             4-0
+           Ebusua Dwarfs                  v Bechem United FC               1-0
+  Sat Jun/10 2017
+           Great Olympics FC              v Tema Youth FC                  0-4
+  Mon Jun/12 2017
+           Aduana Stars                   v Asante Kotoko FC               0-0
+
+» Matchday 19
+  Sat Jun/24 2017
+           Asante Kotoko FC               v Wa All Stars FC                2-1
+  Sun Jun/25 2017
+           Elmina Sharks FC               v Accra Hearts of Oak SC         0-2
+           Great Olympics FC              v Liberty Professionals FC       0-1
+           Bechem United FC               v Medeama SC                     1-1
+           Obuasi Ashanti Gold SC         v International Allies FC        3-0
+           Bolga All Stars FC             v West Africa Football Academy   0-0
+           Tema Youth FC                  v Aduana Stars                   1-0
+           Berekum Chelsea FC             v Ebusua Dwarfs                  1-1
+
+» Matchday 20
+  Wed Jun/28 2017
+           Ebusua Dwarfs                  v Asante Kotoko FC               0-1
+           Aduana Stars                   v Great Olympics FC              1-0
+           Wa All Stars FC                v Tema Youth FC                  1-1
+           Accra Hearts of Oak SC         v Obuasi Ashanti Gold SC         0-1
+           International Allies FC        v Bechem United FC               1-0
+           Liberty Professionals FC       v Bolga All Stars FC             3-0
+           West Africa Football Academy   v Elmina Sharks FC               1-0
+  Thu Jun/29 2017
+           Medeama SC                     v Berekum Chelsea FC             3-1
+
+» Matchday 21
+  Sat Jul/8 2017
+           Tema Youth FC                  v Ebusua Dwarfs                  1-2
+  Sun Jul/9 2017
+           Asante Kotoko FC               v Medeama SC                     3-1
+           Aduana Stars                   v Liberty Professionals FC       2-1
+           Berekum Chelsea FC             v International Allies FC        1-1
+           Bechem United FC               v Accra Hearts of Oak SC         1-0
+           Elmina Sharks FC               v Bolga All Stars FC             3-1
+           Great Olympics FC              v Wa All Stars FC                2-0
+  Sun Jul/30 2017
+           Obuasi Ashanti Gold SC         v West Africa Football Academy   2-0
+
+» Matchday 22
+  Wed Jul/12 2017
+           Wa All Stars FC                v Aduana Stars                   3-1
+           Ebusua Dwarfs                  v Great Olympics FC              0-0
+           Medeama SC                     v Tema Youth FC                  1-0
+           International Allies FC        v Asante Kotoko FC               1-0
+           Accra Hearts of Oak SC         v Berekum Chelsea FC             2-0
+           West Africa Football Academy   v Bechem United FC               2-0
+           Bolga All Stars FC             v Obuasi Ashanti Gold SC         0-2
+           Liberty Professionals FC       v Elmina Sharks FC               0-1
+
+» Matchday 23
+  Sat Jul/15 2017
+           Bechem United FC               v Bolga All Stars FC             4-0
+  Sun Jul/16 2017
+           Wa All Stars FC                v Liberty Professionals FC       2-1
+           Berekum Chelsea FC             v West Africa Football Academy   2-1
+           Obuasi Ashanti Gold SC         v Elmina Sharks FC               1-2
+           Aduana Stars                   v Ebusua Dwarfs                  2-0
+           Great Olympics FC              v Medeama SC                     0-3
+           Tema Youth FC                  v International Allies FC        3-1
+  Sun Aug/6 2017
+           Asante Kotoko FC               v Accra Hearts of Oak SC         1-1
+
+» Matchday 24
+  Sat Jul/22 2017
+           Medeama SC                     v Aduana Stars                   0-0
+  Sun Jul/23 2017
+           International Allies FC        v Great Olympics FC              0-1
+           Ebusua Dwarfs                  v Wa All Stars FC                2-2
+           Bolga All Stars FC             v Berekum Chelsea FC             0-4
+           Elmina Sharks FC               v Bechem United FC               2-1
+           Liberty Professionals FC       v Obuasi Ashanti Gold SC         1-0
+           Accra Hearts of Oak SC         v Tema Youth FC                  3-1
+  Wed Aug/23 2017
+           West Africa Football Academy   v Asante Kotoko FC               2-0
+
+» Matchday 25
+  Sun Aug/27 2017
+           Aduana Stars                   v International Allies FC        1-0
+           Asante Kotoko FC               v Bolga All Stars FC             2-1
+           Bechem United FC               v Obuasi Ashanti Gold SC         1-0
+           Berekum Chelsea FC             v Elmina Sharks FC               1-0
+           Ebusua Dwarfs                  v Liberty Professionals FC       3-1
+           Great Olympics FC              v Accra Hearts of Oak SC         1-2
+           Tema Youth FC                  v West Africa Football Academy   1-0
+           Wa All Stars FC                v Medeama SC                     3-0
+
+» Matchday 26
+  Wed Aug/30 2017
+           Obuasi Ashanti Gold SC         v Berekum Chelsea FC             5-2
+           Bolga All Stars FC             v Tema Youth FC                  0-2
+           Elmina Sharks FC               v Asante Kotoko FC               1-0
+           Accra Hearts of Oak SC         v Aduana Stars                   3-3
+           International Allies FC        v Wa All Stars FC                0-0
+           Liberty Professionals FC       v Bechem United FC               2-1
+           Medeama SC                     v Ebusua Dwarfs                  2-1
+           West Africa Football Academy   v Great Olympics FC              0-0
+
+» Matchday 27
+  Wed Oct/4 2017
+           Aduana Stars                   v West Africa Football Academy   1-0
+           Berekum Chelsea FC             v Bechem United FC               2-0
+           Ebusua Dwarfs                  v International Allies FC        3-1
+           Great Olympics FC              v Bolga All Stars FC             4-2
+           Tema Youth FC                  v Elmina Sharks FC               0-2
+           Wa All Stars FC                v Accra Hearts of Oak SC         2-1
+  Thu Oct/5 2017
+           Asante Kotoko FC               v Obuasi Ashanti Gold SC         1-1
+           Medeama SC                     v Liberty Professionals FC       1-2
+
+» Matchday 28
+  Sun Oct/8 2017
+           Obuasi Ashanti Gold SC         v Tema Youth FC                  2-0
+           Bechem United FC               v Asante Kotoko FC               1-0
+           Bolga All Stars FC             v Aduana Stars                   1-4
+           Elmina Sharks FC               v Great Olympics FC              0-1
+           Accra Hearts of Oak SC         v Ebusua Dwarfs                  2-1
+           International Allies FC        v Medeama SC                     2-0
+           Liberty Professionals FC       v Berekum Chelsea FC             4-2
+           West Africa Football Academy   v Wa All Stars FC                3-0
+
+» Matchday 29
+  Sun Oct/15 2017
+           Aduana Stars                   v Elmina Sharks FC               2-1
+           Asante Kotoko FC               v Berekum Chelsea FC             1-0
+           Ebusua Dwarfs                  v West Africa Football Academy   2-1
+           Great Olympics FC              v Obuasi Ashanti Gold SC         1-0
+           International Allies FC        v Liberty Professionals FC       2-1
+           Medeama SC                     v Accra Hearts of Oak SC         1-0
+           Tema Youth FC                  v Bechem United FC               2-1
+           Wa All Stars FC                v Bolga All Stars FC             6-1
+
+» Matchday 30
+  Sun Oct/22 2017
+           Obuasi Ashanti Gold SC         v Aduana Stars                   4-2
+           Bechem United FC               v Great Olympics FC              1-0
+           Berekum Chelsea FC             v Tema Youth FC                  2-0
+           Bolga All Stars FC             v Ebusua Dwarfs                  1-4
+           Elmina Sharks FC               v Wa All Stars FC                2-0
+           Accra Hearts of Oak SC         v International Allies FC        0-0
+           Liberty Professionals FC       v Asante Kotoko FC               2-1
+           West Africa Football Academy   v Medeama SC                     1-1

--- a/africa/ghana/2023-24_gh1.txt
+++ b/africa/ghana/2023-24_gh1.txt
@@ -1,0 +1,504 @@
+= Ghana | Premier League 2023/24
+
+# Date       Fri Sep/15 2023 - Sun Jun/16 2024 (275d)
+# Teams      18
+# Matches    306
+# Source     https://www.rsssf.org/tablesg/gha2024.html
+# Retrieved  2026-08-17
+
+
+» Matchday 1
+  Fri Sep/15 2023
+           Real Tamale United       v Accra Hearts of Oak SC   1-0
+  Sat Sep/16 2023
+           Great Olympics FC        v Bofoakwa Tano FC         0-0
+  Sun Sep/17 2023
+           Legon Cities FC          v Karela United FC         2-1
+           Nsoatreman FC            v Bechem United FC         2-0
+           FC Samartex 1996         v Aduana FC                1-0
+           Berekum Chelsea FC       v Bibiani Gold Stars FC    2-0
+           Asante Kotoko FC         v Heart of Lions FC        0-0
+  Wed Sep/20 2023
+           Medeama SC               v Accra Lions FC           2-2
+           Dreams FC                v Nations FC               1-0
+
+» Matchday 2
+  Fri Sep/22 2023
+           Bofoakwa Tano FC         v Real Tamale United       2-1
+  Sat Sep/23 2023
+           Bibiani Gold Stars FC    v Asante Kotoko FC         2-1
+  Sun Sep/24 2023
+           Accra Hearts of Oak SC   v Nsoatreman FC            1-0
+           Bechem United FC         v Dreams FC                1-0
+           Heart of Lions FC        v Great Olympics FC        0-0
+           Aduana FC                v Medeama SC               2-0
+           Karela United FC         v Berekum Chelsea FC       3-1
+           Nations FC               v FC Samartex 1996         2-0
+  Mon Sep/25 2023
+           Accra Lions FC           v Legon Cities FC          1-0
+
+» Matchday 3
+  Fri Sep/29 2023
+           Berekum Chelsea FC       v Accra Lions FC           1-1
+  Sat Sep/30 2023
+           Bofoakwa Tano FC         v Accra Hearts of Oak SC   1-0
+  Sun Oct/1 2023
+           Legon Cities FC          v Aduana FC                2-1
+           Real Tamale United       v Heart of Lions FC        2-2
+           Great Olympics FC        v Bibiani Gold Stars FC    1-0
+           FC Samartex 1996         v Bechem United FC         4-1
+           Asante Kotoko FC         v Karela United FC         1-1
+  Wed Oct/11 2023
+           Dreams FC                v Nsoatreman FC            1-1
+  Wed Oct/25 2023
+           Medeama SC               v Nations FC               1-0
+
+» Matchday 4
+  Fri Oct/6 2023
+           Aduana FC                v Berekum Chelsea FC       1-0
+  Sat Oct/7 2023
+           Bechem United FC         v Medeama SC               1-2
+  Sun Oct/8 2023
+           Heart of Lions FC        v Bofoakwa Tano FC         0-0
+           Nsoatreman FC            v FC Samartex 1996         1-0
+           Nations FC               v Legon Cities FC          1-1
+           Karela United FC         v Great Olympics FC        0-0
+           Bibiani Gold Stars FC    v Real Tamale United       3-0
+           Accra Hearts of Oak SC   v Dreams FC                0-0
+  Mon Oct/9 2023
+           Accra Lions FC           v Asante Kotoko FC         0-1
+
+» Matchday 5
+  Fri Oct/13 2023
+           Asante Kotoko FC         v Aduana FC                1-0
+  Sat Oct/14 2023
+           Bofoakwa Tano FC         v Bibiani Gold Stars FC    0-0
+  Sun Oct/15 2023
+           Legon Cities FC          v Bechem United FC         1-1
+           Berekum Chelsea FC       v Nations FC               1-0
+           FC Samartex 1996         v Dreams FC                2-0
+           Real Tamale United       v Karela United FC         3-2
+  Mon Oct/16 2023
+           Great Olympics FC        v Accra Lions FC           3-0
+  Wed Nov/8 2023
+           Heart of Lions FC        v Accra Hearts of Oak SC   0-0
+  Thu Nov/9 2023
+           Medeama SC               v Nsoatreman FC            1-0
+
+» Matchday 6
+  Fri Oct/20 2023
+           Accra Lions FC           v Real Tamale United       1-3
+  Sat Oct/21 2023
+           Accra Hearts of Oak SC   v FC Samartex 1996         0-0
+  Sun Oct/22 2023
+           Bechem United FC         v Berekum Chelsea FC       2-0
+           Nsoatreman FC            v Legon Cities FC          2-0
+           Aduana FC                v Great Olympics FC        3-1
+           Dreams FC                v Medeama SC               2-1
+           Karela United FC         v Bofoakwa Tano FC         0-0
+           Nations FC               v Asante Kotoko FC         2-2
+  Mon Oct/23 2023
+           Bibiani Gold Stars FC    v Heart of Lions FC        2-2
+
+» Matchday 7
+  Fri Oct/27 2023
+           Bofoakwa Tano FC         v Accra Lions FC           1-1
+  Sat Oct/28 2023
+           Bibiani Gold Stars FC    v Accra Hearts of Oak SC   1-1
+           Great Olympics FC        v Nations FC               1-0
+  Sun Oct/29 2023
+           Heart of Lions FC        v Karela United FC         0-0
+           Asante Kotoko FC         v Bechem United FC         1-1
+           Berekum Chelsea FC       v Nsoatreman FC            0-1
+           Legon Cities FC          v Dreams FC                1-0
+           Medeama SC               v FC Samartex 1996         1-0
+           Real Tamale United       v Aduana FC                1-3
+
+» Matchday 8
+  Wed Nov/1 2023
+           Accra Hearts of Oak SC   v Medeama SC               3-1
+           Bechem United FC         v Great Olympics FC        2-1
+           FC Samartex 1996         v Legon Cities FC          3-0
+           Aduana FC                v Bofoakwa Tano FC         4-2
+           Dreams FC                v Berekum Chelsea FC       0-2
+           Karela United FC         v Bibiani Gold Stars FC    1-1
+           Nations FC               v Real Tamale United       4-0
+  Thu Nov/2 2023
+           Accra Lions FC           v Heart of Lions FC        2-1
+           Nsoatreman FC            v Asante Kotoko FC         1-0
+
+» Matchday 9
+  Sat Nov/4 2023
+           Karela United FC         v Accra Hearts of Oak SC   1-1
+  Sun Nov/5 2023
+           Asante Kotoko FC         v Dreams FC                0-1
+           Heart of Lions FC        v Aduana FC                1-2
+           Berekum Chelsea FC       v FC Samartex 1996         1-0
+           Legon Cities FC          v Medeama SC               0-2
+           Real Tamale United       v Bechem United FC         0-0
+           Bofoakwa Tano FC         v Nations FC               1-0
+           Bibiani Gold Stars FC    v Accra Lions FC           1-1
+  Mon Nov/6 2023
+           Great Olympics FC        v Nsoatreman FC            2-1
+
+» Matchday 10
+  Fri Nov/10 2023
+           Accra Lions FC           v Karela United FC         2-1
+  Sat Nov/11 2023
+           FC Samartex 1996         v Asante Kotoko FC         1-0
+  Sun Nov/12 2023
+           Accra Hearts of Oak SC   v Legon Cities FC          0-0
+           Bechem United FC         v Bofoakwa Tano FC         1-1
+           Medeama SC               v Berekum Chelsea FC       0-1
+           Dreams FC                v Great Olympics FC        2-0
+           Nsoatreman FC            v Real Tamale United       2-0
+           Nations FC               v Heart of Lions FC        1-0
+  Mon Nov/13 2023
+           Aduana FC                v Bibiani Gold Stars FC    3-0
+
+» Matchday 11
+  Sat Nov/18 2023
+           Heart of Lions FC        v Bechem United FC         1-2
+           Karela United FC         v Aduana FC                2-1
+  Sun Nov/19 2023
+           Bibiani Gold Stars FC    v Nations FC               0-1
+           Berekum Chelsea FC       v Legon Cities FC          1-0
+           Real Tamale United       v Dreams FC                3-1
+           Bofoakwa Tano FC         v Nsoatreman FC            0-0
+           Asante Kotoko FC         v Medeama SC               1-0
+  Mon Nov/20 2023
+           Great Olympics FC        v FC Samartex 1996         0-0
+  Tue Nov/21 2023
+           Accra Lions FC           v Accra Hearts of Oak SC   1-2
+
+» Matchday 12
+  Sat Nov/25 2023
+           Legon Cities FC          v Asante Kotoko FC         1-3
+           Nations FC               v Karela United FC         1-0
+  Sun Nov/26 2023
+           Accra Hearts of Oak SC   v Berekum Chelsea FC       1-1
+           Aduana FC                v Accra Lions FC           0-1
+           FC Samartex 1996         v Real Tamale United       2-1
+           Nsoatreman FC            v Heart of Lions FC        0-0
+  Mon Nov/27 2023
+           Bechem United FC         v Bibiani Gold Stars FC    0-0
+  Wed Jan/10 2024
+           Dreams FC                v Bofoakwa Tano FC         3-1
+           Medeama SC               v Great Olympics FC        1-0
+
+» Matchday 13
+  Sun Dec/3 2023
+           Karela United FC         v Bechem United FC         0-4
+           Aduana FC                v Accra Hearts of Oak SC   1-0
+           Accra Lions FC           v Nations FC               0-1
+           Bofoakwa Tano FC         v FC Samartex 1996         0-2
+           Bibiani Gold Stars FC    v Nsoatreman FC            1-2
+  Mon Dec/4 2023
+           Great Olympics FC        v Legon Cities FC          0-2
+           Asante Kotoko FC         v Berekum Chelsea FC       1-0
+  Wed Jan/3 2024
+           Real Tamale United       v Medeama SC               1-0
+  Thu Jan/4 2024
+           Heart of Lions FC        v Dreams FC                1-0
+
+» Matchday 14
+  Sat Dec/9 2023
+           Nations FC               v Aduana FC                2-1
+  Sun Dec/10 2023
+           Nsoatreman FC            v Karela United FC         0-1
+           FC Samartex 1996         v Heart of Lions FC        2-0
+           Berekum Chelsea FC       v Great Olympics FC        1-0
+           Legon Cities FC          v Real Tamale United       3-1
+           Bechem United FC         v Accra Lions FC           4-0
+           Accra Hearts of Oak SC   v Asante Kotoko FC         2-3
+  Sat Jan/13 2024
+           Dreams FC                v Bibiani Gold Stars FC    3-0
+           Medeama SC               v Bofoakwa Tano FC         0-0
+
+» Matchday 15
+  Fri Dec/15 2023
+           Aduana FC                v Bechem United FC         1-0
+  Sat Dec/16 2023
+           Nations FC               v Accra Hearts of Oak SC   1-1
+  Sun Dec/17 2023
+           Bibiani Gold Stars FC    v FC Samartex 1996         3-0
+           Great Olympics FC        v Asante Kotoko FC         0-0
+           Real Tamale United       v Berekum Chelsea FC       0-1
+           Bofoakwa Tano FC         v Legon Cities FC          0-1
+  Mon Dec/18 2023
+           Accra Lions FC           v Nsoatreman FC            2-1
+  Wed Jan/17 2024
+           Karela United FC         v Dreams FC                0-0
+           Heart of Lions FC        v Medeama SC               2-2
+
+» Matchday 16
+  Fri Dec/22 2023
+           Great Olympics FC        v Accra Hearts of Oak SC   0-0
+  Sat Dec/23 2023
+           Berekum Chelsea FC       v Bofoakwa Tano FC         0-0
+  Sun Dec/24 2023
+           Nsoatreman FC            v Aduana FC                1-0
+           Dreams FC                v Accra Lions FC           1-1
+           Bechem United FC         v Nations FC               3-0
+           FC Samartex 1996         v Karela United FC         3-0
+           Asante Kotoko FC         v Real Tamale United       1-0
+  Mon Dec/25 2023
+           Legon Cities FC          v Heart of Lions FC        1-0
+  Tue Dec/26 2023
+           Medeama SC               v Bibiani Gold Stars FC    1-0
+
+» Matchday 17
+  Fri Dec/29 2023
+           Accra Lions FC           v FC Samartex 1996         1-3
+  Sat Dec/30 2023
+           Bibiani Gold Stars FC    v Legon Cities FC          4-2
+           Karela United FC         v Medeama SC               0-0
+           Bofoakwa Tano FC         v Asante Kotoko FC         0-2
+  Sun Dec/31 2023
+           Accra Hearts of Oak SC   v Bechem United FC         1-0
+           Heart of Lions FC        v Berekum Chelsea FC       2-0
+           Nations FC               v Nsoatreman FC            4-1
+           Real Tamale United       v Great Olympics FC        0-1
+           Aduana FC                v Dreams FC                4-1
+
+» Matchday 18
+  Sat Feb/24 2024
+           Heart of Lions FC        v Asante Kotoko FC         1-0
+  Sun Feb/25 2024
+           Bibiani Gold Stars FC    v Berekum Chelsea FC       3-1
+           Accra Hearts of Oak SC   v Real Tamale United       3-0
+           Bofoakwa Tano FC         v Great Olympics FC        0-1
+           Karela United FC         v Legon Cities FC          2-0
+           Bechem United FC         v Nsoatreman FC            0-1
+  Mon Feb/26 2024
+           Aduana FC                v FC Samartex 1996         1-2
+  Wed Mar/20 2024
+           Nations FC               v Dreams FC                1-0
+  Tue Apr/2 2024
+           Accra Lions FC           v Medeama SC               1-0
+
+» Matchday 19
+  Fri Mar/1 2024
+           Asante Kotoko FC         v Bibiani Gold Stars FC    1-0
+  Sat Mar/2 2024
+           Great Olympics FC        v Heart of Lions FC        2-0
+  Sun Mar/3 2024
+           Berekum Chelsea FC       v Karela United FC         3-0
+           Nsoatreman FC            v Accra Hearts of Oak SC   1-2
+           Legon Cities FC          v Accra Lions FC           0-0
+  Mon Mar/4 2024
+           FC Samartex 1996         v Nations FC               0-1
+           Real Tamale United       v Bofoakwa Tano FC         1-1
+  Wed Mar/20 2024
+           Medeama SC               v Aduana FC                2-0
+  Wed May/15 2024
+           Dreams FC                v Bechem United FC         2-1
+
+» Matchday 20
+  Sat Mar/9 2024
+           Karela United FC         v Asante Kotoko FC         1-0
+           Accra Lions FC           v Berekum Chelsea FC       5-0
+  Sun Mar/10 2024
+           Nations FC               v Medeama SC               1-1
+           Heart of Lions FC        v Real Tamale United       2-0
+           Aduana FC                v Legon Cities FC          1-0
+           Bechem United FC         v FC Samartex 1996         1-0
+           Nsoatreman FC            v Dreams FC                0-2
+           Bibiani Gold Stars FC    v Great Olympics FC        3-0
+  Mon Mar/11 2024
+           Accra Hearts of Oak SC   v Bofoakwa Tano FC         1-1
+
+» Matchday 21
+  Wed Mar/13 2024
+           Berekum Chelsea FC       v Aduana FC                1-0
+           Great Olympics FC        v Karela United FC         0-0
+           FC Samartex 1996         v Nsoatreman FC            2-0
+           Asante Kotoko FC         v Accra Lions FC           2-3
+  Thu Mar/14 2024
+           Bofoakwa Tano FC         v Heart of Lions FC        1-0
+           Medeama SC               v Bechem United FC         1-0
+           Real Tamale United       v Bibiani Gold Stars FC    2-2
+           Legon Cities FC          v Nations FC               1-0
+           Dreams FC                v Accra Hearts of Oak SC   2-2
+
+» Matchday 22
+  Sun Mar/17 2024
+           Aduana FC                v Asante Kotoko FC         2-1
+           Bechem United FC         v Legon Cities FC          1-0
+           Bibiani Gold Stars FC    v Bofoakwa Tano FC         2-1
+           Dreams FC                v FC Samartex 1996         2-2
+           Karela United FC         v Real Tamale United       3-2
+           Nations FC               v Berekum Chelsea FC       3-0
+           Nsoatreman FC            v Medeama SC               1-0
+  Mon Mar/18 2024
+           Accra Hearts of Oak SC   v Heart of Lions FC        2-1
+  Tue Mar/19 2024
+           Accra Lions FC           v Great Olympics FC        1-0
+
+» Matchday 23
+  Sat Mar/23 2024
+           FC Samartex 1996         v Accra Hearts of Oak SC   2-1
+  Sun Mar/24 2024
+           Legon Cities FC          v Nsoatreman FC            1-0
+           Great Olympics FC        v Aduana FC                4-2
+           Medeama SC               v Dreams FC                0-0
+           Bofoakwa Tano FC         v Karela United FC         2-1
+           Berekum Chelsea FC       v Bechem United FC         1-1
+           Asante Kotoko FC         v Nations FC               0-1
+  Mon Mar/25 2024
+           Heart of Lions FC        v Bibiani Gold Stars FC    2-2
+           Real Tamale United       v Accra Lions FC           1-0
+
+» Matchday 24
+  Fri Apr/5 2024
+           Nations FC               v Great Olympics FC        1-0
+  Sat Apr/6 2024
+           Accra Lions FC           v Bofoakwa Tano FC         1-0
+           Bechem United FC         v Asante Kotoko FC         0-0
+  Sun Apr/7 2024
+           Aduana FC                v Real Tamale United       3-1
+           FC Samartex 1996         v Medeama SC               1-0
+           Nsoatreman FC            v Berekum Chelsea FC       0-0
+           Karela United FC         v Heart of Lions FC        1-0
+           Accra Hearts of Oak SC   v Bibiani Gold Stars FC    0-1
+  Wed May/22 2024
+           Dreams FC                v Legon Cities FC          2-0
+
+» Matchday 25
+  Wed Apr/10 2024
+           Real Tamale United       v Nations FC               1-0
+           Medeama SC               v Accra Hearts of Oak SC   2-0
+           Bofoakwa Tano FC         v Aduana FC                1-0
+           Heart of Lions FC        v Accra Lions FC           2-0
+           Great Olympics FC        v Bechem United FC         1-1
+           Legon Cities FC          v FC Samartex 1996         1-1
+           Bibiani Gold Stars FC    v Karela United FC         3-2
+           Berekum Chelsea FC       v Dreams FC                3-2
+  Thu Apr/11 2024
+           Asante Kotoko FC         v Nsoatreman FC            1-2
+
+» Matchday 26
+  Sat Apr/13 2024
+           Accra Hearts of Oak SC   v Karela United FC         3-1
+  Sun Apr/14 2024
+           Medeama SC               v Legon Cities FC          1-0
+           Nsoatreman FC            v Great Olympics FC        1-1
+           Aduana FC                v Heart of Lions FC        1-0
+           FC Samartex 1996         v Berekum Chelsea FC       3-2
+           Nations FC               v Bofoakwa Tano FC         2-2
+           Dreams FC                v Asante Kotoko FC         2-0
+           Bechem United FC         v Real Tamale United       3-2
+  Mon Apr/15 2024
+           Accra Lions FC           v Bibiani Gold Stars FC    2-0
+
+» Matchday 27
+  Sat Apr/20 2024
+           Karela United FC         v Accra Lions FC           1-1
+           Legon Cities FC          v Accra Hearts of Oak SC   2-0
+  Sun Apr/21 2024
+           Heart of Lions FC        v Nations FC               3-0
+           Real Tamale United       v Nsoatreman FC            1-2
+           Asante Kotoko FC         v FC Samartex 1996         1-0
+           Bibiani Gold Stars FC    v Aduana FC                1-0
+           Bofoakwa Tano FC         v Bechem United FC         1-1
+  Mon Apr/22 2024
+           Berekum Chelsea FC       v Medeama SC               2-0
+  Wed Jun/5 2024
+           Great Olympics FC        v Dreams FC                0-0
+
+» Matchday 28
+  Fri Apr/26 2024
+           Legon Cities FC          v Berekum Chelsea FC       3-2
+  Sat Apr/27 2024
+           Medeama SC               v Asante Kotoko FC         1-1
+           FC Samartex 1996         v Great Olympics FC        1-0
+           Bechem United FC         v Heart of Lions FC        1-1
+           Nations FC               v Bibiani Gold Stars FC    0-0
+           Aduana FC                v Karela United FC         1-2
+  Mon Apr/29 2024
+           Nsoatreman FC            v Bofoakwa Tano FC         0-0
+  Wed May/1 2024
+           Accra Hearts of Oak SC   v Accra Lions FC           0-1
+  Wed Jun/12 2024
+           Dreams FC                v Real Tamale United       8-1
+
+» Matchday 29
+  Sat May/4 2024
+           Karela United FC         v Nations FC               1-0
+  Sun May/5 2024
+           Great Olympics FC        v Medeama SC               0-1
+           Heart of Lions FC        v Nsoatreman FC            1-0
+           Asante Kotoko FC         v Legon Cities FC          2-0
+           Real Tamale United       v FC Samartex 1996         1-0
+           Bibiani Gold Stars FC    v Bechem United FC         1-1
+           Bofoakwa Tano FC         v Dreams FC                1-1
+  Mon May/6 2024
+           Accra Lions FC           v Aduana FC                0-0
+  Wed May/8 2024
+           Berekum Chelsea FC       v Accra Hearts of Oak SC   0-3
+
+» Matchday 30
+  Fri May/17 2024
+           Nations FC               v Accra Lions FC           1-0
+  Sat May/18 2024
+           Berekum Chelsea FC       v Asante Kotoko FC         2-1
+           Legon Cities FC          v Great Olympics FC        2-1
+  Sun May/19 2024
+           Dreams FC                v Heart of Lions FC        1-2
+           Medeama SC               v Real Tamale United       1-0
+           FC Samartex 1996         v Bofoakwa Tano FC         3-0
+           Nsoatreman FC            v Bibiani Gold Stars FC    4-0
+           Accra Hearts of Oak SC   v Aduana FC                0-1
+           Bechem United FC         v Karela United FC         3-1
+
+» Matchday 31
+  Sat May/25 2024
+           Karela United FC         v Nsoatreman FC            2-1
+           Aduana FC                v Nations FC               1-0
+           Accra Lions FC           v Bechem United FC         3-0
+  Sun May/26 2024
+           Heart of Lions FC        v FC Samartex 1996         2-0
+           Bibiani Gold Stars FC    v Dreams FC                2-1
+           Great Olympics FC        v Berekum Chelsea FC       3-2
+           Bofoakwa Tano FC         v Medeama SC               0-2
+           Asante Kotoko FC         v Accra Hearts of Oak SC   2-0
+           Real Tamale United       v Legon Cities FC          1-0
+
+» Matchday 32
+  Fri May/31 2024
+           Accra Hearts of Oak SC   v Nations FC               2-0
+  Sat Jun/1 2024
+           Bechem United FC         v Aduana FC                1-0
+           Legon Cities FC          v Bofoakwa Tano FC         1-0
+  Sun Jun/2 2024
+           Asante Kotoko FC         v Great Olympics FC        0-1
+           Nsoatreman FC            v Accra Lions FC           1-1
+           Berekum Chelsea FC       v Real Tamale United       2-0
+           Medeama SC               v Heart of Lions FC        0-1
+           Dreams FC                v Karela United FC         1-0
+           FC Samartex 1996         v Bibiani Gold Stars FC    1-0
+
+» Matchday 33
+  Sat Jun/8 2024
+           Real Tamale United       v Asante Kotoko FC         0-2
+           Accra Lions FC           v Dreams FC                1-0
+  Sun Jun/9 2024
+           Nations FC               v Bechem United FC         1-1
+           Bofoakwa Tano FC         v Berekum Chelsea FC       0-1
+           Bibiani Gold Stars FC    v Medeama SC               2-0
+           Karela United FC         v FC Samartex 1996         4-2
+           Heart of Lions FC        v Legon Cities FC          2-0
+           Aduana FC                v Nsoatreman FC            2-2
+           Accra Hearts of Oak SC   v Great Olympics FC        0-0
+
+» Matchday 34
+  Sun Jun/16 2024
+           FC Samartex 1996         v Accra Lions FC           2-0
+           Legon Cities FC          v Bibiani Gold Stars FC    1-1
+           Medeama SC               v Karela United FC         0-1
+           Bechem United FC         v Accra Hearts of Oak SC   2-3
+           Berekum Chelsea FC       v Heart of Lions FC        2-2
+           Nsoatreman FC            v Nations FC               1-0
+           Great Olympics FC        v Real Tamale United       3-0 (awarded)
+           Dreams FC                v Aduana FC                2-1
+           Asante Kotoko FC         v Bofoakwa Tano FC         3-1

--- a/africa/ghana/2024-25_gh1.txt
+++ b/africa/ghana/2024-25_gh1.txt
@@ -1,0 +1,464 @@
+= Ghana | Premier League 2024/25
+
+# Date       Sat Sep/7 2024 - Sun Jun/8 2025 (274d)
+# Teams      18
+# Matches    306
+# Source     https://www.rsssf.org/tablesg/gha2025.html
+# Retrieved  2026-08-17
+
+
+» Matchday 1
+  Sat Sep/7 2024
+           Dreams FC                  v FC Samartex 1996           0-0
+           Vision FC                  v Berekum Chelsea FC         0-0
+  Sun Sep/8 2024
+           Accra Hearts of Oak SC     v Basake Holy Stars FC       0-1
+           Aduana FC                  v Heart of Lions FC          1-1
+           Karela United FC           v Asante Kotoko FC           0-1
+           Bibiani Gold Stars FC      v Legon Cities FC            2-1
+           Nsoatreman FC              v Wenchi Young Apostles FC   2-0
+           Nations FC                 v Bechem United FC           0-0
+           Medeama SC                 v Accra Lions FC             1-0
+
+» Matchday 2
+  Sat Sep/14 2024
+           Legon Cities FC            v Medeama SC                 0-1
+  Sun Sep/15 2024
+           Basake Holy Stars FC       v Dreams FC                  0-0
+           Wenchi Young Apostles FC   v Nations FC                 0-0
+           Berekum Chelsea FC         v Karela United FC           1-0
+           Bechem United FC           v Aduana FC                  0-0
+           Heart of Lions FC          v Accra Hearts of Oak SC     2-0
+  Mon Sep/16 2024
+           Accra Lions FC             v Vision FC                  0-2
+  Wed Oct/2 2024
+           FC Samartex 1996           v Bibiani Gold Stars FC      1-1
+           Asante Kotoko FC           v Nsoatreman FC              1-0
+
+» Matchday 3
+  Sat Sep/21 2024
+           Vision FC                  v Legon Cities FC            1-1
+  Sun Sep/22 2024
+           Bibiani Gold Stars FC      v Basake Holy Stars FC       1-0
+           Asante Kotoko FC           v Wenchi Young Apostles FC   1-1
+           Karela United FC           v Accra Lions FC             1-1
+           Aduana FC                  v Nations FC                 1-2
+           Accra Hearts of Oak SC     v Bechem United FC           2-0
+  Mon Sep/23 2024
+           Dreams FC                  v Heart of Lions FC          2-2
+  Wed Oct/9 2024
+           Nsoatreman FC              v Berekum Chelsea FC         0-0
+           Medeama SC                 v FC Samartex 1996           0-0
+
+» Matchday 4
+  Sat Sep/28 2024
+           Accra Lions FC             v Nsoatreman FC              3-1
+  Sun Sep/29 2024
+           Nations FC                 v Accra Hearts of Oak SC     0-0
+           Legon Cities FC            v Karela United FC           0-2
+           Wenchi Young Apostles FC   v Aduana FC                  3-2
+           Heart of Lions FC          v Bibiani Gold Stars FC      0-0
+           Basake Holy Stars FC       v Medeama SC                 1-2
+           FC Samartex 1996           v Vision FC                  2-1
+           Berekum Chelsea FC         v Asante Kotoko FC           1-1
+           Bechem United FC           v Dreams FC                  1-0
+
+» Matchday 5
+  Fri Oct/4 2024
+           Accra Hearts of Oak SC     v Aduana FC                  0-0
+  Sat Oct/5 2024
+           Medeama SC                 v Heart of Lions FC          0-0
+  Sun Oct/6 2024
+           Berekum Chelsea FC         v Wenchi Young Apostles FC   1-0
+           Asante Kotoko FC           v Accra Lions FC             1-0
+           Dreams FC                  v Nations FC                 0-1
+           Karela United FC           v FC Samartex 1996           1-1
+           Vision FC                  v Basake Holy Stars FC       1-0
+           Bibiani Gold Stars FC      v Bechem United FC           1-0
+           Nsoatreman FC              v Legon Cities FC            3-1
+
+» Matchday 6
+  Sat Oct/12 2024
+           Accra Lions FC             v Berekum Chelsea FC         1-1
+           Heart of Lions FC          v Vision FC                  0-0
+  Sun Oct/13 2024
+           Bechem United FC           v Medeama SC                 2-0
+           Nations FC                 v Bibiani Gold Stars FC      1-1
+           Aduana FC                  v Dreams FC                  2-0
+           Wenchi Young Apostles FC   v Accra Hearts of Oak SC     1-2
+           Basake Holy Stars FC       v Karela United FC           1-0
+  Mon Oct/14 2024
+           FC Samartex 1996           v Nsoatreman FC              2-0
+  Wed Oct/30 2024
+           Legon Cities FC            v Asante Kotoko FC           2-1
+
+» Matchday 7
+  Sat Oct/19 2024
+           Accra Lions FC             v Wenchi Young Apostles FC   0-0
+  Sun Oct/20 2024
+           Asante Kotoko FC           v FC Samartex 1996           1-0
+           Karela United FC           v Heart of Lions FC          1-0
+           Nsoatreman FC              v Basake Holy Stars FC       2-0
+           Vision FC                  v Bechem United FC           1-1
+           Berekum Chelsea FC         v Legon Cities FC            3-1
+           Dreams FC                  v Accra Hearts of Oak SC     0-0
+           Bibiani Gold Stars FC      v Aduana FC                  2-0
+           Medeama SC                 v Nations FC                 1-0
+
+» Matchday 8
+  Fri Oct/25 2024
+           Legon Cities FC            v Accra Lions FC             0-0
+  Sun Oct/27 2024
+           FC Samartex 1996           v Berekum Chelsea FC         1-0
+           Accra Hearts of Oak SC     v Bibiani Gold Stars FC      0-1
+           Heart of Lions FC          v Nsoatreman FC              1-0
+           Wenchi Young Apostles FC   v Dreams FC                  1-0
+           Bechem United FC           v Karela United FC           0-0
+           Basake Holy Stars FC       v Asante Kotoko FC           1-1
+           Nations FC                 v Vision FC                  3-0
+  Mon Oct/28 2024
+           Aduana FC                  v Medeama SC                 2-2
+
+» Matchday 9
+  Fri Nov/1 2024
+           Medeama SC                 v Accra Hearts of Oak SC     0-2
+           Accra Lions FC             v FC Samartex 1996           1-1
+  Sun Nov/3 2024
+           Berekum Chelsea FC         v Basake Holy Stars FC       2-2
+           Asante Kotoko FC           v Heart of Lions FC          0-1
+           Karela United FC           v Nations FC                 0-1
+           Vision FC                  v Aduana FC                  0-0
+           Bibiani Gold Stars FC      v Dreams FC                  0-0
+           Nsoatreman FC              v Bechem United FC           2-2
+  Mon Nov/4 2024
+           Legon Cities FC            v Wenchi Young Apostles FC   2-0
+
+» Matchday 10
+  Fri Nov/8 2024
+           Accra Hearts of Oak SC     v Vision FC                  1-0
+  Sat Nov/9 2024
+           Dreams FC                  v Medeama SC                 1-0
+  Sun Nov/10 2024
+           Bechem United FC           v Asante Kotoko FC           1-0
+           FC Samartex 1996           v Legon Cities FC            1-0
+           Heart of Lions FC          v Berekum Chelsea FC         1-0
+           Aduana FC                  v Karela United FC           1-0
+           Wenchi Young Apostles FC   v Bibiani Gold Stars FC      0-0
+           Basake Holy Stars FC       v Accra Lions FC             2-1
+           Nations FC                 v Nsoatreman FC              3-0
+
+» Matchday 11
+  Sat Nov/16 2024
+           Nsoatreman FC              v Aduana FC                  1-1
+           Accra Lions FC             v Heart of Lions FC          0-0
+  Sun Nov/17 2024
+           Medeama SC                 v Bibiani Gold Stars FC      2-0
+           Legon Cities FC            v Basake Holy Stars FC       2-1
+           Asante Kotoko FC           v Nations FC                 0-2
+           FC Samartex 1996           v Wenchi Young Apostles FC   0-1
+           Vision FC                  v Dreams FC                  0-1
+           Berekum Chelsea FC         v Bechem United FC           1-2
+           Karela United FC           v Accra Hearts of Oak SC     0-1
+
+» Matchday 12
+  Sat Nov/23 2024
+           Accra Hearts of Oak SC     v Nsoatreman FC              1-1
+  Sun Nov/24 2024
+           Bibiani Gold Stars FC      v Vision FC                  2-0
+           Basake Holy Stars FC       v FC Samartex 1996           1-0
+           Bechem United FC           v Accra Lions FC             1-0
+           Heart of Lions FC          v Legon Cities FC            3-0
+           Nations FC                 v Berekum Chelsea FC         0-1
+           Dreams FC                  v Karela United FC           0-1
+           Wenchi Young Apostles FC   v Medeama SC                 0-2
+           Aduana FC                  v Asante Kotoko FC           0-2
+
+» Matchday 13
+  Sat Dec/14 2024
+           Berekum Chelsea FC         v Aduana FC                  0-0
+           Accra Lions FC             v Nations FC                 1-0
+           Basake Holy Stars FC       v Wenchi Young Apostles FC   3-0
+           Vision FC                  v Medeama SC                 3-2
+           FC Samartex 1996           v Heart of Lions FC          0-1
+           Karela United FC           v Bibiani Gold Stars FC      1-1
+           Nsoatreman FC              v Dreams FC                  1-1
+           Legon Cities FC            v Bechem United FC           0-2
+  Sun Dec/15 2024
+           Asante Kotoko FC           v Accra Hearts of Oak SC     1-0
+
+» Matchday 14
+  Fri Dec/20 2024
+           Accra Hearts of Oak SC     v Berekum Chelsea FC         3-1
+  Sat Dec/21 2024
+           Bechem United FC           v FC Samartex 1996           1-0
+           Heart of Lions FC          v Basake Holy Stars FC       3-1
+           Dreams FC                  v Asante Kotoko FC           1-2
+           Bibiani Gold Stars FC      v Nsoatreman FC              2-1
+           Wenchi Young Apostles FC   v Vision FC                  1-1
+           Nations FC                 v Legon Cities FC            3-0
+  Mon Dec/23 2024
+           Aduana FC                  v Accra Lions FC             0-0
+  Wed Jan/1 2025
+           Medeama SC                 v Karela United FC           1-0
+
+» Matchday 15
+  Thu Dec/26 2024
+           Heart of Lions FC          v Wenchi Young Apostles FC   1-0
+           Legon Cities FC            v Aduana FC                  0-1
+           Basake Holy Stars FC       v Bechem United FC           3-0 (awarded)
+  Fri Dec/27 2024
+           Asante Kotoko FC           v Bibiani Gold Stars FC      2-0
+  Sun Dec/29 2024
+           FC Samartex 1996           v Nations FC                 1-1
+           Accra Lions FC             v Accra Hearts of Oak SC     2-3
+           Karela United FC           v Vision FC                  1-1
+           Berekum Chelsea FC         v Dreams FC                  0-0
+  Wed Jan/8 2025
+           Nsoatreman FC              v Medeama SC                 1-1
+
+» Matchday 16
+  Fri Jan/3 2025
+           Accra Hearts of Oak SC     v Legon Cities FC            1-0
+  Sat Jan/4 2025
+           Bibiani Gold Stars FC      v Berekum Chelsea FC         2-0
+  Sun Jan/5 2025
+           Bechem United FC           v Heart of Lions FC          3-0
+           Vision FC                  v Nsoatreman FC              1-0
+           Nations FC                 v Basake Holy Stars FC       3-1
+           Medeama SC                 v Asante Kotoko FC           1-1
+           Wenchi Young Apostles FC   v Karela United FC           2-0
+           Aduana FC                  v FC Samartex 1996           0-1
+           Dreams FC                  v Accra Lions FC             1-0
+
+» Matchday 17
+  Sun Jan/19 2025
+           Accra Lions FC             v Bibiani Gold Stars FC      0-3
+           Berekum Chelsea FC         v Medeama SC                 2-1
+           Legon Cities FC            v Dreams FC                  3-0
+           Nsoatreman FC              v Karela United FC           1-0
+           Wenchi Young Apostles FC   v Bechem United FC           0-0
+           FC Samartex 1996           v Accra Hearts of Oak SC     0-0
+           Basake Holy Stars FC       v Aduana FC                  1-1
+           Asante Kotoko FC           v Vision FC                  4-1
+           Heart of Lions FC          v Nations FC                 0-1
+
+» Matchday 18
+  Sat Jan/25 2025
+           Accra Lions FC             v Medeama SC                 1-0
+  Sun Jan/26 2025
+           Bechem United FC           v Nations FC                 2-0
+           Berekum Chelsea FC         v Vision FC                  1-0
+           Heart of Lions FC          v Aduana FC                  2-1
+           Legon Cities FC            v Bibiani Gold Stars FC      1-0
+           Wenchi Young Apostles FC   v Nsoatreman FC              1-0
+           Basake Holy Stars FC       v Accra Hearts of Oak SC     0-0
+           Asante Kotoko FC           v Karela United FC           1-0
+           FC Samartex 1996           v Dreams FC                  1-1
+
+» Matchday 19
+  Fri Jan/31 2025
+           Accra Hearts of Oak SC     v Heart of Lions FC          1-0
+  Sun Feb/2 2025
+           Nations FC                 v Wenchi Young Apostles FC   1-2
+           Bibiani Gold Stars FC      v FC Samartex 1996           0-0
+           Aduana FC                  v Bechem United FC           1-0
+           Medeama SC                 v Legon Cities FC            1-0
+           Karela United FC           v Berekum Chelsea FC         2-1
+           Vision FC                  v Accra Lions FC             2-1
+           Dreams FC                  v Basake Holy Stars FC       2-1
+           Nsoatreman FC              v Asante Kotoko FC           1-0
+
+» Matchday 20
+  Wed Mar/19 2025
+           FC Samartex 1996           v Medeama SC                 2-1
+           Bechem United FC           v Accra Hearts of Oak SC     1-0
+           Wenchi Young Apostles FC   v Asante Kotoko FC           0-0
+           Berekum Chelsea FC         v Nsoatreman FC              3-0 (awarded)
+           Basake Holy Stars FC       v Bibiani Gold Stars FC      0-1
+           Heart of Lions FC          v Dreams FC                  1-2
+           Nations FC                 v Aduana FC                  0-1
+           Legon Cities FC            v Vision FC                  1-1
+  Thu Mar/20 2025
+           Accra Lions FC             v Karela United FC           0-0
+
+» Matchday 21
+  Tue Apr/1 2025
+           Bibiani Gold Stars FC      v Heart of Lions FC          2-1
+           Medeama SC                 v Basake Holy Stars FC       2-1
+  Wed Apr/2 2025
+           Nsoatreman FC              v Accra Lions FC             0-3 (awarded)
+           Karela United FC           v Legon Cities FC            2-0
+           Aduana FC                  v Wenchi Young Apostles FC   2-2
+           Vision FC                  v FC Samartex 1996           3-2
+           Asante Kotoko FC           v Berekum Chelsea FC         1-0
+           Dreams FC                  v Bechem United FC           1-0
+  Thu Apr/3 2025
+           Accra Hearts of Oak SC     v Nations FC                 0-1
+
+» Matchday 22
+  Wed Apr/16 2025
+           Aduana FC                  v Accra Hearts of Oak SC     2-0
+           Heart of Lions FC          v Medeama SC                 1-0
+           Wenchi Young Apostles FC   v Berekum Chelsea FC         2-1
+           Accra Lions FC             v Asante Kotoko FC           3-0
+           Nations FC                 v Dreams FC                  1-0
+           FC Samartex 1996           v Karela United FC           2-0
+           Basake Holy Stars FC       v Vision FC                  1-0
+           Bechem United FC           v Bibiani Gold Stars FC      0-2
+           Legon Cities FC            v Nsoatreman FC              3-0 (awarded)
+
+» Matchday 23
+  Sat Mar/8 2025
+           Accra Hearts of Oak SC     v Wenchi Young Apostles FC   2-0
+  Sun Mar/9 2025
+           Berekum Chelsea FC         v Accra Lions FC             3-1
+           Vision FC                  v Heart of Lions FC          1-1
+           Medeama SC                 v Bechem United FC           3-1
+           Bibiani Gold Stars FC      v Nations FC                 1-0
+           Dreams FC                  v Aduana FC                  0-0
+           Karela United FC           v Basake Holy Stars FC       1-1
+           Asante Kotoko FC           v Legon Cities FC            2-0
+  Mon Mar/10 2025
+           Nsoatreman FC              v FC Samartex 1996           0-1
+
+» Matchday 24
+  Sat Mar/15 2025
+           FC Samartex 1996           v Asante Kotoko FC           1-1
+           Wenchi Young Apostles FC   v Accra Lions FC             1-0
+           Accra Hearts of Oak SC     v Dreams FC                  0-1
+  Sun Mar/16 2025
+           Bechem United FC           v Vision FC                  2-0
+           Heart of Lions FC          v Karela United FC           1-0
+           Legon Cities FC            v Berekum Chelsea FC         2-1
+           Aduana FC                  v Bibiani Gold Stars FC      2-0
+           Nations FC                 v Medeama SC                 2-1
+           Basake Holy Stars FC       v Nsoatreman FC              3-0 (awarded)
+
+» Matchday 25
+  Sun Mar/23 2025
+           Accra Lions FC             v Legon Cities FC            2-1
+           Asante Kotoko FC           v Basake Holy Stars FC       1-0
+           Berekum Chelsea FC         v FC Samartex 1996           0-0
+           Bibiani Gold Stars FC      v Accra Hearts of Oak SC     1-1
+           Dreams FC                  v Wenchi Young Apostles FC   1-0
+           Karela United FC           v Bechem United FC           2-1
+           Medeama SC                 v Aduana FC                  2-0
+           Vision FC                  v Nations FC                 0-0
+  Mon Mar/24 2025
+           Nsoatreman FC              v Heart of Lions FC          0-3 (awarded)
+
+» Matchday 26
+  Sun Apr/6 2025
+           Accra Hearts of Oak SC     v Medeama SC                 1-0
+           FC Samartex 1996           v Accra Lions FC             2-0
+           Heart of Lions FC          v Asante Kotoko FC           1-1
+           Wenchi Young Apostles FC   v Legon Cities FC            0-0
+           Aduana FC                  v Vision FC                  1-0
+           Bechem United FC           v Nsoatreman FC              3-0 (awarded)
+           Basake Holy Stars FC       v Berekum Chelsea FC         2-1
+           Dreams FC                  v Bibiani Gold Stars FC      2-0
+  Mon Apr/7 2025
+           Nations FC                 v Karela United FC           1-0
+
+» Matchday 27
+  Fri Apr/11 2025
+           Medeama SC                 v Dreams FC                  4-0
+  Sat Apr/12 2025
+           Accra Lions FC             v Basake Holy Stars FC       2-1
+  Sun Apr/13 2025
+           Vision FC                  v Accra Hearts of Oak SC     1-1
+           Karela United FC           v Aduana FC                  2-0
+           Asante Kotoko FC           v Bechem United FC           1-1
+           Nsoatreman FC              v Nations FC                 0-3 (awarded)
+           Legon Cities FC            v FC Samartex 1996           0-2
+           Bibiani Gold Stars FC      v Wenchi Young Apostles FC   1-0
+           Berekum Chelsea FC         v Heart of Lions FC          1-0
+
+» Matchday 28
+  Sun Apr/20 2025
+           Aduana FC                  v Nsoatreman FC              3-0 (awarded)
+           Dreams FC                  v Vision FC                  1-1
+           Nations FC                 v Asante Kotoko FC           2-0
+           Basake Holy Stars FC       v Legon Cities FC            1-0
+           Accra Hearts of Oak SC     v Karela United FC           0-0
+           Bibiani Gold Stars FC      v Medeama SC                 1-0
+           Heart of Lions FC          v Accra Lions FC             3-1
+           Wenchi Young Apostles FC   v FC Samartex 1996           1-1
+           Bechem United FC           v Berekum Chelsea FC         1-2
+
+» Matchday 29
+  Sat Apr/26 2025
+           Accra Lions FC             v Bechem United FC           2-0
+           Medeama SC                 v Wenchi Young Apostles FC   3-0
+  Sun Apr/27 2025
+           Karela United FC           v Dreams FC                  1-2
+           FC Samartex 1996           v Basake Holy Stars FC       3-0
+           Asante Kotoko FC           v Aduana FC                  1-0
+           Vision FC                  v Bibiani Gold Stars FC      2-0
+           Nsoatreman FC              v Accra Hearts of Oak SC     0-3 (awarded)
+           Legon Cities FC            v Heart of Lions FC          0-1
+           Berekum Chelsea FC         v Nations FC                 1-0
+
+» Matchday 30
+  Fri May/2 2025
+           Medeama SC                 v Vision FC                  3-1
+  Sun May/4 2025
+           Dreams FC                  v Nsoatreman FC              3-0 (awarded)
+           Accra Hearts of Oak SC     v Asante Kotoko FC           0-0
+           Bechem United FC           v Legon Cities FC            1-0
+           Heart of Lions FC          v FC Samartex 1996           2-1
+           Aduana FC                  v Berekum Chelsea FC         3-2
+           Bibiani Gold Stars FC      v Karela United FC           0-1
+           Wenchi Young Apostles FC   v Basake Holy Stars FC       2-0
+           Nations FC                 v Accra Lions FC             1-0
+
+» Matchday 31
+  Sat May/17 2025
+           Accra Lions FC             v Aduana FC                  5-3
+  Sun May/18 2025
+           Vision FC                  v Wenchi Young Apostles FC   2-0
+           Asante Kotoko FC           v Dreams FC                  4-1
+           Berekum Chelsea FC         v Accra Hearts of Oak SC     0-1
+           Basake Holy Stars FC       v Heart of Lions FC          0-0
+           Karela United FC           v Medeama SC                 3-1
+           Nsoatreman FC              v Bibiani Gold Stars FC      0-3 (awarded)
+           FC Samartex 1996           v Bechem United FC           2-1
+  Mon May/19 2025
+           Legon Cities FC            v Nations FC                 1-4
+
+» Matchday 32
+  Fri May/23 2025
+           Accra Hearts of Oak SC     v Accra Lions FC             3-1
+  Sun May/25 2025
+           Wenchi Young Apostles FC   v Heart of Lions FC          3-1
+           Aduana FC                  v Legon Cities FC            4-0
+           Bechem United FC           v Basake Holy Stars FC       0-0
+           Bibiani Gold Stars FC      v Asante Kotoko FC           0-0
+           Nations FC                 v FC Samartex 1996           3-0
+           Vision FC                  v Karela United FC           1-0
+           Dreams FC                  v Berekum Chelsea FC         1-0
+           Medeama SC                 v Nsoatreman FC              3-0 (awarded)
+
+» Matchday 33
+  Sun Jun/1 2025
+           Accra Lions FC             v Dreams FC                  0-2
+           Asante Kotoko FC           v Medeama SC                 3-2
+           Berekum Chelsea FC         v Bibiani Gold Stars FC      2-3
+           Heart of Lions FC          v Bechem United FC           2-1
+           Basake Holy Stars FC       v Nations FC                 3-0 (awarded)
+           Karela United FC           v Wenchi Young Apostles FC   3-0
+           Legon Cities FC            v Accra Hearts of Oak SC     0-2
+           Nsoatreman FC              v Vision FC                  0-3 (awarded)
+           FC Samartex 1996           v Aduana FC                  2-1
+
+» Matchday 34
+  Sun Jun/8 2025
+           Accra Hearts of Oak SC     v FC Samartex 1996           1-0
+           Aduana FC                  v Basake Holy Stars FC       3-1
+           Bechem United FC           v Wenchi Young Apostles FC   1-0
+           Bibiani Gold Stars FC      v Accra Lions FC             4-0
+           Dreams FC                  v Legon Cities FC            4-1
+           Karela United FC           v Nsoatreman FC              3-0 (awarded)
+           Medeama SC                 v Berekum Chelsea FC         1-2
+           Nations FC                 v Heart of Lions FC          0-2
+           Vision FC                  v Asante Kotoko FC           3-1


### PR DESCRIPTION
## Summary

- add Ghana Premier League 2016/17 (`gh1`)
- add Ghana Premier League 2023/24 (`gh1`)
- add Ghana Premier League 2024/25 (`gh1`)

## Validation

- 2016/17: 240 matches, 16 teams
- 2023/24: 306 matches, 18 teams
- 2024/25: 306 matches, 18 teams
- all files pass match-count, team-count, duplicate-fixture, and score-format validation