### PR TITLE
Add Uganda Premier League seasons 2023-2026

### DIFF
--- a/africa/uganda/2023-24_ug1.txt
+++ b/africa/uganda/2023-24_ug1.txt
@@ -1,0 +1,411 @@
+= Uganda Premier League 2023/2024
+
+# Date       Fri Sep 15 2023 - Sat May 18 2024 (246d)
+# Teams      16
+# Matches    225
+# Source     https://www.rsssf.org/tableso/oeg2024.html
+# Retrieved  2026-08-21
+
+
+▪ Matchday 1
+  Fri Sep 15 2023
+           Bright Stars FC     v BUL FC              0-1
+           SC Villa            v Kitara FC           1-2
+           Mbarara City FC     v NEC FC              0-1
+  Sat Sep 16 2023
+           UPDF FC             v URA FC              0-0
+           Wakiso Giants FC    v Maroons FC          0-3
+           Gaddafi Modern FC   v Vipers SC           1-2
+           Arua Hill SC        v Busoga United FC    0-1
+  Sun Oct 8 2023
+           KCCA FC             v Express FC          1-2
+
+▪ Matchday 2
+  Thu Sep 21 2023
+           Vipers SC           v Arua Hill SC        2-0
+  Fri Sep 22 2023
+           URA FC              v Gaddafi Modern FC   2-0
+           NEC FC              v Busoga United FC    5-0
+           Kitara FC           v UPDF FC             1-0
+  Sat Sep 23 2023
+           BUL FC              v KCCA FC             1-0
+           Express FC          v Mbarara City FC     0-0
+           Wakiso Giants FC    v Bright Stars FC     1-1
+  Sun Sep 24 2023
+           Maroons FC          v SC Villa            1-1
+
+▪ Matchday 3
+  Thu Sep 28 2023
+           Bright Stars FC     v URA FC              1-1
+           Busoga United FC    v Express FC          0-2
+  Fri Sep 29 2023
+           Gaddafi Modern FC   v Kitara FC           1-2
+           SC Villa            v NEC FC              3-0
+           UPDF FC             v Wakiso Giants FC    0-2
+  Sun Oct 1 2023
+           Arua Hill SC        v BUL FC              1-2
+  Tue Oct 3 2023
+           Mbarara City FC     v Vipers SC           0-0
+           KCCA FC             v Maroons FC          1-2
+
+▪ Matchday 4
+  Thu Oct 19 2023
+           Busoga United FC    v Mbarara City FC     0-0
+           Arua Hill SC        abd.   Gaddafi Modern FC   [abandoned at 0-0 after 10' due to heavy rain]
+  Fri Oct 20 2023
+           Arua Hill SC        v Gaddafi Modern FC   0-1 [remaining 80']
+           Kitara FC           v KCCA FC             3-1
+           NEC FC              v UPDF FC             2-0
+           BUL FC              v Maroons FC          3-0
+           Vipers SC           v SC Villa            1-1
+  Sat Oct 21 2023
+           URA FC              v Wakiso Giants FC    1-0
+           Express FC          v Bright Stars FC     1-0
+
+▪ Matchday 5
+  Tue Oct 24 2023
+           Gaddafi Modern FC   v Busoga United FC    0-1
+           SC Villa            v BUL FC              1-2
+  Wed Oct 25 2023
+           Mbarara City FC     v Arua Hill SC        1-0
+           Wakiso Giants FC    v Kitara FC           1-3
+  Thu Oct 26 2023
+           KCCA FC             v NEC FC              0-2
+  Fri Oct 27 2023
+           Maroons FC          v URA FC              1-1
+           Bright Stars FC     v Vipers SC           0-2
+           UPDF FC             v Express FC          1-1
+
+▪ Matchday 6
+  Tue Oct 31 2023
+           Mbarara City FC     v Bright Stars FC     1-1
+           BUL FC              v URA FC              1-0
+           Arua Hill SC        v KCCA FC             1-1
+           Vipers SC           v Wakiso Giants FC    3-0
+  Wed Nov 1 2023
+           NEC FC              v Gaddafi Modern FC   0-3
+           Busoga United FC    v UPDF FC             0-2
+           Kitara FC           v Maroons FC          0-1
+  Fri Dec 8 2023
+           Express FC          v SC Villa            1-2
+
+▪ Matchday 7
+  Thu Nov 9 2023
+           SC Villa            v Arua Hill SC        3-1
+           UPDF FC             v BUL FC              2-0
+  Fri Nov 10 2023
+           URA FC              v Kitara FC           2-2
+           Bright Stars FC     v Busoga United FC    3-2
+           KCCA FC             v Vipers SC           3-1
+  Sat Nov 11 2023
+           Gaddafi Modern FC   v Mbarara City FC     2-1
+           Maroons FC          v NEC FC              0-1
+  Fri Nov 17 2023
+           Wakiso Giants FC    v Express FC          0-0
+
+▪ Matchday 8
+  Thu Nov 23 2023
+           Gaddafi Modern FC   v Bright Stars FC     2-2
+           Vipers SC           v URA FC              2-0
+  Fri Nov 24 2023
+           Arua Hill SC        v UPDF FC             2-0
+           Express FC          v Maroons FC          0-1
+           Busoga United FC    v KCCA FC             2-1
+  Sat Nov 25 2023
+           Mbarara City FC     v SC Villa            0-0
+           NEC FC              v Wakiso Giants FC    1-1
+  Sun Nov 26 2023
+           BUL FC              v Kitara FC           2-1
+
+▪ Matchday 9
+  Thu Nov 30 2023
+           SC Villa            v Busoga United FC    2-0
+           Bright Stars FC     v Arua Hill SC        3-1
+  Fri Dec 1 2023
+           URA FC              v Express FC          2-1
+           Wakiso Giants FC    v BUL FC              0-3
+           KCCA FC             v Gaddafi Modern FC   6-1
+  Sat Dec 2 2023
+           Kitara FC           v NEC FC              1-0
+           Maroons FC          v Mbarara City FC     1-0
+  Sun Dec 3 2023
+           UPDF FC             v Vipers SC           0-1
+
+▪ Matchday 10
+  Tue Dec 5 2023
+           Bright Stars FC     v SC Villa            1-1
+           Arua Hill SC        v Wakiso Giants FC    2-2
+           Express FC          v BUL FC              1-1
+  Wed Dec 6 2023
+           Mbarara City FC     v KCCA FC             2-1
+           Busoga United FC    v Maroons FC          1-1
+           NEC FC              v URA FC              2-0
+  Thu Dec 7 2023
+           Gaddafi Modern FC   v UPDF FC             2-1
+           Vipers SC           v Kitara FC           2-1
+
+▪ Matchday 11
+  Sun Dec 10 2023
+           URA FC              v Arua Hill SC        4-1
+           BUL FC              v NEC FC              1-1
+           Wakiso Giants FC    v Busoga United FC    3-0
+  Mon Dec 11 2023
+           UPDF FC             v Mbarara City FC     1-1
+  Tue Dec 12 2023
+           Kitara FC           v Express FC          1-0
+           KCCA FC             v Bright Stars FC     3-0
+  Wed Dec 13 2023
+           SC Villa            v Gaddafi Modern FC   1-0
+           Maroons FC          v Vipers SC           1-1
+
+▪ Matchday 12
+  Wed Dec 20 2023
+           Mbarara City FC     v Kitara FC           0-0
+           Arua Hill SC        v Maroons FC          1-3
+  Thu Dec 21 2023
+           Busoga United FC    v URA FC              2-2
+           NEC FC              v Express FC          2-5
+  Fri Dec 22 2023
+           SC Villa            v KCCA FC             1-2
+           Bright Stars FC     v UPDF FC             2-1
+           Vipers SC           v BUL FC              2-3
+  Sat Dec 23 2023
+           Gaddafi Modern FC   v Wakiso Giants FC    0-1
+
+▪ Matchday 13
+  Thu Dec 28 2023
+           Kitara FC           v Arua Hill SC        7-1
+           BUL FC              v Busoga United FC    1-0
+           UPDF FC             v KCCA FC             1-2
+  Fri Dec 29 2023
+           URA FC              v Mbarara City FC     3-0
+           NEC FC              v Bright Stars FC     0-0
+  Sat Dec 30 2023
+           Wakiso Giants FC    v SC Villa            0-1
+           Express FC          v Vipers SC           2-0
+           Maroons FC          v Gaddafi Modern FC   5-0
+
+▪ Matchday 14
+  Tue Jan 2 2024
+           Busoga United FC    v Kitara FC           2-1
+           Mbarara City FC     v Wakiso Giants FC    2-1
+           Bright Stars FC     v Maroons FC          1-0
+           SC Villa            v UPDF FC             3-0
+           KCCA FC             v URA FC              3-2
+  Wed Jan 3 2024
+           Arua Hill SC        v Express FC          0-1
+           Gaddafi Modern FC   v BUL FC              2-1
+           Vipers SC           v NEC FC              4-1
+
+▪ Matchday 15
+  Fri Jan 5 2024
+           Kitara FC           v Bright Stars FC     3-1
+           Maroons FC          v UPDF FC             4-2
+  Sat Jan 6 2024
+           Wakiso Giants FC    v KCCA FC             2-1
+           BUL FC              v Mbarara City FC     1-1
+           Express FC          v Gaddafi Modern FC   3-0
+           NEC FC              v Arua Hill SC        2-1
+  Sun Jan 7 2024
+           URA FC              v SC Villa            0-0
+           Vipers SC           v Busoga United FC    3-0
+
+▪ Matchday 16
+  Thu Feb 1 2024
+           SC Villa            v Maroons FC          2-1
+  Fri Feb 2 2024
+           Mbarara City FC     v Express FC          3-1
+           Gaddafi Modern FC   v URA FC              0-1
+           KCCA FC             v BUL FC              0-0
+  Sat Feb 3 2024
+           UPDF FC             v Kitara FC           0-3
+  Sun Feb 4 2024
+           Busoga United FC    v NEC FC              2-3
+           Bright Stars FC     v Wakiso Giants FC    1-0
+           Vipers SC            bye
+
+▪ Matchday 17
+  Tue Feb 6 2024
+           URA FC              v UPDF FC             1-0
+  Wed Feb 7 2024
+           BUL FC              v Bright Stars FC     2-1
+  Thu Feb 8 2024
+           Maroons FC          v Wakiso Giants FC    0-0
+           Vipers SC           v Gaddafi Modern FC   0-0
+  Fri Feb 9 2024
+           Kitara FC           v SC Villa            1-1
+           NEC FC              v Mbarara City FC     2-0
+  Sat Feb 10 2024
+           Express FC          v KCCA FC             3-4
+           Busoga United FC     bye
+
+▪ Matchday 18
+  Tue Feb 13 2024
+           UPDF FC             v NEC FC              2-2
+           Wakiso Giants FC    v URA FC              1-0
+  Thu Feb 22 2024
+           Bright Stars FC     v Express FC          1-1
+           Mbarara City FC     v Busoga United FC    1-0
+  Fri Feb 23 2024
+           Maroons FC          v BUL FC              0-0
+           KCCA FC             v Kitara FC           0-1
+  Tue Apr 9 2024
+           SC Villa            v Vipers SC           0-0
+           Gaddafi Modern FC    bye
+
+▪ Matchday 19
+  Tue Feb 27 2024
+           Express FC          v UPDF FC             3-1
+           Kitara FC           v Wakiso Giants FC    1-0
+  Wed Feb 28 2024
+           NEC FC              v KCCA FC             0-3
+  Thu Feb 29 2024
+           Busoga United FC    v Gaddafi Modern FC   1-1
+           URA FC              v Maroons FC          2-0
+           Vipers SC           v Bright Stars FC     1-1
+  Fri Mar 15 2024
+           BUL FC              v SC Villa            0-1
+           Mbarara City FC     bye
+
+▪ Matchday 20
+  Fri Mar 8 2024
+           URA FC              v BUL FC              1-1
+           Bright Stars FC     v Mbarara City FC     1-1
+           Maroons FC          v Kitara FC           0-0
+  Sat Mar 9 2024
+           UPDF FC             v Busoga United FC    2-0
+           Gaddafi Modern FC   v NEC FC              0-1
+           SC Villa            v Express FC          1-0
+  Sun Mar 10 2024
+           Wakiso Giants FC    v Vipers SC           0-4
+           KCCA FC             bye
+
+▪ Matchday 21
+  Tue Mar 12 2024
+           BUL FC              v UPDF FC             0-1
+  Wed Mar 13 2024
+           Express FC          v Wakiso Giants FC    2-3
+           Mbarara City FC     v Gaddafi Modern FC   5-0
+           NEC FC              v Maroons FC          2-1
+  Thu Mar 14 2024
+           Kitara FC           v URA FC              3-0
+           Busoga United FC    v Bright Stars FC     2-2
+  Fri Mar 15 2024
+           Vipers SC           v KCCA FC             0-1
+           SC Villa            bye
+
+▪ Matchday 22
+  Thu Mar 28 2024
+           Maroons FC          v Express FC          2-0
+           KCCA FC             v Busoga United FC    4-1
+  Fri Mar 29 2024
+           Kitara FC           v BUL FC              0-0
+           Wakiso Giants FC    v NEC FC              1-0
+  Sat Mar 30 2024
+           SC Villa            v Mbarara City FC     2-1
+           URA FC              v Vipers SC           0-2
+  Sun Mar 31 2024
+           Bright Stars FC     v Gaddafi Modern FC   4-0
+           UPDF FC             bye
+
+▪ Matchday 23
+  Thu Apr 4 2024
+           Busoga United FC    v SC Villa            1-1
+           NEC FC              v Kitara FC           1-0
+  Fri Apr 5 2024
+           Mbarara City FC     v Maroons FC          0-0
+           Gaddafi Modern FC   v KCCA FC             1-2
+           Vipers SC           v UPDF FC             2-1
+  Sat Apr 6 2024
+           BUL FC              v Wakiso Giants FC    3-0
+           Express FC          v URA FC              1-0
+           Bright Stars FC     bye
+  Tue Apr 16 2024
+           URA FC              v NEC FC              2-0
+           UPDF FC             v Gaddafi Modern FC   1-1
+  Thu Apr 18 2024
+           Maroons FC          v Busoga United FC    3-0
+           KCCA FC             v Mbarara City FC     4-0
+  Fri Apr 19 2024
+           Kitara FC           v Vipers SC           0-2
+  Sat Apr 20 2024
+           BUL FC              v Express FC          2-0
+  Sun Apr 21 2024
+           SC Villa            v Bright Stars FC     1-1
+           Wakiso Giants FC    bye
+
+▪ Matchday 25
+  Tue Apr 23 2024
+           Vipers SC           v Maroons FC          1-1
+  Wed Apr 24 2024
+           Express FC          v Kitara FC           1-2
+           NEC FC              v BUL FC              1-0
+  Thu Apr 25 2024
+           Gaddafi Modern FC   v SC Villa            0-1
+           Bright Stars FC     v KCCA FC             2-2
+  Fri Apr 26 2024
+           Mbarara City FC     v UPDF FC             0-0
+           Busoga United FC    v Wakiso Giants FC    2-1
+           URA FC              bye
+
+▪ Matchday 26
+  Tue Apr 30 2024
+           Kitara FC           v Mbarara City FC     1-1
+           URA FC              v Busoga United FC    0-0
+  Wed May 1 2024
+           BUL FC              v Vipers SC           1-0
+           KCCA FC             v SC Villa            2-0
+  Thu May 2 2024
+           UPDF FC             v Bright Stars FC     1-0
+           Wakiso Giants FC    v Gaddafi Modern FC   3-0
+  Mon May 13 2024
+           Express FC          v NEC FC              1-2
+           Maroons FC          bye
+
+▪ Matchday 27
+  Tue May 7 2024
+           Gaddafi Modern FC   v Maroons FC          3-1
+           Mbarara City FC     v URA FC              0-0
+           KCCA FC             v UPDF FC             1-0
+  Wed May 8 2024
+           SC Villa            v Wakiso Giants FC    3-2
+           Bright Stars FC     v NEC FC              1-1
+           Vipers SC           v Express FC          1-0
+  Sat May 18 2024
+           Busoga United FC    v BUL FC              0-3
+           Kitara FC           bye
+
+▪ Matchday 28
+  Sat May 11 2024
+           URA FC              v KCCA FC             1-0
+           Kitara FC           v Busoga United FC    3-2
+           Maroons FC          v Bright Stars FC     0-0
+           BUL FC              v Gaddafi Modern FC   1-0
+           NEC FC              v Vipers SC           0-0
+           Wakiso Giants FC    v Mbarara City FC     2-0
+           UPDF FC             v SC Villa            0-2
+           Express FC          bye
+
+▪ Matchday 29
+  Tue May 14 2024
+           Bright Stars FC     v Kitara FC           1-0
+           Busoga United FC    v Vipers SC           1-2
+           KCCA FC             v Wakiso Giants FC    4-0
+           UPDF FC             v Maroons FC          2-1
+           SC Villa            v URA FC              2-1
+           Mbarara City FC     v BUL FC              0-0
+  Wed May 15 2024
+           Gaddafi Modern FC   v Express FC          3-2
+           NEC FC              bye
+
+▪ Matchday 30
+  Sun May 5 2024
+           Express FC          v Busoga United FC    1-2
+  Sat May 18 2024
+           Kitara FC           v Gaddafi Modern FC   3-0
+           Maroons FC          v KCCA FC             1-1
+           NEC FC              v SC Villa            0-2
+           URA FC              v Bright Stars FC     1-1
+           Vipers SC           v Mbarara City FC     4-1
+           Wakiso Giants FC    v UPDF FC             0-1
+           BUL FC              bye

--- a/africa/uganda/2024-25_ug1.txt
+++ b/africa/uganda/2024-25_ug1.txt
@@ -1,0 +1,411 @@
+= Uganda Premier League 2024/2025
+
+# Date       Fri Sep 13 2024 - Sat May 24 2025 (253d)
+# Teams      16
+# Matches    240
+# Source     https://www.rsssf.org/tableso/oeg2025.html
+# Retrieved  2026-08-21
+
+
+▪ Matchday 1
+  Fri Sep 13 2024
+           KCCA FC            v URA FC             1-0
+  Sat Sep 14 2024
+           Lugazi FC          v Kitara FC          0-3
+  Sun Sep 15 2024
+           Wakiso Giants FC   v Bright Stars FC    1-1
+           Maroons FC         v UPDF FC            1-1
+           NEC FC             v Vipers SC          3-1
+  Mon Sep 16 2024
+           Police FC          v BUL FC             0-0
+           SC Villa           v Mbarara City FC    4-2
+           Express FC         v Mbale Heroes FC    2-1
+
+▪ Matchday 2
+  Thu Sep 19 2024
+           Kitara FC          v NEC FC             1-2
+           UPDF FC            v Lugazi FC          1-0
+           Vipers SC          v Express FC         3-0
+  Fri Sep 20 2024
+           BUL FC             v KCCA FC            1-1
+           Mbarara City FC    v Police FC          0-0
+           Bright Stars FC    v URA FC             0-1
+           Maroons FC         v Wakiso Giants FC   2-3
+  Sun Sep 22 2024
+           Mbale Heroes FC    v SC Villa           1-0
+
+▪ Matchday 3
+  Tue Sep 24 2024
+           Police FC          v Bright Stars FC    1-1
+           NEC FC             v UPDF FC            1-0
+  Thu Sep 26 2024
+           Lugazi FC          v Vipers SC          0-0
+           SC Villa           v BUL FC             2-1
+  Fri Sep 27 2024
+           Wakiso Giants FC   v Mbale Heroes FC    1-0
+           KCCA FC            v Kitara FC          2-0
+  Sat Sep 28 2024
+           URA FC             v Mbarara City FC    1-1
+           Express FC         v Maroons FC         0-0
+
+▪ Matchday 4
+  Tue Oct 1 2024
+           UPDF FC            v Wakiso Giants FC   1-0
+           Bright Stars FC    v KCCA FC            0-1
+  Wed Oct 2 2024
+           BUL FC             v Mbarara City FC    0-2
+  Thu Oct 3 2024
+           Kitara FC          v Police FC          0-1
+           Express FC         v NEC FC             2-1
+  Sat Oct 5 2024
+           Mbale Heroes FC    v URA FC             0-4
+           Vipers SC          v SC Villa           2-1
+  Sun Oct 6 2024
+           Maroons FC         v Lugazi FC          1-0
+
+▪ Matchday 5
+  Wed Oct 16 2024
+           Lugazi FC          v Mbale Heroes FC    1-1
+           Police FC          v Express FC         2-2
+  Thu Oct 17 2024
+           Wakiso Giants FC   v Vipers SC          0-2
+  Fri Oct 18 2024
+           Mbarara City FC    v Kitara FC          1-1
+           SC Villa           v Bright Stars FC    2-2
+           NEC FC             v Maroons FC         2-1
+           URA FC             v BUL FC             0-1
+  Sat Oct 19 2024
+           KCCA FC            v UPDF FC            0-0
+
+▪ Matchday 6
+  Tue Oct 22 2024
+           Express FC         v Lugazi FC          0-1
+  Wed Oct 23 2024
+           Bright Stars FC    v Mbarara City FC    0-1
+  Thu Oct 24 2024
+           UPDF FC            v URA FC             0-0
+           Maroons FC         v SC Villa           1-1
+  Fri Oct 25 2024
+           Kitara FC          v BUL FC             1-3
+           Vipers SC          v Police FC          2-1
+  Sat Oct 26 2024
+           Mbale Heroes FC    v KCCA FC            0-1
+           NEC FC             v Wakiso Giants FC   2-0
+
+▪ Matchday 7
+  Tue Oct 29 2024
+           Mbarara City FC    v Vipers SC          1-3
+  Wed Oct 30 2024
+           Lugazi FC          v NEC FC             1-0
+           Police FC          v Mbale Heroes FC    2-1
+  Thu Oct 31 2024
+           BUL FC             v Bright Stars FC    1-0
+           Wakiso Giants FC   v Express FC         0-0
+           KCCA FC            v Maroons FC         5-0
+  Fri Nov 1 2024
+           SC Villa           v UPDF FC            5-0
+           URA FC             v Kitara FC          2-0
+
+▪ Matchday 8
+  Tue Nov 5 2024
+           NEC FC             v Police FC          0-0
+  Wed Nov 6 2024
+           Wakiso Giants FC   v Lugazi FC          0-0
+           UPDF FC            v Mbarara City FC    2-1
+  Fri Nov 8 2024
+           Bright Stars FC    v Kitara FC          1-0
+           Express FC         v SC Villa           1-0
+  Sat Nov 9 2024
+           Maroons FC         v URA FC             2-1
+           Vipers SC          v KCCA FC            1-1
+  Sun Nov 10 2024
+           Mbale Heroes FC    v BUL FC             0-0
+
+▪ Matchday 9
+  Wed Nov 20 2024
+           Police FC          v Lugazi FC          0-0
+  Thu Nov 21 2024
+           BUL FC             v Express FC         1-1
+           Bright Stars FC    v Maroons FC         0-1
+           KCCA FC            v NEC FC             0-1
+  Fri Nov 22 2024
+           Kitara FC          v UPDF FC            4-0
+           URA FC             v Vipers SC          0-2
+  Sat Nov 23 2024
+           Mbarara City FC    v Mbale Heroes FC    1-0
+           SC Villa           v Wakiso Giants FC   6-1
+
+▪ Matchday 10
+  Wed Nov 27 2024
+           UPDF FC            v Police FC          2-2
+           Wakiso Giants FC   v URA FC             0-3
+  Thu Nov 28 2024
+           Mbale Heroes FC    v Bright Stars FC    1-0
+           Express FC         v Mbarara City FC    3-1
+  Fri Nov 29 2024
+           Maroons FC         v BUL FC             0-0
+           NEC FC             v SC Villa           2-1
+  Sat Nov 30 2024
+           Lugazi FC          v KCCA FC            1-1
+           Vipers SC          v Kitara FC          0-0
+
+▪ Matchday 11
+  Wed Dec 4 2024
+           Police FC          v Wakiso Giants FC   2-1
+           BUL FC             v UPDF FC            0-2
+  Thu Dec 5 2024
+           Mbarara City FC    v Maroons FC         0-3
+           URA FC             v NEC FC             1-1
+  Fri Dec 6 2024
+           Kitara FC          v Mbale Heroes FC    6-0
+           SC Villa           v Lugazi FC          1-1
+  Sat Dec 7 2024
+           Bright Stars FC    v Vipers SC          1-2
+           KCCA FC            v Express FC         0-1
+
+▪ Matchday 12
+  Wed Dec 11 2024
+           UPDF FC            v Mbale Heroes FC    1-1
+           NEC FC             v Bright Stars FC    1-0
+  Thu Dec 12 2024
+           Maroons FC         v Kitara FC          0-4
+           Lugazi FC          v Mbarara City FC    1-1
+  Fri Dec 13 2024
+           SC Villa           v Police FC          1-1
+           Express FC         v URA FC             1-2
+  Sat Dec 14 2024
+           Vipers SC          v BUL FC             1-1
+  Sun Dec 15 2024
+           Wakiso Giants FC   v KCCA FC            1-2
+
+▪ Matchday 13
+  Wed Dec 18 2024
+           Bright Stars FC    v UPDF FC            2-1
+           BUL FC             v NEC FC             1-1
+  Thu Dec 19 2024
+           URA FC             v Lugazi FC          1-0
+           Police FC          v Maroons FC         1-2
+  Fri Dec 20 2024
+           Mbale Heroes FC    v Vipers SC          0-4
+           KCCA FC            v SC Villa           1-1
+  Sat Dec 21 2024
+           Kitara FC          v Express FC         7-0
+  Mon Dec 30 2024
+           Mbarara City FC    v Wakiso Giants FC   0-0
+
+▪ Matchday 14
+  Thu Jan 2 2025
+           Maroons FC         v Mbale Heroes FC    1-0
+           Police FC          v KCCA FC            0-0
+           Express FC         v Bright Stars FC    2-1
+  Fri Jan 3 2025
+           UPDF FC            v Vipers SC          0-1
+           Lugazi FC          v BUL FC             1-2
+  Sat Jan 4 2025
+           SC Villa           v URA FC             1-0
+           NEC FC             v Mbarara City FC    1-0
+  Sun Jan 5 2025
+           Wakiso Giants FC   v Kitara FC          0-0
+
+▪ Matchday 15
+  Mon Jan 6 2025
+           UPDF FC            v Express FC         0-2
+           Bright Stars FC    v Lugazi FC          1-1
+           Vipers SC          v Maroons FC         1-0
+  Tue Jan 7 2025
+           Mbarara City FC    v KCCA FC            3-0 [awarded 3-0; originally 0-2, KCC fielded suspended player]
+           BUL FC             v Wakiso Giants FC   1-1
+           Kitara FC          v SC Villa           1-0
+           Mbale Heroes FC    v NEC FC             0-1
+           URA FC             v Police FC          1-0
+
+▪ Matchday 16
+  Tue Feb 11 2025
+           Wakiso Giants FC   v SC Villa           1-1
+           Vipers SC          v URA FC             2-0
+  Wed Feb 12 2025
+           Lugazi FC          v Police FC          1-0
+           Maroons FC         v Bright Stars FC    1-1
+           Express FC         v BUL FC             0-2
+  Thu Feb 13 2025
+           Mbale Heroes FC    v Mbarara City FC    0-1
+           UPDF FC            v Kitara FC          0-0
+           NEC FC             v KCCA FC            1-0
+
+▪ Matchday 17
+  Sat Feb 15 2025
+           SC Villa           v Express FC         1-0
+           URA FC             v Maroons FC         1-0
+  Sun Feb 16 2025
+           Police FC          v NEC FC             1-1
+           Lugazi FC          v Wakiso Giants FC   1-0
+           BUL FC             v Mbale Heroes FC    3-0
+           KCCA FC            v Vipers SC          0-2
+  Mon Feb 17 2025
+           Kitara FC          v Bright Stars FC    2-0
+           Mbarara City FC    v UPDF FC            0-1
+
+▪ Matchday 18
+  Sat Mar 1 2025
+           Kitara FC          v URA FC             1-0
+           Mbale Heroes FC    v Police FC          1-1
+           Bright Stars FC    v BUL FC             0-2
+           NEC FC             v Lugazi FC          2-0
+  Sun Mar 2 2025
+           UPDF FC            v SC Villa           2-0
+           Maroons FC         v KCCA FC            0-0
+           Vipers SC          v Mbarara City FC    1-0
+  Mon Mar 3 2025
+           Express FC         v Wakiso Giants FC   4-1
+
+▪ Matchday 19
+  Thu Mar 6 2025
+           Police FC          v Vipers SC          0-1
+           Lugazi FC          v Express FC         1-0
+           BUL FC             v Kitara FC          1-0
+  Fri Mar 7 2025
+           Wakiso Giants FC   v NEC FC             0-0
+           URA FC             v UPDF FC            2-1
+  Sat Mar 8 2025
+           Mbarara City FC    v Bright Stars FC    0-0
+           KCCA FC            v Mbale Heroes FC    5-0
+  Sun Mar 9 2025
+           SC Villa           v Maroons FC         0-2
+
+▪ Matchday 20
+  Thu Mar 13 2025
+           UPDF FC            v KCCA FC            1-2
+           Mbale Heroes FC    v Lugazi FC          1-3
+           Express FC         v Police FC          1-2
+  Fri Mar 14 2025
+           Kitara FC          v Mbarara City FC    1-1
+           Maroons FC         v NEC FC             1-3
+           BUL FC             v URA FC             2-1
+           Bright Stars FC    v SC Villa           1-3
+           Vipers SC          v Wakiso Giants FC   1-0
+
+▪ Matchday 21
+  Thu Mar 27 2025
+           Police FC          v Kitara FC          0-1
+           NEC FC             v Express FC         3-1
+  Fri Mar 28 2025
+           Lugazi FC          v Maroons FC         0-1
+           Wakiso Giants FC   v UPDF FC            0-1
+           KCCA FC            v Bright Stars FC    5-0
+  Sat Mar 29 2025
+           SC Villa           v Vipers SC          1-0
+           Mbarara City FC    v BUL FC             0-0
+           URA FC             v Mbale Heroes FC    3-2
+
+▪ Matchday 22
+  Thu Apr 3 2025
+           Bright Stars FC    v Police FC          3-1
+           Vipers SC          v Lugazi FC          1-0
+  Fri Apr 4 2025
+           UPDF FC            v NEC FC             0-0
+           Mbarara City FC    v URA FC             0-2
+           BUL FC             v SC Villa           1-0
+  Sat Apr 5 2025
+           Mbale Heroes FC    v Wakiso Giants FC   0-1
+           Maroons FC         v Express FC         1-0
+           Kitara FC          v KCCA FC            4-0
+
+▪ Matchday 23
+  Wed Apr 9 2025
+           Wakiso Giants FC   v Maroons FC         3-3
+           URA FC             v Bright Stars FC    4-0
+  Thu Apr 10 2025
+           Police FC          v Mbarara City FC    2-0
+           SC Villa           v Mbale Heroes FC    3-1
+           NEC FC             v Kitara FC          2-1
+  Fri Apr 11 2025
+           Lugazi FC          v UPDF FC            2-2
+           Express FC         v Vipers SC          2-2
+  Sat Apr 12 2025
+           KCCA FC            v BUL FC             1-2
+
+▪ Matchday 24
+  Tue Apr 15 2025
+           Kitara FC          v Lugazi FC          0-0
+           Bright Stars FC    v Wakiso Giants FC   0-0
+  Wed Apr 16 2025
+           Mbarara City FC    v SC Villa           0-2
+           Mbale Heroes FC    v Express FC         0-1
+           BUL FC             v Police FC          0-0
+           UPDF FC            v Maroons FC         2-1
+           URA FC             v KCCA FC            1-0
+  Thu Apr 17 2025
+           Vipers SC          v NEC FC             3-1
+
+▪ Matchday 25
+  Thu Apr 24 2025
+           Maroons FC         v Vipers SC          0-1
+           Express FC         v UPDF FC            2-2
+  Fri Apr 25 2025
+           Lugazi FC          v Bright Stars FC    3-1
+           Police FC          v URA FC             2-0
+           NEC FC             v Mbale Heroes FC    2-0
+  Sat Apr 26 2025
+           SC Villa           v Kitara FC          0-0
+           Wakiso Giants FC   v BUL FC             1-2
+           KCCA FC            v Mbarara City FC    1-0
+
+▪ Matchday 26
+  Tue Apr 29 2025
+           BUL FC             v Lugazi FC          4-0
+           KCCA FC            v Police FC          2-1
+           Vipers SC          v UPDF FC            1-0
+  Wed Apr 30 2025
+           Mbarara City FC    v NEC FC             1-2
+           Kitara FC          v Wakiso Giants FC   0-0
+           Bright Stars FC    v Express FC         0-1
+           Mbale Heroes FC    v Maroons FC         0-1
+           URA FC             v SC Villa           1-1
+
+▪ Matchday 27
+  Tue May 6 2025
+           Wakiso Giants FC   v Mbarara City FC    0-1
+           Maroons FC         v Police FC          1-0
+           Lugazi FC          v URA FC             0-1
+           UPDF FC            v Bright Stars FC    1-0
+           Express FC         v Kitara FC          1-0
+  Wed May 7 2025
+           SC Villa           v KCCA FC            2-2
+           Vipers SC          v Mbale Heroes FC    6-0
+           NEC FC             v BUL FC             1-1
+
+▪ Matchday 28
+  Sat May 10 2025
+           BUL FC             v Vipers SC          1-0
+           Kitara FC          v Maroons FC         1-0
+           KCCA FC            v Wakiso Giants FC   5-0
+           Mbarara City FC    v Lugazi FC          1-0
+           Mbale Heroes FC    v UPDF FC            0-3
+           Bright Stars FC    v NEC FC             1-5
+           URA FC             v Express FC         5-0
+  Sun May 11 2025
+           Police FC          v SC Villa           1-3
+
+▪ Matchday 29
+  Wed May 14 2025
+           Kitara FC          v Vipers SC          0-2
+           SC Villa           v NEC FC             0-1
+           BUL FC             v Maroons FC         1-0
+           KCCA FC            v Lugazi FC          5-0
+  Thu May 15 2025
+           Police FC          v UPDF FC            1-0
+  Fri May 16 2025
+           Mbarara City FC    v Express FC         2-0
+           Bright Stars FC    v Mbale Heroes FC    5-1
+           URA FC             v Wakiso Giants FC   4-1
+
+▪ Matchday 30
+  Sat May 24 2025
+           Vipers SC          v Bright Stars FC    1-1
+           Lugazi FC          v SC Villa           0-1
+           Mbale Heroes FC    v Kitara FC          1-6
+           NEC FC             v URA FC             1-0
+           UPDF FC            v BUL FC             2-3
+           Wakiso Giants FC   v Police FC          0-2
+           Maroons FC         v Mbarara City FC    2-0
+           Express FC         v KCCA FC            0-3

--- a/africa/uganda/2025-26_ug1.txt
+++ b/africa/uganda/2025-26_ug1.txt
@@ -1,0 +1,403 @@
+= Uganda Premier League 2025/2026
+
+# Date       Fri Sep 26 2025 - Sat May 23 2026 (239d)
+# Teams      16
+# Matches    240
+# Source     https://www.rsssf.org/tableso/oeg2026.html
+# Retrieved  2026-08-21
+
+
+▪ Matchday 1
+  Fri Sep 26 2025
+           BUL FC                  v URA FC                  0-0
+           Entebbe UPPC FC         v Buhimba United Saints   0-1
+           Kitara FC               v KCCA FC                 1-1
+           Lugazi FC               v Calvary FC              3-1
+           Police FC               v Mbarara City FC         1-1
+           Express FC              v UPDF FC                 1-0
+  Sat Nov 29 2025
+           Maroons FC              v NEC FC                  1-1
+           Vipers SC               v SC Villa                1-1
+
+▪ Matchday 2
+  Wed Oct 1 2025
+           Entebbe UPPC FC         v Lugazi FC               2-1
+           BUL FC                  v Maroons FC              1-0
+  Thu Oct 2 2025
+           Police FC               v Express FC              2-1
+           URA FC                  v NEC FC                  1-1
+  Fri Oct 3 2025
+           Mbarara City FC         v UPDF FC                 0-1
+  Sat Oct 4 2025
+           Buhimba United Saints   v Calvary FC              2-0
+           KCCA FC                 v SC Villa                2-1
+           Kitara FC               v Vipers SC               3-0 [awarded 3-0; Vipers dns because of dispute over new league format]
+
+▪ Matchday 3
+  Wed Oct 15 2025
+           UPDF FC                 v Maroons FC              1-2
+           SC Villa                v Entebbe UPPC FC         1-1
+  Thu Oct 16 2025
+           Buhimba United Saints   v Kitara FC               1-0
+           KCCA FC                 v Lugazi FC               0-0
+  Fri Oct 17 2025
+           Mbarara City FC         v BUL FC                  1-1
+           URA FC                  v Express FC              1-1
+  Sat Oct 18 2025
+           NEC FC                  v Police FC               2-2
+  Tue Dec 9 2025
+           Calvary FC              v Vipers SC               0-0
+
+▪ Matchday 4
+  Wed Oct 22 2025
+           Lugazi FC               v URA FC                  0-0
+           Maroons FC              v Calvary FC              0-0
+  Thu Oct 23 2025
+           BUL FC                  v Buhimba United Saints   3-0
+           Express FC              v KCCA FC                 0-1
+  Fri Oct 24 2025
+           Kitara FC               v Mbarara City FC         3-2
+           SC Villa                v Police FC               2-1
+  Sat Oct 25 2025
+           Entebbe UPPC FC         v NEC FC                  1-0
+  Tue Dec 2 2025
+           Vipers SC               v UPDF FC                 5-1
+
+▪ Matchday 5
+  Wed Oct 29 2025
+           Police FC               v Maroons FC              2-1
+           URA FC                  v UPDF FC                 3-2
+  Thu Oct 30 2025
+           Kitara FC               v Lugazi FC               4-0
+           BUL FC                  v Express FC              0-0
+  Fri Oct 31 2025
+           Buhimba United Saints   v SC Villa                0-3
+           KCCA FC                 v Calvary FC              4-2
+  Sat Nov 1 2025
+           Mbarara City FC         v NEC FC                  0-1
+           Entebbe UPPC FC         v Vipers SC               0-1
+
+▪ Matchday 6
+  Wed Nov 5 2025
+           Maroons FC              v URA FC                  0-0
+           Express FC              v Mbarara City FC         4-1
+  Thu Nov 6 2025
+           UPDF FC                 v Police FC               1-2
+           SC Villa                v Kitara FC               1-0
+  Fri Nov 7 2025
+           Calvary FC              v Entebbe UPPC FC         2-4
+           Vipers SC               v KCCA FC                 1-0
+  Sat Nov 8 2025
+           Lugazi FC               v Buhimba United Saints   5-2
+           NEC FC                  v BUL FC                  1-1
+
+▪ Matchday 7
+  Wed Nov 19 2025
+           Calvary FC              v UPDF FC                 0-1
+           Entebbe UPPC FC         v Police FC               0-2
+  Thu Nov 20 2025
+           Kitara FC               v BUL FC                  1-0
+           Lugazi FC               v Express FC              0-0
+           SC Villa                v NEC FC                  2-1
+  Fri Nov 21 2025
+           Buhimba United Saints   v Mbarara City FC         1-2
+           KCCA FC                 v URA FC                  2-1
+  Sat Nov 22 2025
+           Vipers SC               v Maroons FC              2-1
+
+▪ Matchday 8
+  Tue Nov 25 2025
+           Maroons FC              v Lugazi FC               3-0
+           UPDF FC                 v SC Villa                0-1
+           NEC FC                  v Calvary FC              1-0
+  Wed Nov 26 2025
+           URA FC                  v Buhimba United Saints   7-3
+           Express FC              v Vipers SC               0-3
+  Thu Nov 27 2025
+           BUL FC                  v Entebbe UPPC FC         0-2
+           Police FC               v Kitara FC               1-2
+  Fri Nov 28 2025
+           Mbarara City FC         v KCCA FC                 1-2
+
+▪ Matchday 9
+  Wed Dec 3 2025
+           Police FC               v Buhimba United Saints   4-0
+           Mbarara City FC         v Entebbe UPPC FC         1-1
+  Thu Dec 4 2025
+           Express FC              v Calvary FC              4-0
+           URA FC                  v Kitara FC               0-1
+  Fri Dec 5 2025
+           UPDF FC                 v Lugazi FC               2-0
+           NEC FC                  v Vipers SC               1-1
+  Sat Dec 6 2025
+           Maroons FC              v SC Villa                1-0
+  Sun Dec 7 2025
+           BUL FC                  v KCCA FC                 1-2
+
+▪ Matchday 10
+  Wed Dec 10 2025
+           Lugazi FC               v Police FC               1-1
+           Buhimba United Saints   v UPDF FC                 2-2
+  Thu Dec 11 2025
+           Entebbe UPPC FC         v Express FC              2-0
+           SC Villa                v URA FC                  3-0
+  Fri Dec 12 2025
+           Kitara FC               v Maroons FC              2-0
+           KCCA FC                 v NEC FC                  2-1
+  Sat Dec 13 2025
+           Calvary FC              v Mbarara City FC         1-1
+           Vipers SC               v BUL FC                  3-1
+
+▪ Matchday 11
+  Tue Dec 16 2025
+           UPDF FC                 v NEC FC                  0-0
+           BUL FC                  v Police FC               1-3
+           KCCA FC                 v Buhimba United Saints   1-0
+  Wed Dec 17 2025
+           Lugazi FC               v Vipers SC               1-2
+           Maroons FC              v Express FC              4-0
+           Mbarara City FC         v URA FC                  1-0
+           SC Villa                v Calvary FC              1-0
+  Thu Dec 18 2025
+           Entebbe UPPC FC         v Kitara FC               1-0
+
+▪ Matchday 12
+  Tue Jan 6 2026
+           Buhimba United Saints   v Maroons FC              1-0
+           Police FC               v KCCA FC                 2-0
+           Vipers SC               v Mbarara City FC         2-0
+  Wed Jan 7 2026
+           Kitara FC               v UPDF FC                 2-1
+           Calvary FC              v BUL FC                  0-1
+           NEC FC                  v Lugazi FC               1-0
+  Thu Jan 8 2026
+           Express FC              v SC Villa                0-1
+  Tue Jan 13 2026
+           URA FC                  v Entebbe UPPC FC         0-1
+
+▪ Matchday 13
+  Wed Jan 21 2026
+           Maroons FC              v KCCA FC                 0-0
+           Police FC               v Calvary FC              2-0
+           UPDF FC                 v Entebbe UPPC FC         0-1
+  Fri Jan 23 2026
+           BUL FC                  v SC Villa                2-1
+  Sat Jan 24 2026
+           Mbarara City FC         v Lugazi FC               0-0
+           NEC FC                  v Kitara FC               3-3
+           Express FC              v Buhimba United Saints   3-1
+           URA FC                  v Vipers SC               0-3
+
+▪ Matchday 14
+  Tue Jan 27 2026
+           Buhimba United Saints   v NEC FC                  0-1
+           Lugazi FC               v BUL FC                  2-1
+           KCCA FC                 v UPDF FC                 4-0
+           Entebbe UPPC FC         v Maroons FC              0-0
+           Calvary FC              v URA FC                  0-0
+           Vipers SC               v Police FC               4-1
+  Wed Jan 28 2026
+           Kitara FC               v Express FC              1-0
+           SC Villa                v Mbarara City FC         6-1
+
+▪ Matchday 15
+  Fri Jan 30 2026
+           Vipers SC               v Buhimba United Saints   4-0
+           UPDF FC                 v BUL FC                  0-1
+           KCCA FC                 v Entebbe UPPC FC         0-1
+  Sat Jan 31 2026
+           NEC FC                  v Express FC              0-0
+           Maroons FC              v Mbarara City FC         1-1
+           URA FC                  v Police FC               0-0
+           Calvary FC              v Kitara FC               0-1
+           SC Villa                v Lugazi FC               0-0
+
+▪ Matchday 16
+  Thu Feb 12 2026
+           Police FC               v Lugazi FC               2-1
+           Maroons FC              v Kitara FC               0-1
+           Mbarara City FC         v Calvary FC              1-0
+  Fri Feb 13 2026
+           BUL FC                  v Vipers SC               1-1
+           UPDF FC                 v Buhimba United Saints   0-0
+           NEC FC                  v KCCA FC                 3-1
+  Sat Feb 14 2026
+           Express FC              v Entebbe UPPC FC         0-0
+           URA FC                  v SC Villa                0-0
+
+▪ Matchday 17
+  Tue Feb 17 2026
+           Entebbe UPPC FC         v Mbarara City FC         1-0
+           Buhimba United Saints   v Police FC               1-1
+           Vipers SC               v NEC FC                  1-1
+  Wed Feb 18 2026
+           Calvary FC              v Express FC              0-0
+           Lugazi FC               v UPDF FC                 1-0
+           KCCA FC                 v BUL FC                  2-1
+  Thu Feb 19 2026
+           Kitara FC               v URA FC                  1-1
+           SC Villa                v Maroons FC              2-0
+
+▪ Matchday 18
+  Mon Mar 2 2026
+           Buhimba United Saints   v KCCA FC                 0-2
+           Calvary FC              v SC Villa                0-3 [awarded 0-3; abandoned at 0-1 at half-time due to crowd trouble]
+           Police FC               v BUL FC                  0-2
+           Kitara FC               v Entebbe UPPC FC         2-0
+           NEC FC                  v UPDF FC                 1-0
+           Vipers SC               v Lugazi FC               3-0
+  Wed Mar 4 2026
+           URA FC                  v Mbarara City FC         2-0
+           Express FC              v Maroons FC              1-1
+
+▪ Matchday 19
+  Fri Mar 6 2026
+           BUL FC                  v Calvary FC              5-1
+           UPDF FC                 v Kitara FC               1-1
+           Lugazi FC               v NEC FC                  0-2
+           KCCA FC                 v Police FC               2-1
+  Sat Mar 7 2026
+           Entebbe UPPC FC         v URA FC                  0-0
+           Maroons FC              v Buhimba United Saints   1-0
+           Mbarara City FC         v Vipers SC               1-2
+           SC Villa                v Express FC              0-0
+
+▪ Matchday 20
+  Tue Mar 10 2026
+           Buhimba United Saints   v BUL FC                  0-1
+           Calvary FC              v Maroons FC              0-1
+           Mbarara City FC         v Kitara FC               0-1
+           Police FC               v SC Villa                1-0
+           NEC FC                  v Entebbe UPPC FC         0-0
+  Wed Mar 11 2026
+           UPDF FC                 v Vipers SC               1-2
+           URA FC                  v Lugazi FC               1-0
+           KCCA FC                 v Express FC              3-0
+
+▪ Matchday 21
+  Fri Mar 13 2026
+           BUL FC                  v Mbarara City FC         0-0
+           Kitara FC               v Buhimba United Saints   4-0
+           Police FC               v NEC FC                  0-1
+  Sat Mar 14 2026
+           Maroons FC              v UPDF FC                 0-0
+           Lugazi FC               v KCCA FC                 0-3
+           Entebbe UPPC FC         v SC Villa                0-2
+           Express FC              v URA FC                  3-1
+           Vipers SC               v Calvary FC              1-0
+
+▪ Matchday 22
+  Wed Apr 8 2026
+           Maroons FC              v BUL FC                  1-0
+           Express FC              v Police FC               3-1
+  Thu Apr 9 2026
+           UPDF FC                 v Mbarara City FC         3-1
+           NEC FC                  v URA FC                  1-0
+  Fri Apr 10 2026
+           Lugazi FC               v Entebbe UPPC FC         1-1
+           Vipers SC               v Kitara FC               0-0
+  Sat Apr 11 2026
+           Calvary FC              v Buhimba United Saints   2-0
+           SC Villa                v KCCA FC                 1-0
+
+▪ Matchday 23
+  Wed Apr 15 2026
+           Calvary FC              v Lugazi FC               0-0
+           UPDF FC                 v Express FC              0-1
+           SC Villa                v Vipers SC               1-1
+  Thu Apr 16 2026
+           Mbarara City FC         v Police FC               1-2
+           Buhimba United Saints   v Entebbe UPPC FC         1-2
+           URA FC                  v BUL FC                  1-1
+  Fri Apr 17 2026
+           KCCA FC                 v Kitara FC               1-0
+  Sat Apr 18 2026
+           NEC FC                  v Maroons FC              1-0
+
+▪ Matchday 24
+  Tue Apr 21 2026
+           BUL FC                  v UPDF FC                 2-5
+           Mbarara City FC         v Maroons FC              2-2
+           Police FC               v URA FC                  2-1
+           Buhimba United Saints   v Vipers SC               0-2
+           Entebbe UPPC FC         v KCCA FC                 0-1
+           Express FC              v NEC FC                  0-0
+  Wed Apr 22 2026
+           Kitara FC               v Calvary FC              0-0
+           Lugazi FC               v SC Villa                0-1
+
+▪ Matchday 25
+  Fri Apr 24 2026
+           UPDF FC                 v URA FC                  0-0
+           Express FC              v BUL FC                  0-2
+           NEC FC                  v Mbarara City FC         1-0
+  Sat Apr 25 2026
+           Calvary FC              v KCCA FC                 1-0
+           Lugazi FC               v Kitara FC               1-2
+           Maroons FC              v Police FC               3-1
+           SC Villa                v Buhimba United Saints   4-0
+  Sun Apr 26 2026
+           Vipers SC               v Entebbe UPPC FC         3-0
+
+▪ Matchday 26
+  Tue Apr 28 2026
+           BUL FC                  v NEC FC                  0-1
+           Mbarara City FC         v Express FC              2-1
+           URA FC                  v Maroons FC              2-2
+  Wed Apr 29 2026
+           Buhimba United Saints   v Lugazi FC               0-2
+           Entebbe UPPC FC         v Calvary FC              2-0
+           Police FC               v UPDF FC                 2-0
+           KCCA FC                 v Vipers SC               1-1
+  Thu Apr 30 2026
+           Kitara FC               v SC Villa                2-0
+
+▪ Matchday 27
+  Wed May 6 2026
+           Calvary FC              v Police FC               1-0
+           Lugazi FC               v Mbarara City FC         0-1
+  Thu May 7 2026
+           Entebbe UPPC FC         v UPDF FC                 2-0
+           KCCA FC                 v Maroons FC              3-0
+  Fri May 8 2026
+           Buhimba United Saints   v Express FC              0-2
+           SC Villa                v BUL FC                  0-0
+           Vipers SC               v URA FC                  1-1
+  Sat May 9 2026
+           Kitara FC               v NEC FC                  0-1
+
+▪ Matchday 28
+  Tue May 12 2026
+           BUL FC                  v Lugazi FC               0-0
+           Maroons FC              v Entebbe UPPC FC         0-0
+           Police FC               v Vipers SC               0-0
+           URA FC                  v Calvary FC              1-1
+           Express FC              v Kitara FC               3-2
+  Wed May 13 2026
+           Mbarara City FC         v SC Villa                1-3
+           UPDF FC                 v KCCA FC                 1-2
+           NEC FC                  v Buhimba United Saints   3-0 [awarded 3-0, Buhimba dns]
+
+▪ Matchday 29
+  Tue May 19 2026
+           BUL FC                  v Kitara FC               1-1
+           Maroons FC              v Vipers SC               0-3
+           UPDF FC                 v Calvary FC              0-0
+           URA FC                  v KCCA FC                 0-0
+           Police FC               v Entebbe UPPC FC         1-1
+           Mbarara City FC         v Buhimba United Saints   2-0
+           Express FC              v Lugazi FC               0-0
+  Wed May 20 2026
+           NEC FC                  v SC Villa                1-4
+
+▪ Matchday 30
+  Fri May 22 2026
+           Buhimba United Saints   v URA FC                  0-3
+  Sat May 23 2026
+           Calvary FC              v NEC FC                  2-0
+           Entebbe UPPC FC         v BUL FC                  4-0
+           KCCA FC                 v Mbarara City FC         4-1
+           Kitara FC               v Police FC               2-2
+           Lugazi FC               v Maroons FC              0-1
+           SC Villa                v UPDF FC                 2-1
+           Vipers SC               v Express FC              2-0


### PR DESCRIPTION
Adds completed Uganda Premier League seasons 2023/24, 2024/25, and 2025/26. The 2023/24 season has 225 fixtures because Arua Hill was excluded mid-season. Data-only submission; source retrieval and validation tooling remain local.