### PR TITLE
Add Nigeria National League season 2025-2026

### DIFF
--- a/africa/nigeria/2025-26_ng2.txt
+++ b/africa/nigeria/2025-26_ng2.txt
@@ -1,0 +1,552 @@
+= Nigeria National League 2025/2026
+
+# Date       Sat Nov 8 2025 - Fri May 8 2026 (181d)
+# Teams      36
+# Matches    275
+# Stages     Group A (74)  Group B (90)  Group C (56)  Group D (49)  Super 4 (6)
+# Source     https://www.betexplorer.com/football/nigeria/nnl/results/?stage=82xRYEUg
+# Retrieved  2026-08-21
+
+
+▪ Group A
+
+▪▪ Matchday 1
+  Sat Nov 15 2025
+           Abia Comets FC           v Smart City FC            2-0
+           Beyond Limits FC         v Dakkada FC               [cancelled]
+           Crown FC                 v Heartland FC             3-0
+           Edel FC                  v Sunshine Stars FC        1-0
+           Gateway Utd.             v Inter Lagos FC           0-1
+
+▪▪ Matchday 2
+  Sat Nov 22 2025
+           Abia Comets FC           v Beyond Limits FC         1-1
+           Dakkada FC               v Crown FC                 [cancelled]
+           Heartland FC             v Edel FC                  2-1
+           Sunshine Stars FC        v Gateway Utd.             2-0
+  Sun Nov 23 2025
+           Smart City FC            v Inter Lagos FC           2-1
+
+▪▪ Matchday 3
+  Sat Nov 29 2025
+           Beyond Limits FC         v Smart City FC            0-0
+           Crown FC                 v Abia Comets FC           1-0
+           Gateway Utd.             v Heartland FC             0-0
+           Inter Lagos FC           v Sunshine Stars FC        2-1
+
+▪▪ Matchday 4
+  Sat Dec 6 2025
+           Abia Comets FC           v Edel FC                  3-1
+           Beyond Limits FC         v Crown FC                 3-1
+           Heartland FC             v Inter Lagos FC           3-2
+           Smart City FC            v Sunshine Stars FC        2-1
+
+▪▪ Matchday 5
+  Wed Dec 10 2025
+           Crown FC                 v Smart City FC            2-0
+           Edel FC                  v Beyond Limits FC         0-1
+           Gateway Utd.             v Abia Comets FC           0-0
+           Sunshine Stars FC        v Heartland FC             3-1
+
+▪▪ Matchday 6
+  Sat Dec 13 2025
+           Abia Comets FC           v Inter Lagos FC           0-3
+           Beyond Limits FC         v Gateway Utd.             3-2
+           Crown FC                 v Edel FC                  3-0
+
+▪▪ Matchday 7
+  Sat Dec 20 2025
+           Edel FC                  v Smart City FC            1-0
+           Gateway Utd.             v Crown FC                 2-1
+           Sunshine Stars FC        v Abia Comets FC           1-1
+  Mon Dec 22 2025
+           Inter Lagos FC           v Beyond Limits FC         1-0
+
+▪▪ Matchday 8
+  Sat Jan 3 2026
+           Abia Comets FC           v Heartland FC             1-3
+           Beyond Limits FC         v Sunshine Stars FC        3-0
+           Crown FC                 v Inter Lagos FC           1-1
+           Edel FC                  v Gateway Utd.             2-0
+
+▪▪ Matchday 9
+  Sat Jan 10 2026
+           Gateway Utd.             v Smart City FC            1-1
+           Heartland FC             v Beyond Limits FC         0-0
+           Inter Lagos FC           v Edel FC                  2-1
+           Sunshine Stars FC        v Crown FC                 1-0
+  Thu Jan 15 2026
+           Smart City FC            v Heartland FC             2-1
+
+▪▪ Matchday 10
+  Sat Feb 14 2026
+           Beyond Limits FC         v Heartland FC             1-0
+           Crown FC                 v Sunshine Stars FC        0-0
+           Smart City FC            v Gateway Utd.             3-2
+  Sun Feb 15 2026
+           Edel FC                  v Inter Lagos FC           0-3
+
+▪▪ Matchday 11
+  Sat Feb 21 2026
+           Gateway Utd.             v Edel FC                  0-1
+           Heartland FC             v Abia Comets FC           2-1
+           Inter Lagos FC           v Crown FC                 1-1
+           Sunshine Stars FC        v Beyond Limits FC         1-1
+
+▪▪ Matchday 12
+  Sat Feb 28 2026
+           Abia Comets FC           v Sunshine Stars FC        0-2
+           Beyond Limits FC         v Inter Lagos FC           0-0
+           Crown FC                 v Gateway Utd.             0-1
+           Smart City FC            v Edel FC                  1-0
+
+▪▪ Matchday 13
+  Sat Mar 7 2026
+           Edel FC                  v Crown FC                 2-1
+           Gateway Utd.             v Beyond Limits FC         1-2
+           Heartland FC             v Smart City FC            3-1
+           Inter Lagos FC           v Abia Comets FC           5-0
+
+▪▪ Matchday 14
+  Sat Mar 14 2026
+           Abia Comets FC           v Gateway Utd.             2-1
+           Beyond Limits FC         v Edel FC                  1-1
+           Heartland FC             v Sunshine Stars FC        1-0
+           Smart City FC            v Crown FC                 3-1
+
+▪▪ Matchday 15
+  Wed Mar 25 2026
+           Crown FC                 v Beyond Limits FC         2-2
+           Edel FC                  v Abia Comets FC           2-1
+           Sunshine Stars FC        v Smart City FC            2-0
+  Wed Apr 1 2026
+           Inter Lagos FC           v Heartland FC             2-1
+
+▪▪ Matchday 16
+  Sat Mar 28 2026
+           Abia Comets FC           v Crown FC                 2-1
+           Heartland FC             v Gateway Utd.             3-0
+           Sunshine Stars FC        v Inter Lagos FC           0-0
+  Sun Mar 29 2026
+           Smart City FC            v Beyond Limits FC         2-0
+
+▪▪ Matchday 17
+  Sat Apr 4 2026
+           Beyond Limits FC         v Abia Comets FC           5-1
+           Edel FC                  v Heartland FC             0-0
+           Gateway Utd.             v Sunshine Stars FC        1-2
+  Mon Apr 6 2026
+           Inter Lagos FC           v Smart City FC            1-1
+
+▪▪ Matchday 18
+  Sat Apr 11 2026
+           Heartland FC             v Crown FC                 1-0
+           Inter Lagos FC           v Gateway Utd.             1-2
+           Smart City FC            v Abia Comets FC           3-1
+           Sunshine Stars FC        v Edel FC                  2-1
+
+▪ Group B
+
+▪▪ Matchday 1
+  Sat Nov 15 2025
+           Abakaliki FC             v Rovers FC                1-1
+           Godswill Akpabio FC      v First Bank FC            5-1
+           Sporting Lagos FC        v Osun FC                  3-1
+  Sun Nov 16 2025
+           Akwa United FC           v Solution FC              2-0
+           Ekiti United FC          v Stormers FC              1-0
+
+▪▪ Matchday 2
+  Sat Nov 22 2025
+           Rovers FC                v Ekiti United FC          2-1
+           Solution FC              v Osun FC                  1-0
+  Sun Nov 23 2025
+           Akwa United FC           v Abakaliki FC             1-0
+           First Bank FC            v Sporting Lagos FC        0-1
+  Mon Nov 24 2025
+           Stormers FC              v Godswill Akpabio FC      3-1
+
+▪▪ Matchday 3
+  Fri Nov 28 2025
+           Sporting Lagos FC        v Stormers FC              1-1
+  Sat Nov 29 2025
+           Abakaliki FC             v Solution FC              2-0
+           Osun FC                  v First Bank FC            2-1
+  Sun Nov 30 2025
+           Ekiti United FC          v Akwa United FC           2-1
+           Godswill Akpabio FC      v Rovers FC                4-0
+
+▪▪ Matchday 4
+  Sat Dec 6 2025
+           Abakaliki FC             v Ekiti United FC          1-0
+           Rovers FC                v Sporting Lagos FC        2-1
+           Solution FC              v First Bank FC            2-0
+           Stormers FC              v Osun FC                  4-2
+  Sun Dec 7 2025
+           Akwa United FC           v Godswill Akpabio FC      1-1
+
+▪▪ Matchday 5
+  Tue Dec 9 2025
+           First Bank FC            v Stormers FC              1-1
+  Wed Dec 10 2025
+           Ekiti United FC          v Solution FC              1-0
+           Godswill Akpabio FC      v Abakaliki FC             0-0
+           Osun FC                  v Rovers FC                1-0
+           Sporting Lagos FC        v Akwa United FC           2-0
+
+▪▪ Matchday 6
+  Sat Dec 13 2025
+           Abakaliki FC             v Sporting Lagos FC        1-0
+           Ekiti United FC          v Godswill Akpabio FC      2-1
+  Sun Dec 14 2025
+           Akwa United FC           v Osun FC                  1-0
+           Rovers FC                v First Bank FC            1-0
+           Solution FC              v Stormers FC              3-0
+
+▪▪ Matchday 7
+  Fri Dec 19 2025
+           Stormers FC              v Rovers FC                1-0
+  Sat Dec 20 2025
+           Godswill Akpabio FC      v Solution FC              3-0
+           Osun FC                  v Abakaliki FC             3-3
+  Mon Dec 22 2025
+           First Bank FC            v Akwa United FC           1-3
+           Sporting Lagos FC        v Ekiti United FC          2-1
+
+▪▪ Matchday 8
+  Sat Jan 3 2026
+           Godswill Akpabio FC      v Sporting Lagos FC        0-2
+           Solution FC              v Rovers FC                3-2
+  Sun Jan 4 2026
+           Akwa United FC           v Stormers FC              2-0
+           Ekiti United FC          v Osun FC                  1-0
+  Wed Jan 7 2026
+           Abakaliki FC             v First Bank FC            1-0
+
+▪▪ Matchday 9
+  Sat Jan 10 2026
+           Osun FC                  v Godswill Akpabio FC      2-2
+           Rovers FC                v Akwa United FC           0-2
+  Sun Jan 11 2026
+           Sporting Lagos FC        v Solution FC              1-1
+           Stormers FC              v Abakaliki FC             4-2
+  Mon Jan 12 2026
+           First Bank FC            v Ekiti United FC          2-0
+
+▪▪ Matchday 10
+  Fri Feb 13 2026
+           Abakaliki FC             v Stormers FC              1-0
+  Sat Feb 14 2026
+           Godswill Akpabio FC      v Osun FC                  1-0
+           Solution FC              v Sporting Lagos FC        0-3
+  Sun Feb 15 2026
+           Akwa United FC           v Rovers FC                1-0
+           Ekiti United FC          v First Bank FC            2-1
+
+▪▪ Matchday 11
+  Fri Feb 20 2026
+           First Bank FC            v Abakaliki FC             0-0
+  Sat Feb 21 2026
+           Osun FC                  v Ekiti United FC          1-0
+           Rovers FC                v Solution FC              0-1
+  Sun Feb 22 2026
+           Stormers FC              v Akwa United FC           3-1
+  Mon Feb 23 2026
+           Sporting Lagos FC        v Godswill Akpabio FC      1-1
+
+▪▪ Matchday 12
+  Sat Feb 28 2026
+           Abakaliki FC             v Osun FC                  0-1
+           Rovers FC                v Stormers FC              1-0
+  Sun Mar 1 2026
+           Akwa United FC           v First Bank FC            2-0
+           Ekiti United FC          v Sporting Lagos FC        3-0
+           Solution FC              v Godswill Akpabio FC      2-1
+
+▪▪ Matchday 13
+  Fri Mar 6 2026
+           First Bank FC            v Rovers FC                1-0
+  Sat Mar 7 2026
+           Osun FC                  v Akwa United FC           1-0
+  Sun Mar 8 2026
+           Godswill Akpabio FC      v Ekiti United FC          1-0
+           Sporting Lagos FC        v Abakaliki FC             2-1
+           Stormers FC              v Solution FC              1-0
+
+▪▪ Matchday 14
+  Sat Mar 14 2026
+           Abakaliki FC             v Godswill Akpabio FC      4-1
+           Rovers FC                v Osun FC                  2-0
+           Solution FC              v Ekiti United FC          1-0
+  Sun Mar 15 2026
+           Akwa United FC           v Sporting Lagos FC        1-0
+           Stormers FC              v First Bank FC            3-1
+
+▪▪ Matchday 15
+  Wed Mar 25 2026
+           Ekiti United FC          v Abakaliki FC             1-0
+           Osun FC                  v Stormers FC              0-1
+  Thu Mar 26 2026
+           Godswill Akpabio FC      v Akwa United FC           0-0
+  Wed Apr 1 2026
+           First Bank FC            v Solution FC              1-0
+  Wed Apr 8 2026
+           Sporting Lagos FC        v Rovers FC                1-0
+
+▪▪ Matchday 16
+  Sat Mar 28 2026
+           First Bank FC            v Osun FC                  2-0
+           Solution FC              v Abakaliki FC             2-1
+  Sun Mar 29 2026
+           Akwa United FC           v Ekiti United FC          3-1
+           Rovers FC                v Godswill Akpabio FC      2-0
+           Stormers FC              v Sporting Lagos FC        1-5
+
+▪▪ Matchday 17
+  Sat Apr 4 2026
+           Abakaliki FC             v Akwa United FC           1-0
+           Osun FC                  v Solution FC              2-1
+           Sporting Lagos FC        v First Bank FC            5-0
+  Sun Apr 5 2026
+           Godswill Akpabio FC      v Stormers FC              2-1
+  Sun Apr 12 2026
+           Ekiti United FC          v Rovers FC                3-1
+
+▪▪ Matchday 18
+  Thu Apr 16 2026
+           First Bank FC            v Godswill Akpabio FC      3-3
+           Osun FC                  v Sporting Lagos FC        0-1
+           Rovers FC                v Abakaliki FC             1-0
+           Solution FC              v Akwa United FC           1-2
+           Stormers FC              v Ekiti United FC          0-2
+
+▪ Group C
+
+▪▪ Matchday 1
+  Sat Nov 8 2025
+           Basira FC                v Mighty Jets FC           3-1
+  Sat Nov 15 2025
+           ABS FC                   v Sokoto FC                1-0
+           Doma United FC           v Kada Warriors FC         1-0
+           Lobi Stars FC            v City FC Abuja            1-0
+
+▪▪ Matchday 2
+  Sat Nov 22 2025
+           ABS FC                   v Basira FC                2-0
+           Kada Warriors FC         v Lobi Stars FC            1-0
+           Mighty Jets FC           v Doma United FC           0-1
+           Sokoto FC                v City FC Abuja            1-1
+
+▪▪ Matchday 3
+  Sat Nov 29 2025
+           Basira FC                v Sokoto FC                1-0
+           City FC Abuja            v Kada Warriors FC         0-0
+           Doma United FC           v ABS FC                   3-1
+  Sun Nov 30 2025
+           Lobi Stars FC            v Mighty Jets FC           2-1
+
+▪▪ Matchday 4
+  Sat Dec 6 2025
+           ABS FC                   v Lobi Stars FC            1-0
+           Basira FC                v Doma United FC           2-2
+           Sokoto FC                v Kada Warriors FC         1-0
+  Mon Dec 8 2025
+           Mighty Jets FC           v City FC Abuja            2-0
+
+▪▪ Matchday 5
+  Wed Dec 10 2025
+           Doma United FC           v Sokoto FC                1-0
+           Lobi Stars FC            v Basira FC                1-1
+  Thu Dec 11 2025
+           City FC Abuja            v ABS FC                   2-1
+           Kada Warriors FC         v Mighty Jets FC           1-0
+
+▪▪ Matchday 6
+  Sun Dec 14 2025
+           ABS FC                   v Kada Warriors FC         0-1
+           Basira FC                v City FC Abuja            2-0
+           Doma United FC           v Lobi Stars FC            2-0
+           Sokoto FC                v Mighty Jets FC           1-0
+
+▪▪ Matchday 7
+  Sat Dec 20 2025
+           City FC Abuja            v Doma United FC           1-0
+           Kada Warriors FC         v Basira FC                1-1
+           Lobi Stars FC            v Sokoto FC                2-0
+           Mighty Jets FC           v ABS FC                   3-0
+
+▪▪ Matchday 8
+  Sat Feb 14 2026
+           ABS FC                   v Mighty Jets FC           2-1
+           Basira FC                v Kada Warriors FC         1-0
+           Doma United FC           v City FC Abuja            2-0
+           Sokoto FC                v Lobi Stars FC            0-0
+
+▪▪ Matchday 9
+  Sat Feb 21 2026
+           Lobi Stars FC            v Doma United FC           2-1
+           Mighty Jets FC           v Sokoto FC                2-1
+  Sun Feb 22 2026
+           City FC Abuja            v Basira FC                3-1
+  Mon Feb 23 2026
+           Kada Warriors FC         v ABS FC                   1-0
+
+▪▪ Matchday 10
+  Sat Feb 28 2026
+           ABS FC                   v City FC Abuja            0-0
+           Basira FC                v Lobi Stars FC            2-0
+           Mighty Jets FC           v Kada Warriors FC         1-1
+           Sokoto FC                v Doma United FC           1-0
+
+▪▪ Matchday 11
+  Sat Mar 7 2026
+           City FC Abuja            v Mighty Jets FC           1-0
+           Doma United FC           v Basira FC                1-0
+           Kada Warriors FC         v Sokoto FC                1-1
+           Lobi Stars FC            v ABS FC                   2-0
+
+▪▪ Matchday 12
+  Sat Mar 14 2026
+           ABS FC                   v Doma United FC           1-1
+           Kada Warriors FC         v City FC Abuja            1-1
+           Mighty Jets FC           v Lobi Stars FC            1-0
+           Sokoto FC                v Basira FC                1-0
+
+▪▪ Matchday 13
+  Wed Mar 25 2026
+           Basira FC                v ABS FC                   2-0
+           City FC Abuja            v Sokoto FC                1-2
+           Doma United FC           v Mighty Jets FC           2-0
+           Lobi Stars FC            v Kada Warriors FC         1-0
+
+▪▪ Matchday 14
+  Sat Mar 28 2026
+           City FC Abuja            v Lobi Stars FC            0-1
+           Kada Warriors FC         v Doma United FC           3-1
+           Mighty Jets FC           v Basira FC                2-1
+           Sokoto FC                v ABS FC                   0-1
+
+▪ Group D
+
+▪▪ Matchday 1
+  Sat Nov 15 2025
+           Adamawa United FC        v Sporting Supreme FC      [cancelled]
+           Bichi First FC           v Yobe Desert Stars FC     3-0
+           Jigawa Golden Stars FC   v Kebbi FC                 2-1
+  Sun Nov 16 2025
+           Ranchers Bees FC         v Gombe United FC          1-0
+
+▪▪ Matchday 2
+  Fri Nov 21 2025
+           Kebbi FC                 v Ranchers Bees FC         3-0
+  Sat Nov 22 2025
+           Bichi First FC           v Jigawa Golden Stars FC   1-1
+           Yobe Desert Stars FC     v Sporting Supreme FC      [cancelled]
+  Sun Nov 23 2025
+           Gombe United FC          v Adamawa United FC        1-0
+
+▪▪ Matchday 3
+  Fri Nov 28 2025
+           Sporting Supreme FC      v Gombe United FC          [cancelled]
+  Sat Nov 29 2025
+           Adamawa United FC        v Kebbi FC                 2-0
+           Jigawa Golden Stars FC   v Yobe Desert Stars FC     3-0
+  Sun Nov 30 2025
+           Ranchers Bees FC         v Bichi First FC           1-0
+
+▪▪ Matchday 4
+  Fri Dec 5 2025
+           Kebbi FC                 v Sporting Supreme FC      [cancelled]
+  Sat Dec 6 2025
+           Bichi First FC           v Adamawa United FC        1-0
+           Jigawa Golden Stars FC   v Ranchers Bees FC         1-1
+           Yobe Desert Stars FC     v Gombe United FC          2-0
+
+▪▪ Matchday 5
+  Wed Dec 10 2025
+           Adamawa United FC        v Jigawa Golden Stars FC   2-1
+           Ranchers Bees FC         v Yobe Desert Stars FC     1-0
+           Sporting Supreme FC      v Bichi First FC           [cancelled]
+  Thu Dec 11 2025
+           Gombe United FC          v Kebbi FC                 1-0
+
+▪▪ Matchday 6
+  Sat Dec 13 2025
+           Jigawa Golden Stars FC   v Sporting Supreme FC      [cancelled]
+           Ranchers Bees FC         v Adamawa United FC        1-0
+  Sun Dec 14 2025
+           Bichi First FC           v Gombe United FC          2-0
+           Yobe Desert Stars FC     v Kebbi FC                 2-0
+
+▪▪ Matchday 7
+  Fri Dec 19 2025
+           Kebbi FC                 v Bichi First FC           1-0
+           Sporting Supreme FC      v Ranchers Bees FC         [cancelled]
+  Sat Dec 20 2025
+           Adamawa United FC        v Yobe Desert Stars FC     2-1
+  Sun Dec 21 2025
+           Gombe United FC          v Jigawa Golden Stars FC   0-0
+
+▪▪ Matchday 8
+  Sat Feb 14 2026
+           Bichi First FC           v Kebbi FC                 1-0
+           Jigawa Golden Stars FC   v Gombe United FC          2-1
+           Yobe Desert Stars FC     v Adamawa United FC        3-1
+
+▪▪ Matchday 9
+  Fri Feb 20 2026
+           Kebbi FC                 v Yobe Desert Stars FC     1-0
+  Sat Feb 21 2026
+           Adamawa United FC        v Ranchers Bees FC         1-0
+  Sun Feb 22 2026
+           Gombe United FC          v Bichi First FC           2-1
+
+▪▪ Matchday 10
+  Fri Feb 27 2026
+           Kebbi FC                 v Gombe United FC          0-0
+  Sat Feb 28 2026
+           Jigawa Golden Stars FC   v Adamawa United FC        1-0
+           Yobe Desert Stars FC     v Ranchers Bees FC         1-0
+
+▪▪ Matchday 11
+  Sat Mar 7 2026
+           Adamawa United FC        v Bichi First FC           1-0
+           Ranchers Bees FC         v Jigawa Golden Stars FC   3-0
+  Sun Mar 8 2026
+           Gombe United FC          v Yobe Desert Stars FC     1-1
+
+▪▪ Matchday 12
+  Fri Mar 13 2026
+           Kebbi FC                 v Adamawa United FC        2-1
+  Sat Mar 14 2026
+           Bichi First FC           v Ranchers Bees FC         1-1
+           Yobe Desert Stars FC     v Jigawa Golden Stars FC   3-0
+
+▪▪ Matchday 13
+  Wed Mar 25 2026
+           Adamawa United FC        v Gombe United FC          2-0
+           Jigawa Golden Stars FC   v Bichi First FC           1-0
+           Ranchers Bees FC         v Kebbi FC                 2-0
+
+▪▪ Matchday 14
+  Wed Apr 22 2026
+           Gombe United FC          v Ranchers Bees FC         2-0
+           Kebbi FC                 v Jigawa Golden Stars FC   3-0
+           Yobe Desert Stars FC     v Bichi First FC           1-1
+
+▪ Super 4
+
+▪▪ Matchday 1
+  Mon May 4 2026
+           Doma United FC           v Inter Lagos FC           1-0
+           Sporting Lagos FC        v Ranchers Bees FC         1-0
+
+▪▪ Matchday 2
+  Wed May 6 2026
+           Ranchers Bees FC         v Inter Lagos FC           0-2
+           Sporting Lagos FC        v Doma United FC           4-0
+
+▪▪ Matchday 3
+  Fri May 8 2026
+           Doma United FC           v Ranchers Bees FC         1-3
+           Inter Lagos FC           v Sporting Lagos FC        1-0


### PR DESCRIPTION
Adds the validated Nigeria National League 2025/26 season.
- 275 fixture records; 266 played; 36 teams
- Preserves nine explicit cancelled fixtures resulting from the Dakkada FC withdrawal and Sporting Supreme FC expulsion
- Includes six Super 4 fixtures
- Source snapshots are checksum-pinned locally; deterministic rebuild and exact-coverage validation passed

This PR contains only africa/nigeria/2025-26_ng2.txt.