### PR TITLE
Add Tanzania Premier League seasons 2023-2026

### DIFF
--- a/africa/tanzania/2023-24_tz1.txt
+++ b/africa/tanzania/2023-24_tz1.txt
@@ -1,0 +1,444 @@
+= Tanzania | Premier League 2023/24
+
+# Date       Tue Aug 15 2023 - Tue May 28 2024 (287d)
+# Teams      16
+# Matches    240
+# Source     https://www.rsssf.org/tablest/tanz2024.html
+# Retrieved  2026-08-19
+
+
+▪ Matchday 1
+  Tue Aug 15 2023
+           Ihefu FC               v Geita Gold FC          0-1
+           Namungo FC             v JKT Tanzania FC        0-1
+           Dodoma Jiji FC         v Coastal Union FC       2-1
+  Wed Aug 16 2023
+           Mashujaa FC            v Kagera Sugar FC        2-0
+           Azam FC                v Tabora United FC       4-0
+  Thu Aug 17 2023
+           Mtibwa Sugar FC        v Simba SC               2-4
+  Tue Aug 22 2023
+           Singida Big Stars FC   v Tanzania Prisons FC    0-0
+  Wed Aug 23 2023
+           Young Africans SC      v KMC FC                 5-0
+
+▪ Matchday 2
+  Sat Aug 19 2023
+           Ihefu FC               v Kagera Sugar FC        1-0
+           Namungo FC             v KMC FC                 1-1
+  Sun Aug 20 2023
+           Mtibwa Sugar FC        v Coastal Union FC       1-1
+           Simba SC               v Dodoma Jiji FC         2-0
+  Mon Aug 21 2023
+           Mashujaa FC            v Geita Gold FC          0-0
+  Mon Aug 28 2023
+           Azam FC                v Tanzania Prisons FC    3-1
+  Tue Aug 29 2023
+           Young Africans SC      v JKT Tanzania FC        5-0
+  Thu Aug 31 2023
+           Singida Big Stars FC   v Tabora United FC       0-0
+
+▪ Matchday 3
+  Fri Sep 15 2023
+           KMC FC                 v JKT Tanzania FC        2-1
+           Tabora United FC       v Tanzania Prisons FC    3-1
+           Dodoma Jiji FC         v Mtibwa Sugar FC        1-1
+  Sat Sep 16 2023
+           Mashujaa FC            v Ihefu FC               2-0
+  Sun Sep 17 2023
+           Kagera Sugar FC        v Geita Gold FC          1-0
+  Wed Sep 20 2023
+           Young Africans SC      v Namungo FC             1-0
+  Thu Sep 21 2023
+           Simba SC               v Coastal Union FC       3-0
+           Azam FC                v Singida Big Stars FC   2-1
+
+▪ Matchday 4
+  Fri Sep 29 2023
+           JKT Tanzania FC        v Kagera Sugar FC        1-1
+           Coastal Union FC       v Tabora United FC       0-0
+  Sat Sep 30 2023
+           Geita Gold FC          v KMC FC                 1-2
+           Namungo FC             v Mashujaa FC            0-0
+  Tue Oct 3 2023
+           Dodoma Jiji FC         v Azam FC                0-0
+  Wed Oct 4 2023
+           Ihefu FC               v Young Africans SC      2-1
+  Thu Oct 5 2023
+           Mtibwa Sugar FC        v Singida Big Stars FC   0-1
+           Tanzania Prisons FC    v Simba SC               1-3
+
+▪ Matchday 5
+  Tue Oct 3 2023
+           JKT Tanzania FC        v Mashujaa FC            1-0
+  Wed Oct 4 2023
+           Kagera Sugar FC        v Namungo FC             1-1
+  Fri Oct 6 2023
+           Coastal Union FC       v Azam FC                0-1
+           Tabora United FC       v Dodoma Jiji FC         2-1
+  Sat Oct 7 2023
+           Geita Gold FC          v Young Africans SC      0-3
+           KMC FC                 v Ihefu FC               1-0
+  Sun Oct 8 2023
+           Tanzania Prisons FC    v Mtibwa Sugar FC        3-2
+           Singida Big Stars FC   v Simba SC               1-2
+
+▪ Matchday 6
+  Thu Oct 19 2023
+           Mtibwa Sugar FC        v Kagera Sugar FC        0-2
+  Sat Oct 21 2023
+           Geita Gold FC          v Dodoma Jiji FC         2-2
+           Ihefu FC               v Coastal Union FC       0-0
+           Namungo FC             v Singida Big Stars FC   2-3
+  Sun Oct 22 2023
+           Tabora United FC       v KMC FC                 0-0
+           Tanzania Prisons FC    v JKT Tanzania FC        1-1
+  Mon Oct 23 2023
+           Young Africans SC      v Azam FC                3-2
+  Sat Feb 3 2024
+           Mashujaa FC            v Simba SC               0-1
+
+▪ Matchday 7
+  Wed Oct 25 2023
+           JKT Tanzania FC        v Tabora United FC       1-0
+           Coastal Union FC       v Mashujaa FC            2-0
+           Dodoma Jiji FC         v Kagera Sugar FC        1-0
+  Thu Oct 26 2023
+           Mtibwa Sugar FC        v Geita Gold FC          3-1
+  Fri Oct 27 2023
+           KMC FC                 v Tanzania Prisons FC    1-1
+           Young Africans SC      v Singida Big Stars FC   2-0
+           Azam FC                v Namungo FC             1-3
+  Sat Oct 28 2023
+           Simba SC               v Ihefu FC               2-1
+
+▪ Matchday 8
+  Mon Oct 30 2023
+           JKT Tanzania FC        v Dodoma Jiji FC         0-1
+           Tanzania Prisons FC    v Geita Gold FC          0-0
+           Kagera Sugar FC        v Tabora United FC       0-0
+  Tue Oct 31 2023
+           KMC FC                 v Mtibwa Sugar FC        1-0
+  Wed Nov 1 2023
+           Singida Big Stars FC   v Ihefu FC               2-2
+           Mashujaa FC            v Azam FC                0-3
+           Coastal Union FC       v Namungo FC             0-0
+  Sun Nov 5 2023
+           Simba SC               v Young Africans SC      1-5
+
+▪ Matchday 9
+  Fri Nov 3 2023
+           KMC FC                 v Dodoma Jiji FC         1-2
+           Mtibwa Sugar FC        v JKT Tanzania FC        1-2
+           Kagera Sugar FC        v Tanzania Prisons FC    2-1
+  Sat Nov 4 2023
+           Ihefu FC               v Azam FC                1-3
+  Mon Nov 6 2023
+           Geita Gold FC          v Tabora United FC       0-0
+           Mashujaa FC            v Singida Big Stars FC   1-3
+  Wed Nov 8 2023
+           Coastal Union FC       v Young Africans SC      0-1
+  Thu Nov 9 2023
+           Simba SC               v Namungo FC             1-1
+
+▪ Matchday 10
+  Wed Nov 22 2023
+           Geita Gold FC          v JKT Tanzania FC        1-0
+           Kagera Sugar FC        v KMC FC                 1-1
+  Thu Nov 23 2023
+           Tanzania Prisons FC    v Coastal Union FC       0-1
+           Namungo FC             v Ihefu FC               2-0
+  Fri Nov 24 2023
+           Azam FC                v Mtibwa Sugar FC        5-0
+           Dodoma Jiji FC         v Singida Big Stars FC   1-2
+  Tue Feb 6 2024
+           Tabora United FC       v Simba SC               0-4
+  Thu Feb 8 2024
+           Young Africans SC      v Mashujaa FC            2-1
+
+▪ Matchday 11
+  Sun Nov 26 2023
+           Geita Gold FC          v Namungo FC             1-0
+           JKT Tanzania FC        v Ihefu FC               1-1
+  Mon Nov 27 2023
+           Singida Big Stars FC   v Coastal Union FC       2-1
+  Wed Nov 29 2023
+           Tanzania Prisons FC    v Dodoma Jiji FC         1-0
+  Fri Dec 1 2023
+           Tabora United FC       v Mtibwa Sugar FC        2-1
+  Sat Dec 2 2023
+           KMC FC                 v Mashujaa FC            3-2
+  Fri Feb 2 2024
+           Kagera Sugar FC        v Young Africans SC      0-0
+  Fri Feb 9 2024
+           Simba SC               v Azam FC                1-1
+
+▪ Matchday 12
+  Thu Nov 30 2023
+           Coastal Union FC       v Geita Gold FC          3-1
+  Fri Dec 1 2023
+           Singida Big Stars FC   v JKT Tanzania FC        2-2
+  Sun Dec 3 2023
+           Namungo FC             v Dodoma Jiji FC         1-0
+  Mon Dec 4 2023
+           Ihefu FC               v Tanzania Prisons FC    0-0
+  Tue Dec 5 2023
+           Mashujaa FC            v Tabora United FC       1-1
+  Thu Dec 7 2023
+           Azam FC                v KMC FC                 5-0
+  Fri Dec 15 2023
+           Simba SC               v Kagera Sugar FC        3-0
+  Sat Dec 16 2023
+           Young Africans SC      v Mtibwa Sugar FC        4-1
+
+▪ Matchday 13
+  Thu Dec 7 2023
+           Namungo FC             v Mtibwa Sugar FC        1-0
+  Fri Dec 8 2023
+           Mashujaa FC            v Tanzania Prisons FC    0-2
+           Ihefu FC               v Tabora United FC       2-1
+  Sat Dec 9 2023
+           Coastal Union FC       v Kagera Sugar FC        1-0
+  Mon Dec 11 2023
+           Singida Big Stars FC   v KMC FC                 0-0
+           Azam FC                v JKT Tanzania FC        2-1
+  Mon Feb 5 2024
+           Young Africans SC      v Dodoma Jiji FC         1-0
+  Mon Feb 12 2024
+           Geita Gold FC          v Simba SC               0-1
+
+▪ Matchday 14
+  Mon Dec 18 2023
+           JKT Tanzania FC        v Coastal Union FC       0-1
+           Dodoma Jiji FC         v Ihefu FC               1-0
+  Tue Dec 19 2023
+           Mtibwa Sugar FC        v Mashujaa FC            2-1
+  Thu Dec 21 2023
+           Tanzania Prisons FC    v Namungo FC             1-0
+           Geita Gold FC          v Singida Big Stars FC   1-0
+           Kagera Sugar FC        v Azam FC                0-4
+  Sat Dec 23 2023
+           KMC FC                 v Simba SC               2-2
+           Tabora United FC       v Young Africans SC      0-1
+
+▪ Matchday 15
+  Sun Feb 11 2024
+           Tabora United FC       v Namungo FC             1-1
+           Tanzania Prisons FC    v Young Africans SC      1-2
+           Dodoma Jiji FC         v Mashujaa FC            1-1
+  Mon Feb 12 2024
+           Mtibwa Sugar FC        v Ihefu FC               2-3
+           Kagera Sugar FC        v Singida Big Stars FC   1-0
+           KMC FC                 v Coastal Union FC       0-0
+  Thu Feb 15 2024
+           JKT Tanzania FC        v Simba SC               0-1
+  Fri Feb 16 2024
+           Azam FC                v Geita Gold FC          2-1
+
+▪ Matchday 16
+  Thu Feb 15 2024
+           Tanzania Prisons FC    v Singida Big Stars FC   3-1
+           Coastal Union FC       v Dodoma Jiji FC         1-0
+  Fri Feb 16 2024
+           Kagera Sugar FC        v Mashujaa FC            1-1
+  Sat Feb 17 2024
+           KMC FC                 v Young Africans SC      0-3
+  Sun Feb 18 2024
+           JKT Tanzania FC        v Namungo FC             0-0
+  Mon Feb 19 2024
+           Geita Gold FC          v Ihefu FC               1-2
+           Tabora United FC       v Azam FC                0-0
+  Fri May 3 2024
+           Simba SC               v Mtibwa Sugar FC        2-0
+
+▪ Matchday 17
+  Sat Feb 24 2024
+           Coastal Union FC       v Mtibwa Sugar FC        1-0
+           KMC FC                 v Namungo FC             2-2
+  Sun Feb 25 2024
+           Tabora United FC       v Singida Big Stars FC   1-1
+           Tanzania Prisons FC    v Azam FC                1-1
+           Geita Gold FC          v Mashujaa FC            1-3
+           Kagera Sugar FC        v Ihefu FC               2-1
+  Wed Apr 24 2024
+           JKT Tanzania FC        v Young Africans SC      0-0
+  Fri May 17 2024
+           Dodoma Jiji FC         v Simba SC               0-1
+
+▪ Matchday 18
+  Tue Feb 27 2024
+           Mtibwa Sugar FC        v Dodoma Jiji FC         0-0
+           JKT Tanzania FC        v KMC FC                 1-1
+  Wed Feb 28 2024
+           Tanzania Prisons FC    v Tabora United FC       2-1
+           Ihefu FC               v Mashujaa FC            1-1
+           Singida Big Stars FC   v Azam FC                0-1
+           Geita Gold FC          v Kagera Sugar FC        0-0
+  Fri Mar 8 2024
+           Namungo FC             v Young Africans SC      1-3
+  Sat Mar 9 2024
+           Coastal Union FC       v Simba SC               1-2
+
+▪ Matchday 19
+  Sat Mar 2 2024
+           Singida Big Stars FC   v Mtibwa Sugar FC        0-2
+           Mashujaa FC            v Namungo FC             1-0
+           Kagera Sugar FC        v JKT Tanzania FC        1-1
+           KMC FC                 v Geita Gold FC          1-1
+  Sun Mar 3 2024
+           Tabora United FC       v Coastal Union FC       1-0
+           Azam FC                v Dodoma Jiji FC         4-1
+  Wed Mar 6 2024
+           Simba SC               v Tanzania Prisons FC    1-2
+  Mon Mar 11 2024
+           Young Africans SC      v Ihefu FC               5-0
+
+▪ Matchday 20
+  Tue Mar 5 2024
+           Ihefu FC               v KMC FC                 1-0
+           Namungo FC             v Kagera Sugar FC        1-0
+  Wed Mar 6 2024
+           Mashujaa FC            v JKT Tanzania FC        1-0
+           Azam FC                v Coastal Union FC       1-1
+           Dodoma Jiji FC         v Tabora United FC       1-0
+  Sat Mar 9 2024
+           Mtibwa Sugar FC        v Tanzania Prisons FC    2-1
+  Tue Mar 12 2024
+           Simba SC               v Singida Big Stars FC   3-1
+  Thu Mar 14 2024
+           Young Africans SC      v Geita Gold FC          1-0
+
+▪ Matchday 21
+  Sat Mar 9 2024
+           Dodoma Jiji FC         v Geita Gold FC          0-1
+  Sun Mar 10 2024
+           KMC FC                 v Tabora United FC       4-2
+  Wed Mar 13 2024
+           JKT Tanzania FC        v Tanzania Prisons FC    1-1
+           Kagera Sugar FC        v Mtibwa Sugar FC        0-0
+  Thu Mar 14 2024
+           Coastal Union FC       v Ihefu FC               1-0
+  Fri Mar 15 2024
+           Simba SC               v Mashujaa FC            2-0
+  Sat Mar 16 2024
+           Singida Big Stars FC   v Namungo FC             1-0
+  Sun Mar 17 2024
+           Azam FC                v Young Africans SC      2-1
+
+▪ Matchday 22
+  Fri Apr 12 2024
+           Tanzania Prisons FC    v KMC FC                 1-1
+           Mashujaa FC            v Coastal Union FC       1-2
+  Sat Apr 13 2024
+           Geita Gold FC          v Mtibwa Sugar FC        2-2
+           Ihefu FC               v Simba SC               1-1
+           Tabora United FC       v JKT Tanzania FC        1-1
+           Kagera Sugar FC        v Dodoma Jiji FC         1-1
+  Sun Apr 14 2024
+           Singida Big Stars FC   v Young Africans SC      0-3
+           Namungo FC             v Azam FC                0-2
+
+▪ Matchday 23
+  Tue Apr 16 2024
+           Mtibwa Sugar FC        v KMC FC                 0-1
+           Dodoma Jiji FC         v JKT Tanzania FC        0-0
+  Wed Apr 17 2024
+           Geita Gold FC          v Tanzania Prisons FC    0-0
+           Tabora United FC       v Kagera Sugar FC        0-3
+           Namungo FC             v Coastal Union FC       1-0
+           Azam FC                v Mashujaa FC            0-0
+  Thu Apr 18 2024
+           Ihefu FC               v Singida Big Stars FC   1-1
+  Sat Apr 20 2024
+           Young Africans SC      v Simba SC               2-1
+
+▪ Matchday 24
+  Sun Apr 21 2024
+           Tabora United FC       v Geita Gold FC          0-0
+           Singida Big Stars FC   v Mashujaa FC            0-0
+           Azam FC                v Ihefu FC               1-0
+  Mon Apr 22 2024
+           Tanzania Prisons FC    v Kagera Sugar FC        0-0
+  Fri Apr 26 2024
+           Dodoma Jiji FC         v KMC FC                 1-0
+  Sat Apr 27 2024
+           Young Africans SC      v Coastal Union FC       1-0
+  Mon Apr 29 2024
+           JKT Tanzania FC        v Mtibwa Sugar FC        2-1
+  Tue Apr 30 2024
+           Namungo FC             v Simba SC               2-2
+
+▪ Matchday 25
+  Sat May 4 2024
+           JKT Tanzania FC        v Geita Gold FC          2-0
+           Singida Big Stars FC   v Dodoma Jiji FC         2-0
+           KMC FC                 v Kagera Sugar FC        0-0
+  Sun May 5 2024
+           Mashujaa FC            v Young Africans SC      0-1
+  Mon May 6 2024
+           Ihefu FC               v Namungo FC             2-0
+           Mtibwa Sugar FC        v Azam FC                0-2
+           Simba SC               v Tabora United FC       2-0
+           Coastal Union FC       v Tanzania Prisons FC    0-0
+
+▪ Matchday 26
+  Wed May 8 2024
+           Mashujaa FC            v KMC FC                 3-0
+           Young Africans SC      v Kagera Sugar FC        1-0
+  Thu May 9 2024
+           Mtibwa Sugar FC        v Tabora United FC       3-0
+           Ihefu FC               v JKT Tanzania FC        0-0
+           Azam FC                v Simba SC               0-3
+  Fri May 10 2024
+           Namungo FC             v Geita Gold FC          2-0
+           Coastal Union FC       v Singida Big Stars FC   2-0
+           Dodoma Jiji FC         v Tanzania Prisons FC    0-0
+
+▪ Matchday 27
+  Sun May 12 2024
+           Tabora United FC       v Mashujaa FC            1-0
+           Kagera Sugar FC        v Simba SC               1-1
+           KMC FC                 v Azam FC                1-2
+  Mon May 13 2024
+           Tanzania Prisons FC    v Ihefu FC               0-1
+           Mtibwa Sugar FC        v Young Africans SC      1-3
+           JKT Tanzania FC        v Singida Big Stars FC   1-1
+  Tue May 14 2024
+           Geita Gold FC          v Coastal Union FC       0-0
+           Dodoma Jiji FC         v Namungo FC             0-0
+
+▪ Matchday 28
+  Thu May 16 2024
+           KMC FC                 v Singida Big Stars FC   1-0
+  Mon May 20 2024
+           Mtibwa Sugar FC        v Namungo FC             0-0
+           Tanzania Prisons FC    v Mashujaa FC            1-2
+  Tue May 21 2024
+           Kagera Sugar FC        v Coastal Union FC       1-2
+           JKT Tanzania FC        v Azam FC                0-2
+           Simba SC               v Geita Gold FC          4-1
+  Wed May 22 2024
+           Tabora United FC       v Ihefu FC               1-1
+           Dodoma Jiji FC         v Young Africans SC      0-4
+
+▪ Matchday 29
+  Sat May 25 2024
+           Azam FC                v Kagera Sugar FC        5-1
+           Coastal Union FC       v JKT Tanzania FC        0-0
+           Ihefu FC               v Dodoma Jiji FC         0-2
+           Mashujaa FC            v Mtibwa Sugar FC        3-2
+           Namungo FC             v Tanzania Prisons FC    2-2
+           Simba SC               v KMC FC                 1-0
+           Singida Big Stars FC   v Geita Gold FC          2-1
+           Young Africans SC      v Tabora United FC       3-0
+
+▪ Matchday 30
+  Tue May 28 2024
+           Coastal Union FC       v KMC FC                 0-0
+           Geita Gold FC          v Azam FC                0-2
+           Ihefu FC               v Mtibwa Sugar FC        5-1
+           Mashujaa FC            v Dodoma Jiji FC         3-0
+           Namungo FC             v Tabora United FC       3-2
+           Simba SC               v JKT Tanzania FC        2-0
+           Singida Big Stars FC   v Kagera Sugar FC        2-3
+           Young Africans SC      v Tanzania Prisons FC    4-1

