### PR TITLE
Add Nigeria Premier Football League season 2025-2026

### DIFF
--- a/africa/nigeria/2025-26_ng1.txt
+++ b/africa/nigeria/2025-26_ng1.txt
@@ -1,0 +1,570 @@
+= Nigeria Professional League 2025/2026
+
+# Date       Fri Aug 22 2025 - Sun May 24 2026 (275d)
+# Teams      20
+# Matches    380
+# Source     https://www.rsssf.org/tablesn/nig2026.html
+# Retrieved  2026-08-21
+
+
+▪ Matchday 1
+  Fri Aug 22 2025
+           Remo Stars FC              v Rivers United FC           1-1
+  Sun Aug 24 2025
+           El-Kanemi Warriors FC      v Bendel FC                  2-0
+           Shooting Stars SC          v Bayelsa United FC          0-1
+           Abia Warriors FC           v Kano Pillars FC            1-0
+           Wikki Tourists FC          v Plateau United FC          1-0
+           Kwara United FC            v Ikorodu City FC            0-0
+           Rangers International FC   v Kun Khalifat FC            0-0
+           Katsina United FC          v Warri Wolves FC            0-1
+           Barau FC                   v Enyimba FC                 0-0
+  Wed Aug 27 2025
+           Niger Tornadoes FC         v Nasarawa United FC         1-0
+
+▪ Matchday 2
+  Sat Aug 30 2025
+           Bendel FC                  v Shooting Stars SC          1-1
+  Sun Aug 31 2025
+           Kano Pillars FC            v Wikki Tourists FC          1-1
+           Plateau United FC          v Katsina United FC          1-2
+           Rivers United FC           v Kwara United FC            1-0
+           Bayelsa United FC          v Barau FC                   2-0
+           Enyimba FC                 v Niger Tornadoes FC         1-0
+           Nasarawa United FC         v Abia Warriors FC           1-0
+           Warri Wolves FC            v Rangers International FC   2-0
+           Ikorodu City FC            v El-Kanemi Warriors FC      0-0
+  Mon Sep 1 2025
+           Kun Khalifat FC            v Remo Stars FC              1-2
+
+▪ Matchday 3
+  Sun Sep 7 2025
+           Wikki Tourists FC          v Abia Warriors FC           1-0
+           Katsina United FC          v Kano Pillars FC            1-0
+           Shooting Stars SC          v Ikorodu City FC            1-1
+           Rangers International FC   v Plateau United FC          2-0
+           Remo Stars FC              v Warri Wolves FC            1-0
+           Kwara United FC            v Kun Khalifat FC            2-0
+           El-Kanemi Warriors FC      v Rivers United FC           0-0
+           Niger Tornadoes FC         v Bayelsa United FC          1-0
+           Enyimba FC                 v Nasarawa United FC         0-0
+           Barau FC                   v Bendel FC                  1-1
+
+▪ Matchday 4
+  Sat Sep 13 2025
+           Bendel FC                  v Niger Tornadoes FC         1-0
+  Sun Sep 14 2025
+           Kano Pillars FC            v Rangers International FC   1-0
+           Plateau United FC          v Remo Stars FC              2-0
+           Warri Wolves FC            v Kwara United FC            0-0
+           Rivers United FC           v Shooting Stars SC          1-0
+           Ikorodu City FC            v Barau FC                   2-0
+           Bayelsa United FC          v Enyimba FC                 0-2
+           Abia Warriors FC           v Katsina United FC          1-0
+           Nasarawa United FC         v Wikki Tourists FC          1-0
+           Kun Khalifat FC            v El-Kanemi Warriors FC      3-1
+
+▪ Matchday 5
+  Sun Sep 21 2025
+           Bayelsa United FC          v Nasarawa United FC         1-2
+           El-Kanemi Warriors FC      v Warri Wolves FC            1-0
+           Enyimba FC                 v Bendel FC                  3-2
+           Niger Tornadoes FC         v Ikorodu City FC            4-2
+           Shooting Stars SC          v Kun Khalifat FC            2-1
+  Mon Sep 22 2025
+           Katsina United FC          v Wikki Tourists FC          1-0
+  Thu Oct 2 2025
+           Kwara United FC            v Plateau United FC          2-1
+  Wed Oct 8 2025
+           Rangers International FC   v Abia Warriors FC           2-0
+  Wed Nov 19 2025
+           Remo Stars FC              v Kano Pillars FC            1-0
+  Fri Dec 19 2025
+           Barau FC                   v Rivers United FC           4-1
+
+▪ Matchday 6
+  Sat Sep 27 2025
+           Bendel FC                  v Bayelsa United FC          1-1
+           Plateau United FC          v El-Kanemi Warriors FC      1-0
+  Sun Sep 28 2025
+           Kun Khalifat FC            v Barau FC                   1-3
+           Warri Wolves FC            v Shooting Stars SC          1-2
+           Wikki Tourists FC          v Rangers International FC   2-2
+           Nasarawa United FC         v Katsina United FC          2-0
+           Ikorodu City FC            v Enyimba FC                 1-1
+  Wed Oct 1 2025
+           Rivers United FC           v Niger Tornadoes FC         1-0
+  Thu Oct 2 2025
+           Abia Warriors FC           v Remo Stars FC              2-0
+  Wed Oct 8 2025
+           Kano Pillars FC            v Kwara United FC            1-0
+
+▪ Matchday 7
+  Sat Oct 4 2025
+           El-Kanemi Warriors FC      v Kano Pillars FC            2-1
+           Bendel FC                  v Nasarawa United FC         0-1
+  Sun Oct 5 2025
+           Niger Tornadoes FC         v Kun Khalifat FC            1-1
+           Enyimba FC                 v Rivers United FC           0-0
+           Barau FC                   v Warri Wolves FC            0-1
+           Bayelsa United FC          v Ikorodu City FC            1-1
+           Kwara United FC            v Abia Warriors FC           0-1
+           Shooting Stars SC          v Plateau United FC          1-0
+  Mon Oct 6 2025
+           Rangers International FC   v Katsina United FC          1-0
+           Remo Stars FC              v Wikki Tourists FC          2-0
+
+▪ Matchday 8
+  Sun Oct 12 2025
+           Warri Wolves FC            v Niger Tornadoes FC         1-1
+           Abia Warriors FC           v El-Kanemi Warriors FC      2-0
+           Kun Khalifat FC            v Enyimba FC                 1-0
+           Kano Pillars FC            v Shooting Stars SC          1-1
+           Wikki Tourists FC          v Kwara United FC            1-1
+           Plateau United FC          v Barau FC                   2-0
+           Nasarawa United FC         v Rangers International FC   2-1
+           Katsina United FC          v Remo Stars FC              3-1
+           Ikorodu City FC            v Bendel FC                  1-0
+  Mon Oct 13 2025
+           Rivers United FC           v Bayelsa United FC          1-2
+
+▪ Matchday 9
+  Sun Oct 19 2025
+           El-Kanemi Warriors FC      v Wikki Tourists FC          2-1
+           Niger Tornadoes FC         v Plateau United FC          4-0
+           Enyimba FC                 v Warri Wolves FC            1-2
+           Barau FC                   v Kano Pillars FC            2-1
+           Bayelsa United FC          v Kun Khalifat FC            1-2
+           Kwara United FC            v Katsina United FC          1-0
+           Shooting Stars SC          v Abia Warriors FC           2-0
+           Ikorodu City FC            v Nasarawa United FC         2-0
+  Thu Nov 6 2025
+           Bendel FC                  v Rivers United FC           0-0
+  Thu Nov 13 2025
+           Remo Stars FC              v Rangers International FC   0-1
+
+▪ Matchday 10
+  Fri Oct 24 2025
+           Katsina United FC          v El-Kanemi Warriors FC      1-0
+  Sat Oct 25 2025
+           Kano Pillars FC            v Niger Tornadoes FC         0-2
+  Sun Oct 26 2025
+           Kun Khalifat FC            v Bendel FC                  1-1
+           Rangers International FC   v Kwara United FC            0-0
+           Wikki Tourists FC          v Shooting Stars SC          2-0
+           Plateau United FC          v Enyimba FC                 2-1
+           Abia Warriors FC           v Barau FC                   2-0
+           Warri Wolves FC            v Bayelsa United FC          2-0
+  Wed Oct 29 2025
+           Rivers United FC           v Ikorodu City FC            0-0
+  Thu Nov 6 2025
+           Nasarawa United FC         v Remo Stars FC              2-1
+
+▪ Matchday 11
+  Sat Nov 1 2025
+           Bendel FC                  v Warri Wolves FC            1-1
+           Kwara United FC            v Remo Stars FC              3-1
+  Sun Nov 2 2025
+           Bayelsa United FC          v Plateau United FC          2-1
+           El-Kanemi Warriors FC      v Rangers International FC   0-0
+           Shooting Stars SC          v Katsina United FC          1-1
+           Enyimba FC                 v Kano Pillars FC            2-0
+           Rivers United FC           v Nasarawa United FC         1-0
+           Barau FC                   v Wikki Tourists FC          0-0
+           Niger Tornadoes FC         v Abia Warriors FC           1-2
+           Ikorodu City FC            v Kun Khalifat FC            2-0
+
+▪ Matchday 12
+  Sat Nov 8 2025
+           Katsina United FC          v Barau FC                   1-1
+  Sun Nov 9 2025
+           Abia Warriors FC           v Enyimba FC                 0-0
+           Kano Pillars FC            v Bayelsa United FC          0-0
+           Nasarawa United FC         v Kwara United FC            1-1
+           Rangers International FC   v Shooting Stars SC          1-0
+           Warri Wolves FC            v Ikorodu City FC            0-2
+           Wikki Tourists FC          v Niger Tornadoes FC         1-0
+  Mon Nov 10 2025
+           Kun Khalifat FC            v Rivers United FC           0-1
+           Plateau United FC          v Bendel FC                  1-0
+           Remo Stars FC              v El-Kanemi Warriors FC      2-1
+
+▪ Matchday 13
+  Sat Nov 15 2025
+           Bendel FC                  v Kano Pillars FC            3-2
+  Sun Nov 16 2025
+           El-Kanemi Warriors FC      v Kwara United FC            2-0
+           Kun Khalifat FC            v Nasarawa United FC         1-1
+           Niger Tornadoes FC         v Katsina United FC          2-0
+           Enyimba FC                 v Wikki Tourists FC          0-1
+           Rivers United FC           v Warri Wolves FC            2-1
+           Bayelsa United FC          v Abia Warriors FC           2-1
+           Ikorodu City FC            v Plateau United FC          2-1
+  Mon Nov 17 2025
+           Barau FC                   v Rangers International FC   2-0
+  Wed Dec 3 2025
+           Shooting Stars SC          v Remo Stars FC              1-0
+
+▪ Matchday 14
+  Sun Nov 23 2025
+           Remo Stars FC              v Barau FC                   2-0
+           Kwara United FC            v Shooting Stars SC          0-0
+           Nasarawa United FC         v El-Kanemi Warriors FC      3-0
+           Rangers International FC   v Niger Tornadoes FC         1-0
+           Wikki Tourists FC          v Bayelsa United FC          1-1
+           Warri Wolves FC            v Kun Khalifat FC            1-1
+           Abia Warriors FC           v Bendel FC                  0-0
+  Mon Nov 24 2025
+           Katsina United FC          v Enyimba FC                 3-2
+           Kano Pillars FC            v Ikorodu City FC            2-1
+  Thu Dec 11 2025
+           Plateau United FC          v Rivers United FC           1-2
+
+▪ Matchday 15
+  Sat Nov 29 2025
+           Niger Tornadoes FC         v Remo Stars FC              1-0
+           Bendel FC                  v Wikki Tourists FC          3-0
+  Sun Nov 30 2025
+           Kun Khalifat FC            v Plateau United FC          2-0
+           Enyimba FC                 v Rangers International FC   2-1
+           Barau FC                   v Kwara United FC            3-2
+           Warri Wolves FC            v Nasarawa United FC         1-0
+           Shooting Stars SC          v El-Kanemi Warriors FC      1-0
+           Ikorodu City FC            v Abia Warriors FC           1-0
+           Bayelsa United FC          v Katsina United FC          1-1
+  Wed Dec 3 2025
+           Rivers United FC           v Kano Pillars FC            1-0
+
+▪ Matchday 16
+  Sun Dec 7 2025
+           El-Kanemi Warriors FC      v Barau FC                   0-0
+           Kano Pillars FC            v Kun Khalifat FC            2-1
+           Plateau United FC          v Warri Wolves FC            1-0
+           Rangers International FC   v Bayelsa United FC          4-1
+           Wikki Tourists FC          v Ikorodu City FC            0-0
+           Kwara United FC            v Niger Tornadoes FC         2-0
+           Abia Warriors FC           v Rivers United FC           1-1
+           Remo Stars FC              v Enyimba FC                 2-1
+  Mon Dec 8 2025
+           Katsina United FC          v Bendel FC                  0-1
+           Nasarawa United FC         v Shooting Stars SC          1-0
+
+▪ Matchday 17
+  Sat Dec 13 2025
+           Bendel FC                  v Rangers International FC   1-1
+  Sun Dec 14 2025
+           Barau FC                   v Shooting Stars SC          0-1
+           Kun Khalifat FC            v Abia Warriors FC           0-1
+           Bayelsa United FC          v Remo Stars FC              2-1
+           Enyimba FC                 v Kwara United FC            3-1
+           Warri Wolves FC            v Kano Pillars FC            0-0
+           Niger Tornadoes FC         v El-Kanemi Warriors FC      3-0
+           Plateau United FC          v Nasarawa United FC         0-0
+  Mon Dec 15 2025
+           Rivers United FC           v Wikki Tourists FC          1-0
+           Ikorodu City FC            v Katsina United FC          0-0
+
+▪ Matchday 18
+  Sun Dec 21 2025
+           El-Kanemi Warriors FC      v Enyimba FC                 3-2
+           Kano Pillars FC            v Plateau United FC          2-1
+           Kwara United FC            v Bayelsa United FC          2-0
+           Rangers International FC   v Ikorodu City FC            2-1
+           Wikki Tourists FC          v Kun Khalifat FC            0-0
+           Shooting Stars SC          v Niger Tornadoes FC         2-1
+           Abia Warriors FC           v Warri Wolves FC            1-0
+           Remo Stars FC              v Bendel FC                  2-3
+  Mon Dec 22 2025
+           Katsina United FC          v Rivers United FC           1-1
+  Tue Dec 23 2025
+           Nasarawa United FC         v Barau FC                   0-0
+
+▪ Matchday 19
+  Sat Dec 27 2025
+           Bendel FC                  v Kwara United FC            2-0
+  Sun Dec 28 2025
+           Kano Pillars FC            v Nasarawa United FC         3-0
+           Kun Khalifat FC            v Katsina United FC          0-1
+           Niger Tornadoes FC         v Barau FC                   2-0
+           Enyimba FC                 v Shooting Stars SC          3-0
+           Warri Wolves FC            v Wikki Tourists FC          2-2
+           Bayelsa United FC          v El-Kanemi Warriors FC      0-1
+           Plateau United FC          v Abia Warriors FC           0-1
+           Rivers United FC           v Rangers International FC   1-0
+           Ikorodu City FC            v Remo Stars FC              1-0
+
+▪ Matchday 20
+  Wed Jan 14 2026
+           El-Kanemi Warriors FC      v Bayelsa United FC          1-0
+           Barau FC                   v Niger Tornadoes FC         2-1
+           Abia Warriors FC           v Plateau United FC          1-1
+           Kwara United FC            v Bendel FC                  0-1
+           Rangers International FC   v Rivers United FC           0-0
+           Wikki Tourists FC          v Warri Wolves FC            0-1
+           Shooting Stars SC          v Enyimba FC                 3-0
+           Remo Stars FC              v Ikorodu City FC            1-0
+           Nasarawa United FC         v Kano Pillars FC            0-1
+  Thu Jan 15 2026
+           Katsina United FC          v Kun Khalifat FC            2-0
+
+▪ Matchday 21
+  Sun Jan 18 2026
+           Kano Pillars FC            v Abia Warriors FC           0-1
+           Ikorodu City FC            v Kwara United FC            1-0
+           Nasarawa United FC         v Niger Tornadoes FC         2-1
+           Bayelsa United FC          v Shooting Stars SC          2-0
+           Plateau United FC          v Wikki Tourists FC          1-0
+           Rivers United FC           v Remo Stars FC              1-0
+           Enyimba FC                 v Barau FC                   0-0
+           Bendel FC                  v El-Kanemi Warriors FC      3-2
+  Mon Jan 19 2026
+           Warri Wolves FC            v Katsina United FC          2-0
+           Kun Khalifat FC            v Rangers International FC   1-2
+
+▪ Matchday 22
+  Sat Jan 24 2026
+           Katsina United FC          v Plateau United FC          0-0
+  Sun Jan 25 2026
+           El-Kanemi Warriors FC      v Ikorodu City FC            1-0
+           Barau FC                   v Bayelsa United FC          1-1
+           Abia Warriors FC           v Nasarawa United FC         1-2
+           Shooting Stars SC          v Bendel FC                  1-0
+           Niger Tornadoes FC         v Enyimba FC                 2-0
+           Wikki Tourists FC          v Kano Pillars FC            2-0
+           Rangers International FC   v Warri Wolves FC            4-2
+  Mon Jan 26 2026
+           Remo Stars FC              v Kun Khalifat FC            1-1
+  Wed Feb 18 2026
+           Kwara United FC            v Rivers United FC           1-1
+
+▪ Matchday 23
+  Wed Jan 28 2026
+           Kano Pillars FC            v Katsina United FC          1-0
+           Nasarawa United FC         v Enyimba FC                 1-1
+           Abia Warriors FC           v Wikki Tourists FC          1-1
+           Plateau United FC          v Rangers International FC   2-1
+  Thu Jan 29 2026
+           Bayelsa United FC          v Niger Tornadoes FC         0-0
+           Ikorodu City FC            v Shooting Stars SC          1-0
+           Warri Wolves FC            v Remo Stars FC              1-0
+           Kun Khalifat FC            v Kwara United FC            1-0
+           Bendel FC                  v Barau FC                   0-0
+  Wed Mar 4 2026
+           Rivers United FC           v El-Kanemi Warriors FC      3-0
+
+▪ Matchday 24
+  Sun Feb 1 2026
+           Katsina United FC          v Abia Warriors FC           2-0
+           Enyimba FC                 v Bayelsa United FC          1-0
+           Rangers International FC   v Kano Pillars FC            2-0
+           Wikki Tourists FC          v Nasarawa United FC         1-1
+           Niger Tornadoes FC         v Bendel FC                  2-2
+  Mon Feb 2 2026
+           Barau FC                   v Ikorodu City FC            1-0
+           Kwara United FC            v Warri Wolves FC            2-1
+           Remo Stars FC              v Plateau United FC          1-2
+           El-Kanemi Warriors FC      v Kun Khalifat FC            3-0 [awarded]
+  Thu Mar 12 2026
+           Shooting Stars SC          v Rivers United FC           2-1
+
+▪ Matchday 25
+  Sat Feb 7 2026
+           Bendel FC                  v Enyimba FC                 2-0
+  Sun Feb 8 2026
+           Nasarawa United FC         v Bayelsa United FC          1-1
+           Abia Warriors FC           v Rangers International FC   0-0
+           Kano Pillars FC            v Remo Stars FC              1-0
+           Ikorodu City FC            v Niger Tornadoes FC         2-0
+           Plateau United FC          v Kwara United FC            1-0
+           Warri Wolves FC            v El-Kanemi Warriors FC      0-0
+           Kun Khalifat FC            v Shooting Stars SC          2-0
+  Mon Feb 9 2026
+           Wikki Tourists FC          v Katsina United FC          4-4
+  Wed Feb 25 2026
+           Rivers United FC           v Barau FC                   1-0
+
+▪ Matchday 26
+  Sat Feb 14 2026
+           Barau FC                   v Kun Khalifat FC            1-0
+  Sun Feb 15 2026
+           El-Kanemi Warriors FC      v Plateau United FC          1-0
+           Shooting Stars SC          v Warri Wolves FC            4-2
+           Rangers International FC   v Wikki Tourists FC          2-0
+           Kwara United FC            v Kano Pillars FC            1-1
+           Remo Stars FC              v Abia Warriors FC           1-1
+           Bayelsa United FC          v Bendel FC                  0-0
+           Katsina United FC          v Nasarawa United FC         1-0
+           Enyimba FC                 v Ikorodu City FC            0-1
+  Thu Mar 19 2026
+           Niger Tornadoes FC         v Rivers United FC           1-0
+
+▪ Matchday 27
+  Sat Feb 21 2026
+           Wikki Tourists FC          v Remo Stars FC              2-1
+           Warri Wolves FC            v Barau FC                   0-0
+  Sun Feb 22 2026
+           Katsina United FC          v Rangers International FC   0-0
+           Kun Khalifat FC            v Niger Tornadoes FC         2-0
+           Abia Warriors FC           v Kwara United FC            1-0
+           Plateau United FC          v Shooting Stars SC          4-1
+           Nasarawa United FC         v Bendel FC                  1-0
+           Kano Pillars FC            v El-Kanemi Warriors FC      3-0
+           Ikorodu City FC            v Bayelsa United FC          1-1
+           Rivers United FC           v Enyimba FC                 1-1
+
+▪ Matchday 28
+  Sat Feb 28 2026
+           El-Kanemi Warriors FC      v Abia Warriors FC           2-0
+           Kwara United FC            v Wikki Tourists FC          1-0
+  Sun Mar 1 2026
+           Shooting Stars SC          v Kano Pillars FC            2-1
+           Rangers International FC   v Nasarawa United FC         2-0
+           Bayelsa United FC          v Rivers United FC           1-0
+           Niger Tornadoes FC         v Warri Wolves FC            0-0
+           Enyimba FC                 v Kun Khalifat FC            1-1
+           Remo Stars FC              v Katsina United FC          2-0
+           Bendel FC                  v Ikorodu City FC            4-0
+  Mon Mar 2 2026
+           Barau FC                   v Plateau United FC          2-1
+
+▪ Matchday 29
+  Sat Mar 7 2026
+           Wikki Tourists FC          v El-Kanemi Warriors FC      2-1
+  Sun Mar 8 2026
+           Rivers United FC           v Bendel FC                  3-1
+           Nasarawa United FC         v Ikorodu City FC            1-0
+           Abia Warriors FC           v Shooting Stars SC          2-0
+           Kano Pillars FC            v Barau FC                   1-0
+           Katsina United FC          v Kwara United FC            1-2
+           Rangers International FC   v Remo Stars FC              4-1
+           Plateau United FC          v Niger Tornadoes FC         3-0
+           Warri Wolves FC            v Enyimba FC                 2-1
+           Kun Khalifat FC            v Bayelsa United FC          1-0
+
+▪ Matchday 30
+  Sat Mar 14 2026
+           Bendel FC                  v Kun Khalifat FC            2-1
+  Sun Mar 15 2026
+           El-Kanemi Warriors FC      v Katsina United FC          1-1
+           Enyimba FC                 v Plateau United FC          2-0
+           Shooting Stars SC          v Wikki Tourists FC          3-2
+           Niger Tornadoes FC         v Kano Pillars FC            0-0
+           Barau FC                   v Abia Warriors FC           2-0
+           Bayelsa United FC          v Warri Wolves FC            2-1
+           Kwara United FC            v Rangers International FC   0-0
+           Remo Stars FC              v Nasarawa United FC         2-1
+  Mon Mar 16 2026
+           Ikorodu City FC            v Rivers United FC           1-0
+
+▪ Matchday 31
+  Sat Mar 21 2026
+           Wikki Tourists FC          v Barau FC                   0-0
+  Sun Mar 22 2026
+           Katsina United FC          v Shooting Stars SC          1-0
+           Remo Stars FC              v Kwara United FC            3-1
+           Kun Khalifat FC            v Ikorodu City FC            2-2
+           Rangers International FC   v El-Kanemi Warriors FC      2-0
+           Plateau United FC          v Bayelsa United FC          1-0
+           Warri Wolves FC            v Bendel FC                  0-0
+           Kano Pillars FC            v Enyimba FC                 2-0
+  Mon Mar 23 2026
+           Abia Warriors FC           v Niger Tornadoes FC         2-1
+           Nasarawa United FC         v Rivers United FC           4-1
+
+▪ Matchday 32
+  Sat Mar 28 2026
+           Bendel FC                  v Plateau United FC          2-2
+           Kwara United FC            v Nasarawa United FC         1-0
+  Sun Mar 29 2026
+           Shooting Stars SC          v Rangers International FC   3-1
+           Rivers United FC           v Kun Khalifat FC            4-2
+           Bayelsa United FC          v Kano Pillars FC            4-1
+           Niger Tornadoes FC         v Wikki Tourists FC          2-0
+           Enyimba FC                 v Abia Warriors FC           2-1
+           Ikorodu City FC            v Warri Wolves FC            4-3
+           El-Kanemi Warriors FC      v Remo Stars FC              1-1
+           Barau FC                   v Katsina United FC          0-0
+
+▪ Matchday 33
+  Sat Apr 4 2026
+           Wikki Tourists FC          v Enyimba FC                 2-2
+  Sun Apr 5 2026
+           Kano Pillars FC            v Bendel FC                  4-0
+           Kwara United FC            v El-Kanemi Warriors FC      3-0
+           Nasarawa United FC         v Kun Khalifat FC            0-1
+           Katsina United FC          v Niger Tornadoes FC         1-0
+           Warri Wolves FC            v Rivers United FC           2-0
+           Rangers International FC   v Barau FC                   0-0
+           Remo Stars FC              v Shooting Stars SC          1-0
+  Mon Apr 6 2026
+           Abia Warriors FC           v Bayelsa United FC          1-0
+           Plateau United FC          v Ikorodu City FC            4-1
+
+▪ Matchday 34
+  Sat Apr 11 2026
+           Bendel FC                  v Abia Warriors FC           1-0
+  Sun Apr 12 2026
+           Enyimba FC                 v Katsina United FC          3-0
+           Shooting Stars SC          v Kwara United FC            0-0
+           Niger Tornadoes FC         v Rangers International FC   0-0
+           Barau FC                   v Remo Stars FC              2-1
+           Bayelsa United FC          v Wikki Tourists FC          0-1
+           Kun Khalifat FC            v Warri Wolves FC            3-0
+           Rivers United FC           v Plateau United FC          1-0
+           Ikorodu City FC            v Kano Pillars FC            3-0
+  Tue Apr 14 2026
+           El-Kanemi Warriors FC      v Nasarawa United FC         1-0
+
+▪ Matchday 35
+  Sun Apr 19 2026
+           Wikki Tourists FC          v Bendel FC                  1-2
+           Plateau United FC          v Kun Khalifat FC            1-1
+           Remo Stars FC              v Niger Tornadoes FC         3-0
+           Rangers International FC   v Enyimba FC                 2-1
+           Kwara United FC            v Barau FC                   2-1
+           Nasarawa United FC         v Warri Wolves FC            3-0
+           El-Kanemi Warriors FC      v Shooting Stars SC          1-2
+           Abia Warriors FC           v Ikorodu City FC            2-1
+           Katsina United FC          v Bayelsa United FC          3-2
+           Kano Pillars FC            v Rivers United FC           2-1
+
+▪ Matchday 36
+  Sun May 3 2026
+           Enyimba FC                 v Remo Stars FC              2-1
+           Shooting Stars SC          v Nasarawa United FC         3-2
+           Niger Tornadoes FC         v Kwara United FC            2-2
+           Barau FC                   v El-Kanemi Warriors FC      3-0
+           Bayelsa United FC          v Rangers International FC   0-2
+           Kun Khalifat FC            v Kano Pillars FC            2-1
+           Rivers United FC           v Abia Warriors FC           3-0
+           Warri Wolves FC            v Plateau United FC          1-0
+  Mon May 4 2026
+           Bendel FC                  v Katsina United FC          1-0
+  Tue May 5 2026
+           Ikorodu City FC            v Wikki Tourists FC          3-1
+
+▪ Matchday 37
+  Sun May 10 2026
+           Wikki Tourists FC          v Rivers United FC           2-3
+           Abia Warriors FC           v Kun Khalifat FC            0-2
+           Shooting Stars SC          v Barau FC                   1-0
+           Nasarawa United FC         v Plateau United FC          1-0
+           El-Kanemi Warriors FC      v Niger Tornadoes FC         0-0
+           Katsina United FC          v Ikorodu City FC            4-1
+           Kwara United FC            v Enyimba FC                 2-0
+           Kano Pillars FC            v Warri Wolves FC            1-0
+           Remo Stars FC              v Bayelsa United FC          2-1
+           Rangers International FC   v Bendel FC                  2-1
+
+▪ Matchday 38
+  Sun May 24 2026
+           Ikorodu City FC            v Rangers International FC   1-2
+           Enyimba FC                 v El-Kanemi Warriors FC      3-0
+           Plateau United FC          v Kano Pillars FC            1-0
+           Niger Tornadoes FC         v Shooting Stars SC          1-0
+           Bayelsa United FC          v Kwara United FC            4-0
+           Bendel FC                  v Remo Stars FC              1-1
+           Warri Wolves FC            v Abia Warriors FC           2-1
+           Barau FC                   v Nasarawa United FC         3-0
+           Rivers United FC           v Katsina United FC          3-0
+           Kun Khalifat FC            v Wikki Tourists FC          3-1


### PR DESCRIPTION
Adds the completed 2025/26 NPFL season (380 fixtures, 20 teams). Data-only submission; source retrieval and validation tooling remain local.