--- a/africa/tanzania/2024-25_tz1.txt
+++ b/africa/tanzania/2024-25_tz1.txt
@@ -1,0 +1,440 @@
+= Tanzania | Premier League 2024/25
+
+# Date       Fri Aug 16 2024 - Wed Jun 25 2025 (313d)
+# Teams      16
+# Matches    240
+# Source     https://www.rsssf.org/tablest/tanz2025.html
+# Retrieved  2026-08-19
+
+
+▪ Matchday 1
+  Fri Aug 16 2024
+           Pamba Jiji FC              v Tanzania Prisons FC        0-0
+  Sat Aug 17 2024
+           Mashujaa FC                v Dodoma Jiji FC             1-0
+  Sun Aug 18 2024
+           KenGold FC                 v Singida Black Stars FC     1-3
+           Simba SC                   v Tabora United FC           3-0
+  Wed Aug 28 2024
+           JKT Tanzania FC            v Azam FC                    0-0
+  Thu Aug 29 2024
+           KMC FC                     v Coastal Union FC           1-1
+           Kagera Sugar FC            v Young Africans SC          0-2
+           Namungo FC                 v Singida Fountain Gate FC   0-2
+
+▪ Matchday 2
+  Fri Aug 23 2024
+           Mashujaa FC                v Tanzania Prisons FC        0-0
+  Sat Aug 24 2024
+           Pamba Jiji FC              v Dodoma Jiji FC             0-0
+           Kagera Sugar FC            v Singida Black Stars FC     0-1
+  Sun Aug 25 2024
+           Simba SC                   v Singida Fountain Gate FC   4-0
+           Namungo FC                 v Tabora United FC           1-2
+  Thu Sep 19 2024
+           KMC FC                     v Azam FC                    0-4
+  Wed Sep 25 2024
+           JKT Tanzania FC            v Coastal Union FC           2-1
+           KenGold FC                 v Young Africans SC          0-1
+
+▪ Matchday 3
+  Wed Sep 11 2024
+           Tabora United FC           v Kagera Sugar FC            1-0
+           Singida Fountain Gate FC   v KenGold FC                 2-1
+  Thu Sep 12 2024
+           Dodoma Jiji FC             v Namungo FC                 1-0
+           Singida Black Stars FC     v KMC FC                     2-1
+  Fri Sep 13 2024
+           Coastal Union FC           v Mashujaa FC                0-1
+  Sat Sep 14 2024
+           Azam FC                    v Pamba Jiji FC              0-0
+  Tue Oct 22 2024
+           Tanzania Prisons FC        v Simba SC                   0-1
+           Young Africans SC          v JKT Tanzania FC            2-0
+
+▪ Matchday 4
+  Sat Sep 14 2024
+           Tabora United FC           v Tanzania Prisons FC        0-0
+  Sun Sep 15 2024
+           Singida Fountain Gate FC   v Dodoma Jiji FC             2-2
+  Mon Sep 16 2024
+           KMC FC                     v KenGold FC                 1-0
+           Kagera Sugar FC            v JKT Tanzania FC            0-0
+  Tue Sep 17 2024
+           Pamba Jiji FC              v Singida Black Stars FC     0-1
+           Coastal Union FC           v Namungo FC                 0-2
+  Thu Sep 26 2024
+           Azam FC                    v Simba SC                   0-2
+  Thu Dec 19 2024
+           Young Africans SC          v Mashujaa FC                3-2
+
+▪ Matchday 5
+  Fri Sep 20 2024
+           Tabora United FC           v Singida Fountain Gate FC   1-3
+           Kagera Sugar FC            v KenGold FC                 2-0
+  Sat Sep 21 2024
+           Tanzania Prisons FC        v Dodoma Jiji FC             0-0
+           Pamba Jiji FC              v Mashujaa FC                2-2
+  Sun Sep 22 2024
+           JKT Tanzania FC            v KMC FC                     0-0
+           Azam FC                    v Coastal Union FC           1-0
+  Fri Oct 25 2024
+           Simba SC                   v Namungo FC                 3-0
+  Wed Oct 30 2024
+           Singida Black Stars FC     v Young Africans SC          0-1
+
+▪ Matchday 6
+  Fri Sep 27 2024
+           Singida Fountain Gate FC   v Kagera Sugar FC            3-1
+  Sat Sep 28 2024
+           KenGold FC                 v Tabora United FC           1-1
+           Coastal Union FC           v Pamba Jiji FC              2-0
+           Namungo FC                 v Tanzania Prisons FC        1-0
+  Sun Sep 29 2024
+           Singida Black Stars FC     v JKT Tanzania FC            1-1
+           Mashujaa FC                v Azam FC                    0-0
+           Dodoma Jiji FC             v Simba SC                   0-1
+           Young Africans SC          v KMC FC                     1-0
+
+▪ Matchday 7
+  Tue Oct 1 2024
+           Tanzania Prisons FC        v Singida Fountain Gate FC   3-2
+  Wed Oct 2 2024
+           Dodoma Jiji FC             v Tabora United FC           2-0
+  Thu Oct 3 2024
+           KMC FC                     v Kagera Sugar FC            1-0
+           Young Africans SC          v Pamba Jiji FC              4-0
+           Namungo FC                 v Azam FC                    0-1
+  Fri Oct 4 2024
+           KenGold FC                 v JKT Tanzania FC            1-0
+           Mashujaa FC                v Singida Black Stars FC     0-1
+           Simba SC                   v Coastal Union FC           2-2
+
+▪ Matchday 8
+  Fri Oct 18 2024
+           Coastal Union FC           v Dodoma Jiji FC             2-0
+           Tanzania Prisons FC        v Azam FC                    0-2
+           JKT Tanzania FC            v Tabora United FC           4-2
+  Sat Oct 19 2024
+           Simba SC                   v Young Africans SC          0-1
+  Sun Oct 20 2024
+           Pamba Jiji FC              v Kagera Sugar FC            1-1
+           Singida Black Stars FC     v Namungo FC                 2-0
+  Mon Oct 21 2024
+           Singida Fountain Gate FC   v KMC FC                     3-1
+           Mashujaa FC                v KenGold FC                 3-0
+
+▪ Matchday 9
+  Fri Oct 25 2024
+           Singida Black Stars FC     v Singida Fountain Gate FC   2-0
+           Azam FC                    v KenGold FC                 4-1
+  Sat Oct 26 2024
+           Tanzania Prisons FC        v KMC FC                     1-2
+           Dodoma Jiji FC             v JKT Tanzania FC            1-0
+  Mon Oct 28 2024
+           Namungo FC                 v Pamba Jiji FC              1-0
+  Tue Oct 29 2024
+           Coastal Union FC           v Kagera Sugar FC            1-0
+  Fri Nov 1 2024
+           Mashujaa FC                v Simba SC                   0-1
+  Thu Nov 7 2024
+           Young Africans SC          v Tabora United FC           1-3
+
+▪ Matchday 10
+  Wed Oct 23 2024
+           Tabora United FC           v Pamba Jiji FC              1-0
+  Sat Oct 26 2024
+           Coastal Union FC           v Young Africans SC          0-1
+  Mon Oct 28 2024
+           Singida Fountain Gate FC   v Mashujaa FC                2-2
+  Tue Oct 29 2024
+           KenGold FC                 v Dodoma Jiji FC             2-2
+  Thu Oct 31 2024
+           KMC FC                     v Namungo FC                 1-0
+  Thu Nov 28 2024
+           Azam FC                    v Singida Black Stars FC     2-1
+  Thu Dec 5 2024
+           Kagera Sugar FC            v Tanzania Prisons FC        0-0
+  Tue Dec 24 2024
+           Simba SC                   v JKT Tanzania FC            1-0
+
+▪ Matchday 11
+  Sat Nov 2 2024
+           Young Africans SC          v Azam FC                    0-1
+           Singida Black Stars FC     v Coastal Union FC           0-0
+  Sun Nov 3 2024
+           Tanzania Prisons FC        v KenGold FC                 1-0
+  Mon Nov 4 2024
+           Tabora United FC           v Mashujaa FC                1-0
+           Kagera Sugar FC            v Dodoma Jiji FC             2-1
+  Tue Nov 5 2024
+           Singida Fountain Gate FC   v Pamba Jiji FC              1-3
+  Wed Nov 6 2024
+           Simba SC                   v KMC FC                     4-0
+  Fri Dec 20 2024
+           Namungo FC                 v JKT Tanzania FC            0-0
+
+▪ Matchday 12
+  Fri Nov 22 2024
+           Pamba Jiji FC              v Simba SC                   0-1
+  Sat Nov 23 2024
+           KenGold FC                 v Coastal Union FC           1-1
+           Mashujaa FC                v Namungo FC                 1-0
+           Azam FC                    v Kagera Sugar FC            1-0
+  Sun Nov 24 2024
+           JKT Tanzania FC            v Tanzania Prisons FC        1-0
+           Dodoma Jiji FC             v KMC FC                     2-1
+  Mon Nov 25 2024
+           Tabora United FC           v Singida Black Stars FC     2-2
+  Sun Dec 29 2024
+           Young Africans SC          v Singida Fountain Gate FC   5-0
+
+▪ Matchday 13
+  Fri Nov 29 2024
+           KMC FC                     v Tabora United FC           0-2
+           Singida Fountain Gate FC   v JKT Tanzania FC            0-1
+  Sat Nov 30 2024
+           Mashujaa FC                v Kagera Sugar FC            1-1
+           Namungo FC                 v Young Africans SC          0-2
+  Sun Dec 1 2024
+           Pamba Jiji FC              v KenGold FC                 1-0
+           Dodoma Jiji FC             v Azam FC                    1-3
+  Mon Dec 2 2024
+           Coastal Union FC           v Tanzania Prisons FC        2-1
+  Sat Dec 28 2024
+           Singida Black Stars FC     v Simba SC                   0-1
+
+▪ Matchday 14
+  Wed Dec 11 2024
+           JKT Tanzania FC            v Pamba Jiji FC              0-0
+           Kagera Sugar FC            v Namungo FC                 1-1
+  Thu Dec 12 2024
+           Singida Black Stars FC     v Dodoma Jiji FC             2-1
+           KMC FC                     v Mashujaa FC                0-0
+  Fri Dec 13 2024
+           Singida Fountain Gate FC   v Coastal Union FC           3-2
+           Tabora United FC           v Azam FC                    2-1
+  Wed Dec 18 2024
+           Simba SC                   v KenGold FC                 2-0
+  Sun Dec 22 2024
+           Young Africans SC          v Tanzania Prisons FC        4-0
+
+▪ Matchday 15
+  Sun Dec 15 2024
+           KenGold FC                 v Namungo FC                 2-3
+           JKT Tanzania FC            v Mashujaa FC                0-0
+  Mon Dec 16 2024
+           Tanzania Prisons FC        v Singida Black Stars FC     0-2
+           KMC FC                     v Pamba Jiji FC              1-0
+  Tue Dec 17 2024
+           Tabora United FC           v Coastal Union FC           1-1
+           Azam FC                    v Singida Fountain Gate FC   2-0
+  Sat Dec 21 2024
+           Kagera Sugar FC            v Simba SC                   2-5
+  Wed Dec 25 2024
+           Dodoma Jiji FC             v Young Africans SC          0-4
+
+▪ Matchday 16
+  Tue Dec 24 2024
+           Singida Black Stars FC     v KenGold FC                 2-1
+  Wed Dec 25 2024
+           Singida Fountain Gate FC   v Namungo FC                 1-2
+  Thu Dec 26 2024
+           Tanzania Prisons FC        v Pamba Jiji FC              1-0
+  Fri Dec 27 2024
+           Azam FC                    v JKT Tanzania FC            3-1
+  Sat Dec 28 2024
+           Dodoma Jiji FC             v Mashujaa FC                3-1
+  Sun Dec 29 2024
+           Coastal Union FC           v KMC FC                     1-1
+  Sat Feb 1 2025
+           Young Africans SC          v Kagera Sugar FC            4-0
+  Sun Feb 2 2025
+           Tabora United FC           v Simba SC                   0-3
+
+▪ Matchday 17
+  Wed Feb 5 2025
+           Tabora United FC           v Namungo FC                 2-1
+           Young Africans SC          v KenGold FC                 6-1
+  Thu Feb 6 2025
+           Dodoma Jiji FC             v Pamba Jiji FC              0-1
+           Tanzania Prisons FC        v Mashujaa FC                2-1
+           Singida Fountain Gate FC   v Simba SC                   1-1
+           Azam FC                    v KMC FC                     2-0
+  Fri Feb 7 2025
+           Coastal Union FC           v JKT Tanzania FC            2-1
+           Singida Black Stars FC     v Kagera Sugar FC            2-2
+
+▪ Matchday 18
+  Sun Feb 9 2025
+           Pamba Jiji FC              v Azam FC                    1-0
+           Namungo FC                 v Dodoma Jiji FC             2-2
+  Mon Feb 10 2025
+           KenGold FC                 v Singida Fountain Gate FC   2-0
+           KMC FC                     v Singida Black Stars FC     2-0
+           JKT Tanzania FC            v Young Africans SC          0-0
+  Tue Feb 11 2025
+           Mashujaa FC                v Coastal Union FC           0-0
+           Simba SC                   v Tanzania Prisons FC        3-0
+           Kagera Sugar FC            v Tabora United FC           1-2
+
+▪ Matchday 19
+  Thu Feb 13 2025
+           JKT Tanzania FC            v Singida Black Stars FC     0-1
+  Fri Feb 14 2025
+           Tabora United FC           v KenGold FC                 1-1
+           KMC FC                     v Young Africans SC          1-6
+           Tanzania Prisons FC        v Namungo FC                 0-1
+           Kagera Sugar FC            v Singida Fountain Gate FC   3-0
+  Sat Feb 15 2025
+           Pamba Jiji FC              v Coastal Union FC           2-0
+           Azam FC                    v Mashujaa FC                2-0
+  Fri Mar 14 2025
+           Simba SC                   v Dodoma Jiji FC             6-0
+
+▪ Matchday 20
+  Mon Feb 17 2025
+           Young Africans SC          v Singida Black Stars FC     2-1
+           Singida Fountain Gate FC   v Tabora United FC           0-0
+  Tue Feb 18 2025
+           KMC FC                     v JKT Tanzania FC            0-2
+           KenGold FC                 v Kagera Sugar FC            1-0
+           Dodoma Jiji FC             v Tanzania Prisons FC        3-2
+  Wed Feb 19 2025
+           Coastal Union FC           v Azam FC                    0-0
+           Mashujaa FC                v Pamba Jiji FC              2-0
+           Namungo FC                 v Simba SC                   0-3
+
+▪ Matchday 21
+  Fri Feb 21 2025
+           Tanzania Prisons FC        v Tabora United FC           1-1
+           JKT Tanzania FC            v Kagera Sugar FC            2-0
+  Sat Feb 22 2025
+           KenGold FC                 v KMC FC                     1-1
+           Dodoma Jiji FC             v Singida Fountain Gate FC   1-0
+  Sun Feb 23 2025
+           Singida Black Stars FC     v Pamba Jiji FC              2-2
+           Mashujaa FC                v Young Africans SC          0-5
+           Namungo FC                 v Coastal Union FC           0-0
+  Mon Feb 24 2025
+           Simba SC                   v Azam FC                    2-2
+
+▪ Matchday 22
+  Wed Feb 26 2025
+           Singida Fountain Gate FC   v Tanzania Prisons FC        1-0
+           Singida Black Stars FC     v Mashujaa FC                3-0
+           Kagera Sugar FC            v KMC FC                     0-0
+  Thu Feb 27 2025
+           JKT Tanzania FC            v KenGold FC                 1-1
+           Azam FC                    v Namungo FC                 1-1
+  Fri Feb 28 2025
+           Tabora United FC           v Dodoma Jiji FC             1-0
+           Pamba Jiji FC              v Young Africans SC          0-3
+  Sat Mar 1 2025
+           Coastal Union FC           v Simba SC                   0-3
+
+▪ Matchday 23
+  Wed Mar 5 2025
+           KenGold FC                 v Mashujaa FC                2-2
+  Thu Mar 6 2025
+           KMC FC                     v Singida Fountain Gate FC   1-2
+           Namungo FC                 v Singida Black Stars FC     0-1
+           Azam FC                    v Tanzania Prisons FC        4-0
+  Fri Mar 7 2025
+           Tabora United FC           v JKT Tanzania FC            1-2
+           Kagera Sugar FC            v Pamba Jiji FC              2-1
+           Dodoma Jiji FC             v Coastal Union FC           0-0
+  Wed Jun 25 2025
+           Young Africans SC          v Simba SC                   2-0
+
+▪ Matchday 24
+  Wed Apr 2 2025
+           Pamba Jiji FC              v Namungo FC                 1-1
+           Tabora United FC           v Young Africans SC          0-3
+           Singida Fountain Gate FC   v Singida Black Stars FC     0-3
+           KMC FC                     v Tanzania Prisons FC        3-2
+  Thu Apr 3 2025
+           JKT Tanzania FC            v Dodoma Jiji FC             2-2
+           KenGold FC                 v Azam FC                    0-2
+           Kagera Sugar FC            v Coastal Union FC           2-1
+  Fri May 2 2025
+           Simba SC                   v Mashujaa FC                2-1
+
+▪ Matchday 25
+  Sat Apr 5 2025
+           Pamba Jiji FC              v Tabora United FC           1-0
+           Mashujaa FC                v Singida Fountain Gate FC   3-0
+  Sun Apr 6 2025
+           Tanzania Prisons FC        v Kagera Sugar FC            1-0
+           Singida Black Stars FC     v Azam FC                    1-0
+           Dodoma Jiji FC             v KenGold FC                 3-0
+           Namungo FC                 v KMC FC                     2-1
+  Mon Apr 7 2025
+           Young Africans SC          v Coastal Union FC           1-0
+  Mon May 5 2025
+           JKT Tanzania FC            v Simba SC                   0-1
+
+▪ Matchday 26
+  Tue Apr 8 2025
+           Pamba Jiji FC              v Singida Fountain Gate FC   1-1
+  Wed Apr 9 2025
+           KenGold FC                 v Tanzania Prisons FC        1-3
+           Dodoma Jiji FC             v Kagera Sugar FC            2-0
+  Thu Apr 10 2025
+           JKT Tanzania FC            v Namungo FC                 2-2
+           Mashujaa FC                v Tabora United FC           3-0
+           Coastal Union FC           v Singida Black Stars FC     2-1
+           Azam FC                    v Young Africans SC          1-2
+  Sun May 11 2025
+           KMC FC                     v Simba SC                   1-2
+
+▪ Matchday 27
+  Fri Apr 18 2025
+           KMC FC                     v Dodoma Jiji FC             2-1
+           Tanzania Prisons FC        v JKT Tanzania FC            3-2
+  Sat Apr 19 2025
+           Singida Black Stars FC     v Tabora United FC           3-0
+           Kagera Sugar FC            v Azam FC                    2-4
+  Sun Apr 20 2025
+           Namungo FC                 v Mashujaa FC                2-1
+  Mon Apr 21 2025
+           Singida Fountain Gate FC   v Young Africans SC          0-4
+           Coastal Union FC           v KenGold FC                 2-1
+  Thu May 8 2025
+           Simba SC                   v Pamba Jiji FC              5-1
+
+▪ Matchday 28
+  Mon May 12 2025
+           Tanzania Prisons FC        v Coastal Union FC           2-1
+           Kagera Sugar FC            v Mashujaa FC                0-1
+  Tue May 13 2025
+           JKT Tanzania FC            v Singida Fountain Gate FC   3-1
+           KenGold FC                 v Pamba Jiji FC              0-2
+           Young Africans SC          v Namungo FC                 3-0
+           Azam FC                    v Dodoma Jiji FC             5-0
+  Wed May 14 2025
+           Tabora United FC           v KMC FC                     0-1
+  Wed May 28 2025
+           Simba SC                   v Singida Black Stars FC     1-0
+
+▪ Matchday 29
+  Wed Jun 18 2025
+           Azam FC                    v Tabora United FC           5-0
+           Coastal Union FC           v Singida Fountain Gate FC   1-0
+           Dodoma Jiji FC             v Singida Black Stars FC     1-2
+           KenGold FC                 v Simba SC                   0-5
+           Mashujaa FC                v KMC FC                     1-1
+           Namungo FC                 v Kagera Sugar FC            0-0
+           Pamba Jiji FC              v JKT Tanzania FC            1-0
+           Tanzania Prisons FC        v Young Africans SC          0-5
+
+▪ Matchday 30
+  Sun Jun 22 2025
+           Coastal Union FC           v Tabora United FC           1-1
+           Mashujaa FC                v JKT Tanzania FC            0-0
+           Namungo FC                 v KenGold FC                 5-0
+           Pamba Jiji FC              v KMC FC                     1-1
+           Simba SC                   v Kagera Sugar FC            1-0
+           Singida Black Stars FC     v Tanzania Prisons FC        3-3
+           Singida Fountain Gate FC   v Azam FC                    2-3
+           Young Africans SC          v Dodoma Jiji FC             5-0

--- a/africa/tanzania/2025-26_tz1.txt
+++ b/africa/tanzania/2025-26_tz1.txt
@@ -1,0 +1,444 @@
+= Tanzania | Premier League 2025/26
+
+# Date       Wed Sep 17 2025 - Tue Jun 30 2026 (286d)
+# Teams      16
+# Matches    240
+# Source     https://www.rsssf.org/tablest/tanz2026.html
+# Retrieved  2026-08-19
+
+
+▪ Matchday 1
+  Wed Sep 17 2025
+           KMC FC                     v Dodoma Jiji FC             1-0
+           Coastal Union FC           v Tanzania Prisons FC        1-0
+  Thu Sep 18 2025
+           Singida Fountain Gate FC   v Mbeya City FC              0-1
+           Mashujaa FC                v JKT Tanzania FC            1-1
+           Namungo FC                 v Pamba Jiji FC              1-1
+  Tue Oct 28 2025
+           Young Africans SC          v Mtibwa Sugar FC            2-0
+  Wed Dec 3 2025
+           Azam FC                    v Singida Black Stars FC     0-0
+  Thu Apr 9 2026
+           TRA United SC              v Simba SC                   0-0
+
+▪ Matchday 2
+  Sat Sep 20 2025
+           TRA United SC              v Dodoma Jiji FC             2-2
+  Sun Sep 21 2025
+           Mashujaa FC                v Mtibwa Sugar FC            1-0
+           Namungo FC                 v Tanzania Prisons FC        1-0
+  Mon Sep 22 2025
+           Coastal Union FC           v JKT Tanzania FC            1-2
+  Tue Sep 23 2025
+           KMC FC                     v Singida Black Stars FC     0-1
+  Wed Sep 24 2025
+           Young Africans SC          v Pamba Jiji FC              3-0
+           Azam FC                    v Mbeya City FC              2-0
+  Thu Sep 25 2025
+           Simba SC                   v Singida Fountain Gate FC   3-0
+
+▪ Matchday 3
+  Sat Sep 27 2025
+           Tanzania Prisons FC        v KMC FC                     1-0
+           Dodoma Jiji FC             v Coastal Union FC           2-0
+  Sun Sep 28 2025
+           Pamba Jiji FC              v TRA United SC              0-0
+           Mtibwa Sugar FC            v Singida Fountain Gate FC   2-0
+  Tue Sep 30 2025
+           Singida Black Stars FC     v Mashujaa FC                1-0
+           Mbeya City FC              v Young Africans SC          0-0
+  Wed Oct 1 2025
+           JKT Tanzania FC            v Azam FC                    1-1
+           Simba SC                   v Namungo FC                 3-0
+
+▪ Matchday 4
+  Fri Oct 17 2025
+           Pamba Jiji FC              v Mashujaa FC                2-1
+           Singida Fountain Gate FC   v Dodoma Jiji FC             1-0
+  Sat Oct 18 2025
+           KMC FC                     v Mbeya City FC              0-3
+  Sun Oct 19 2025
+           Mtibwa Sugar FC            v Coastal Union FC           0-0
+           JKT Tanzania FC            v Namungo FC                 1-1
+  Sat Dec 6 2025
+           Singida Black Stars FC     v TRA United SC              1-3
+  Sun Dec 7 2025
+           Simba SC                   v Azam FC                    0-2
+  Thu Mar 12 2026
+           Tanzania Prisons FC        v Young Africans SC          0-1
+
+▪ Matchday 5
+  Tue Oct 21 2025
+           Mbeya City FC              v Tanzania Prisons FC        1-2
+  Wed Oct 22 2025
+           TRA United SC              v Mashujaa FC                0-0
+           Coastal Union FC           v Singida Fountain Gate FC   1-1
+           Dodoma Jiji FC             v Mtibwa Sugar FC            0-0
+  Sat Nov 8 2025
+           Pamba Jiji FC              v Singida Black Stars FC     1-1
+           JKT Tanzania FC            v Simba SC                   1-2
+  Sun Nov 9 2025
+           Young Africans SC          v KMC FC                     4-1
+           Namungo FC                 v Azam FC                    1-1
+
+▪ Matchday 6
+  Fri Oct 24 2025
+           Mbeya City FC              v JKT Tanzania FC            2-2
+  Sat Oct 25 2025
+           Mashujaa FC                v Namungo FC                 1-0
+           Singida Fountain Gate FC   v KMC FC                     1-0
+           Dodoma Jiji FC             v Pamba Jiji FC              0-3 [awarded]
+  Sun Dec 7 2025
+           Coastal Union FC           v Young Africans SC          0-1
+  Thu Jan 29 2026
+           Azam FC                    v TRA United SC              2-0
+  Sun Feb 22 2026
+           Mtibwa Sugar FC            v Singida Black Stars FC     1-3
+           Tanzania Prisons FC        v Simba SC                   0-2
+
+▪ Matchday 7
+  Fri Nov 21 2025
+           KMC FC                     v JKT Tanzania FC            0-1
+           Namungo FC                 v Dodoma Jiji FC             2-0
+  Sat Nov 22 2025
+           TRA United SC              v Tanzania Prisons FC        1-0
+           Mashujaa FC                v Mbeya City FC              1-0
+  Sun Nov 23 2025
+           Pamba Jiji FC              v Singida Fountain Gate FC   1-0
+  Wed Feb 25 2026
+           Azam FC                    v Mtibwa Sugar FC            3-0
+  Sun Mar 1 2026
+           Young Africans SC          v Simba SC                   0-0
+  Mon Mar 2 2026
+           Singida Black Stars FC     v Coastal Union FC           1-0
+
+▪ Matchday 8
+  Tue Nov 25 2025
+           KMC FC                     v Mtibwa Sugar FC            0-0
+  Wed Nov 26 2025
+           Coastal Union FC           v Mbeya City FC              2-0
+           Singida Fountain Gate FC   v Tanzania Prisons FC        1-0
+           JKT Tanzania FC            v TRA United SC              1-0
+  Tue Jan 27 2026
+           Young Africans SC          v Dodoma Jiji FC             3-1
+  Thu Jan 29 2026
+           Simba SC                   v Mashujaa FC                2-0
+  Thu Feb 26 2026
+           Namungo FC                 v Singida Black Stars FC     1-1
+  Mon Mar 2 2026
+           Pamba Jiji FC              v Azam FC                    2-2
+
+▪ Matchday 9
+  Fri Nov 28 2025
+           Mashujaa FC                v Dodoma Jiji FC             0-0
+  Sat Nov 29 2025
+           Pamba Jiji FC              v KMC FC                     3-0
+           Mtibwa Sugar FC            v TRA United SC              2-1
+  Sun Nov 30 2025
+           Mbeya City FC              v Namungo FC                 0-1
+           Singida Fountain Gate FC   v JKT Tanzania FC            0-2
+  Thu Mar 5 2026
+           Tanzania Prisons FC        v Azam FC                    0-0
+           Singida Black Stars FC     v Young Africans SC          0-3
+  Thu Apr 2 2026
+           Simba SC                   v Coastal Union FC           2-0
+
+▪ Matchday 10
+  Mon Dec 1 2025
+           Mashujaa FC                v Coastal Union FC           0-0
+  Wed Dec 3 2025
+           JKT Tanzania FC            v Mtibwa Sugar FC            0-0
+  Sat Dec 6 2025
+           Tanzania Prisons FC        v Pamba Jiji FC              0-0
+  Sun Feb 22 2026
+           KMC FC                     v Azam FC                    0-2
+           Namungo FC                 v Young Africans SC          0-1
+  Wed Feb 25 2026
+           Dodoma Jiji FC             v Simba SC                   0-0
+  Thu Feb 26 2026
+           Singida Fountain Gate FC   v TRA United SC              1-4
+  Sun Mar 15 2026
+           Mbeya City FC              v Singida Black Stars FC     1-4
+
+▪ Matchday 11
+  Mon Jan 19 2026
+           Young Africans SC          v Mashujaa FC                6-0
+  Tue Jan 20 2026
+           Azam FC                    v Singida Fountain Gate FC   0-0
+           Singida Black Stars FC     v JKT Tanzania FC            0-1
+  Wed Jan 21 2026
+           Mtibwa Sugar FC            v Mbeya City FC              2-1
+  Thu Jan 22 2026
+           Dodoma Jiji FC             v Tanzania Prisons FC        1-0
+  Fri Jan 23 2026
+           TRA United SC              v KMC FC                     3-0
+           Namungo FC                 v Coastal Union FC           1-0
+  Thu Mar 19 2026
+           Pamba Jiji FC              v Simba SC                   1-1
+
+▪ Matchday 12
+  Thu Dec 4 2025
+           Young Africans SC          v Singida Fountain Gate FC   2-0
+           Simba SC                   v Mbeya City FC              3-0
+  Fri Jan 16 2026
+           Dodoma Jiji FC             v Singida Black Stars FC     1-1
+  Sun Jan 25 2026
+           Tanzania Prisons FC        v JKT Tanzania FC            0-0
+           Mtibwa Sugar FC            v Pamba Jiji FC              1-0
+  Tue Jan 27 2026
+           Coastal Union FC           v KMC FC                     1-1
+  Wed Mar 11 2026
+           TRA United SC              v Namungo FC                 2-0
+  Thu Mar 19 2026
+           Mashujaa FC                v Azam FC                    0-0
+
+▪ Matchday 13
+  Sun Jan 18 2026
+           Simba SC                   v Mtibwa Sugar FC            1-1
+  Fri Jan 30 2026
+           Mbeya City FC              v Pamba Jiji FC              1-1
+           JKT Tanzania FC            v Dodoma Jiji FC             0-1
+  Sat Jan 31 2026
+           Namungo FC                 v KMC FC                     1-0
+  Sun Feb 1 2026
+           Coastal Union FC           v TRA United SC              1-1
+  Fri Mar 13 2026
+           Mashujaa FC                v Singida Fountain Gate FC   1-1
+  Sun Mar 15 2026
+           Azam FC                    v Young Africans SC          0-0
+  Wed Mar 18 2026
+           Tanzania Prisons FC        v Singida Black Stars FC     1-2
+
+▪ Matchday 14
+  Sat Jan 17 2026
+           Azam FC                    v Coastal Union FC           3-0
+  Mon Feb 2 2026
+           Mtibwa Sugar FC            v Tanzania Prisons FC        2-1
+           JKT Tanzania FC            v Pamba Jiji FC              3-0
+  Tue Feb 3 2026
+           Mbeya City FC              v Dodoma Jiji FC             1-1
+           KMC FC                     v Mashujaa FC                1-0
+  Wed Feb 4 2026
+           Singida Fountain Gate FC   v Namungo FC                 1-1
+  Wed Mar 11 2026
+           Singida Black Stars FC     v Simba SC                   1-2
+  Wed Mar 18 2026
+           TRA United SC              v Young Africans SC          0-0
+
+▪ Matchday 15
+  Fri Feb 6 2026
+           Pamba Jiji FC              v Coastal Union FC           3-0
+           Tanzania Prisons FC        v Mashujaa FC                0-0
+  Sat Feb 7 2026
+           TRA United SC              v Mbeya City FC              0-2
+           Mtibwa Sugar FC            v Namungo FC                 1-1
+  Wed Feb 11 2026
+           Singida Black Stars FC     v Singida Fountain Gate FC   1-0
+           KMC FC                     v Simba SC                   0-2
+  Wed Feb 25 2026
+           Young Africans SC          v JKT Tanzania FC            5-0
+  Wed Mar 11 2026
+           Dodoma Jiji FC             v Azam FC                    0-3
+
+▪ Matchday 16
+  Sun Feb 8 2026
+           Dodoma Jiji FC             v KMC FC                     2-1
+  Mon Feb 9 2026
+           JKT Tanzania FC            v Mashujaa FC                1-0
+  Tue Feb 10 2026
+           Tanzania Prisons FC        v Coastal Union FC           1-4
+           Pamba Jiji FC              v Namungo FC                 1-0
+  Tue Mar 3 2026
+           Mbeya City FC              v Singida Fountain Gate FC   0-1
+  Sat Mar 21 2026
+           Mtibwa Sugar FC            v Young Africans SC          1-1
+  Sun Mar 22 2026
+           Simba SC                   v TRA United SC              3-0
+  Wed Apr 1 2026
+           Singida Black Stars FC     v Azam FC                    1-2
+
+▪ Matchday 17
+  Thu Feb 12 2026
+           Dodoma Jiji FC             v TRA United SC              3-0
+  Fri Feb 13 2026
+           JKT Tanzania FC            v Coastal Union FC           1-1
+           Mtibwa Sugar FC            v Mashujaa FC                1-3
+  Sat Feb 14 2026
+           Tanzania Prisons FC        v Namungo FC                 3-2
+  Wed Apr 8 2026
+           Singida Black Stars FC     v KMC FC                     1-0
+           Pamba Jiji FC              v Young Africans SC          0-3
+  Thu Apr 9 2026
+           Mbeya City FC              v Azam FC                    0-0
+  Wed Apr 15 2026
+           Singida Fountain Gate FC   v Simba SC                   0-3
+
+▪ Matchday 18
+  Fri Apr 3 2026
+           Dodoma Jiji FC             v Singida Fountain Gate FC   3-0
+           Mbeya City FC              v KMC FC                     3-2
+  Sat Apr 4 2026
+           Mashujaa FC                v Pamba Jiji FC              0-0
+           Young Africans SC          v Tanzania Prisons FC        3-0
+           Namungo FC                 v JKT Tanzania FC            2-2
+  Sun Apr 5 2026
+           TRA United SC              v Singida Black Stars FC     2-0
+           Azam FC                    v Simba SC                   0-0
+  Mon Apr 6 2026
+           Coastal Union FC           v Mtibwa Sugar FC            1-1
+
+▪ Matchday 19
+  Tue Apr 14 2026
+           KMC FC                     v Tanzania Prisons FC        1-1
+  Wed Apr 15 2026
+           Coastal Union FC           v Dodoma Jiji FC             3-1
+  Thu Apr 16 2026
+           Mashujaa FC                v Singida Black Stars FC     1-1
+           Young Africans SC          v Mbeya City FC              6-0
+  Fri Apr 17 2026
+           TRA United SC              v Pamba Jiji FC              1-0
+           Azam FC                    v JKT Tanzania FC            3-0
+  Sat Apr 18 2026
+           Singida Fountain Gate FC   v Mtibwa Sugar FC            2-1
+  Sun Apr 19 2026
+           Namungo FC                 v Simba SC                   1-3
+
+▪ Matchday 20
+  Mon May 4 2026
+           Mashujaa FC                v TRA United SC              1-0
+           Tanzania Prisons FC        v Mbeya City FC              1-2
+  Tue May 5 2026
+           Singida Black Stars FC     v Pamba Jiji FC              3-1
+           Singida Fountain Gate FC   v Coastal Union FC           3-2
+           Azam FC                    v Namungo FC                 1-0
+  Wed May 6 2026
+           KMC FC                     v Young Africans SC          0-1
+           Simba SC                   v JKT Tanzania FC            1-0
+           Mtibwa Sugar FC            v Dodoma Jiji FC             0-1
+
+▪ Matchday 21
+  Fri May 8 2026
+           TRA United SC              v Azam FC                    4-1
+           Namungo FC                 v Mashujaa FC                0-0
+  Sat May 9 2026
+           Singida Black Stars FC     v Mtibwa Sugar FC            4-0
+           Young Africans SC          v Coastal Union FC           3-0
+           JKT Tanzania FC            v Mbeya City FC              1-0
+  Sun May 10 2026
+           KMC FC                     v Singida Fountain Gate FC   2-3
+           Pamba Jiji FC              v Dodoma Jiji FC             0-0
+           Simba SC                   v Tanzania Prisons FC        4-0
+
+▪ Matchday 22
+  Thu Apr 30 2026
+           Singida Fountain Gate FC   v Pamba Jiji FC              1-2
+           Mbeya City FC              v Mashujaa FC                0-0
+           JKT Tanzania FC            v KMC FC                     1-0
+  Fri May 1 2026
+           Tanzania Prisons FC        v TRA United SC              0-3
+           Dodoma Jiji FC             v Namungo FC                 0-0
+  Sat May 2 2026
+           Mtibwa Sugar FC            v Azam FC                    0-3
+           Coastal Union FC           v Singida Black Stars FC     2-1
+  Sun May 3 2026
+           Simba SC                   v Young Africans SC          2-2
+
+▪ Matchday 23
+  Tue May 12 2026
+           Singida Black Stars FC     v Namungo FC                 1-0
+           TRA United SC              v JKT Tanzania FC            1-1
+  Wed May 13 2026
+           Mbeya City FC              v Coastal Union FC           0-2
+           Dodoma Jiji FC             v Young Africans SC          3-2
+  Thu May 14 2026
+           Tanzania Prisons FC        v Singida Fountain Gate FC   1-0
+           Mtibwa Sugar FC            v KMC FC                     4-3
+           Mashujaa FC                v Simba SC                   0-3
+           Azam FC                    v Pamba Jiji FC              2-0
+
+▪ Matchday 24
+  Wed May 20 2026
+           TRA United SC              v Mtibwa Sugar FC            2-1
+           KMC FC                     v Pamba Jiji FC              0-1
+           Dodoma Jiji FC             v Mashujaa FC                1-1
+  Thu May 21 2026
+           JKT Tanzania FC            v Singida Fountain Gate FC   2-2
+           Coastal Union FC           v Simba SC                   1-2
+           Namungo FC                 v Mbeya City FC              1-1
+  Fri May 22 2026
+           Young Africans SC          v Singida Black Stars FC     3-0
+           Azam FC                    v Tanzania Prisons FC        2-0
+
+▪ Matchday 25
+  Sun May 24 2026
+           Mtibwa Sugar FC            v JKT Tanzania FC            2-2
+           TRA United SC              v Singida Fountain Gate FC   1-2
+           Simba SC                   v Dodoma Jiji FC             1-0
+           Coastal Union FC           v Mashujaa FC                1-0
+  Mon May 25 2026
+           Young Africans SC          v Namungo FC                 3-1
+           Azam FC                    v KMC FC                     3-0
+  Tue May 26 2026
+           Pamba Jiji FC              v Tanzania Prisons FC        2-3
+           Singida Black Stars FC     v Mbeya City FC              4-1
+
+▪ Matchday 26
+  Fri Jun 12 2026
+           Singida Fountain Gate FC   v Azam FC                    0-2
+           Coastal Union FC           v Namungo FC                 1-1
+           KMC FC                     v TRA United SC              0-1
+  Sat Jun 13 2026
+           Mbeya City FC              v Mtibwa Sugar FC            1-0
+           Mashujaa FC                v Young Africans SC          0-2
+           JKT Tanzania FC            v Singida Black Stars FC     1-2
+  Sun Jun 14 2026
+           Simba SC                   v Pamba Jiji FC              2-1
+           Tanzania Prisons FC        v Dodoma Jiji FC             3-1
+
+▪ Matchday 27
+  Mon Jun 15 2026
+           KMC FC                     v Coastal Union FC           1-3
+  Tue Jun 16 2026
+           Namungo FC                 v TRA United SC              0-0
+           Azam FC                    v Mashujaa FC                2-0
+  Wed Jun 17 2026
+           Mbeya City FC              v Simba SC                   0-1
+           Singida Black Stars FC     v Dodoma Jiji FC             5-0
+  Thu Jun 18 2026
+           Singida Fountain Gate FC   v Young Africans SC          0-2
+           JKT Tanzania FC            v Tanzania Prisons FC        0-1
+           Pamba Jiji FC              v Mtibwa Sugar FC            4-0
+
+▪ Matchday 28
+  Wed Jun 24 2026
+           Dodoma Jiji FC             v JKT Tanzania FC            0-0
+           KMC FC                     v Namungo FC                 2-3
+           Mtibwa Sugar FC            v Simba SC                   0-3
+           Pamba Jiji FC              v Mbeya City FC              0-2
+           Singida Black Stars FC     v Tanzania Prisons FC        3-1
+           Singida Fountain Gate FC   v Mashujaa FC                0-1
+           TRA United SC              v Coastal Union FC           1-1
+           Young Africans SC          v Azam FC                    3-0
+
+▪ Matchday 29
+  Sat Jun 27 2026
+           Coastal Union FC           v Azam FC                    0-2
+           Dodoma Jiji FC             v Mbeya City FC              1-1
+           Mashujaa FC                v KMC FC                     2-0
+           Namungo FC                 v Singida Fountain Gate FC   0-0
+           Pamba Jiji FC              v JKT Tanzania FC            1-2
+           Simba SC                   v Singida Black Stars FC     2-0
+           Tanzania Prisons FC        v Mtibwa Sugar FC            2-1
+           Young Africans SC          v TRA United SC              3-0
+
+▪ Matchday 30
+  Tue Jun 30 2026
+           Azam FC                    v Dodoma Jiji FC             2-0
+           Coastal Union FC           v Pamba Jiji FC              2-1
+           JKT Tanzania FC            v Young Africans SC          0-3
+           Mashujaa FC                v Tanzania Prisons FC        0-1
+           Mbeya City FC              v TRA United SC              0-0
+           Namungo FC                 v Mtibwa Sugar FC            2-1
+           Simba SC                   v KMC FC                     1-0
+           Singida Fountain Gate FC   v Singida Black Stars FC     4-3


### PR DESCRIPTION
Adds completed Tanzania Premier League seasons for 2023/24, 2024/25, and 2025/26.\n\nEach season contains the complete 16-team, double round-robin schedule (240 matches) and has been validated locally.